### PR TITLE
repaired ODD and RNG for Pgh Frankenstein project

### DIFF
--- a/data/odd/out/shelley-godwin-FULL.rng
+++ b/data/odd/out/shelley-godwin-FULL.rng
@@ -1,0 +1,11682 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:tei="http://www.tei-c.org/ns/1.0"
+         xmlns:teix="http://www.tei-c.org/ns/Examples"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+         ns="http://www.tei-c.org/ns/1.0"><!--
+Schema generated from ODD source 2017-08-16T00:47:32Z. .
+TEI Edition: Version 3.2.0. Last updated on
+	10th July 2017, revision 0fcf651
+TEI Edition Location: http://www.tei-c.org/Vault/P5/Version 3.2.0/
+  
+--><!--This code was updated by Elisa Beshero-Bondar, building on work copyrighted by Trevor Muñoz, Raffaele Viglianti, and Maryland Institute for Technology in the Humanities and licensed under a Creative Commons Attribution 3.0 Unported License.-->
+   <define name="sgamacro.paraContent">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+            <ref name="sgamodel.phrase"/>
+            <ref name="sgamodel.inter"/>
+            <ref name="sgamodel.global"/>
+        
+            <ref name="sgamodel.lLike"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.limitedContent">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.limitedPhrase"/>
+            <ref name="sgamodel.inter"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.phraseSeq">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+            <ref name="sgamodel.phrase"/>
+            <ref name="sgamodel.global"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.phraseSeq.limited">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.limitedPhrase"/>
+            <ref name="sgamodel.global"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.specialPara">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+            <ref name="sgamodel.phrase"/>
+            <ref name="sgamodel.inter"/>
+            <ref name="sgamodel.divPart"/>
+            <ref name="sgamodel.global"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.xtext">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="anyElement-xenoData">
+      <element>
+         <anyName>
+            <except>
+               <nsName ns="http://www.tei-c.org/ns/1.0"/>
+               <name ns="http://www.tei-c.org/ns/Examples">egXML</name>
+            </except>
+         </anyName>
+         <zeroOrMore>
+            <attribute>
+               <anyName/>
+            </attribute>
+         </zeroOrMore>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="anyElement-xenoData"/>
+            </choice>
+         </zeroOrMore>
+      </element>
+   </define>
+   <define name="sgaatt.ascribed.attributes">
+      <ref name="sgaatt.ascribed.attribute.who"/>
+   </define>
+   <define name="sgaatt.ascribed.attribute.who">
+      <optional>
+         <attribute name="who">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the person, or group of people, to whom the element content is ascribed.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.canonical.attributes">
+      <ref name="sgaatt.canonical.attribute.key"/>
+      <ref name="sgaatt.canonical.attribute.ref"/>
+   </define>
+   <define name="sgaatt.canonical.attribute.key">
+      <optional>
+         <attribute name="key">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides an externally-defined means of identifying the entity (or entities) being named, using a coded value of some kind.</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.canonical.attribute.ref">
+      <optional>
+         <attribute name="ref">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) provides an explicit means of locating a full definition or identity for the entity being named by means of one or more URIs.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attributes">
+      <ref name="sgaatt.ranging.attribute.atLeast"/>
+      <ref name="sgaatt.ranging.attribute.atMost"/>
+      <ref name="sgaatt.ranging.attribute.min"/>
+      <ref name="sgaatt.ranging.attribute.max"/>
+      <ref name="sgaatt.ranging.attribute.confidence"/>
+   </define>
+   <define name="sgaatt.ranging.attribute.atLeast">
+      <optional>
+         <attribute name="atLeast">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives a minimum estimated value for the approximate measurement.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.atMost">
+      <optional>
+         <attribute name="atMost">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives a maximum estimated value for the approximate measurement.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.min">
+      <optional>
+         <attribute name="min">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where the measurement summarizes more than one observation or a range, supplies the minimum value observed.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.max">
+      <optional>
+         <attribute name="max">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where the measurement summarizes more than one observation or a range, supplies the maximum value observed.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.confidence">
+      <optional>
+         <attribute name="confidence">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the degree of statistical confidence (between zero and one) that a value falls within the range specified by min and max, or the proportion of observed values that fall within that range.</a:documentation>
+            <data type="double"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attributes">
+      <ref name="sgaatt.ranging.attributes"/>
+      <ref name="sgaatt.dimensions.attribute.unit"/>
+      <ref name="sgaatt.dimensions.attribute.quantity"/>
+      <ref name="sgaatt.dimensions.attribute.extent"/>
+      <ref name="sgaatt.dimensions.attribute.precision"/>
+      <ref name="sgaatt.dimensions.attribute.scope"/>
+   </define>
+   <define name="sgaatt.dimensions.attribute.unit">
+      <optional>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">names the unit used for the measurement
+Suggested values include: 1] cm(centimetres) ; 2] mm(millimetres) ; 3] in(inches) ; 4] lines; 5] chars(characters) </a:documentation>
+            <choice>
+               <value>cm</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(centimetres) </a:documentation>
+               <value>mm</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(millimetres) </a:documentation>
+               <value>in</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(inches) </a:documentation>
+               <value>lines</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">lines of text</a:documentation>
+               <value>chars</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(characters) characters of text</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.quantity">
+      <optional>
+         <attribute name="quantity">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the length in the units specified</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.extent">
+      <optional>
+         <attribute name="extent">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the size of the object concerned using a project-specific vocabulary combining quantity and units in a single string of words.</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.precision">
+      <optional>
+         <attribute name="precision">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the precision of the values specified by the other attributes.</a:documentation>
+            <choice>
+               <value>high</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>medium</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>low</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>unknown</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.scope">
+      <optional>
+         <attribute name="scope">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where the measurement summarizes more than one observation, specifies the applicability of this measurement.
+Sample values include: 1] all; 2] most; 3] range</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.written.attributes">
+      <ref name="sgaatt.written.attribute.hand"/>
+   </define>
+   <define name="sgaatt.written.attribute.hand">
+      <optional>
+         <attribute name="hand">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>#pbs</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Percy Shelley's handwriting) Text written in Percy Shelley's hand.</a:documentation>
+               <value>#mws</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Mary Shelley's handwriting) Text written in Mary Shelley's hand.</a:documentation>
+               <value>#comp</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(compositor's handwriting) Text written in an (unknown?) compositor's hand.</a:documentation>
+               <value>#library</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(librarian's handwriting) Text written in an (unknown?) librarian's hand.</a:documentation>
+               <value>http://viaf.org/viaf/95159449</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.damaged.attributes">
+      <ref name="sgaatt.dimensions.attributes"/>
+      <ref name="sgaatt.written.attributes"/>
+      <ref name="sgaatt.damaged.attribute.agent"/>
+      <ref name="sgaatt.damaged.attribute.degree"/>
+      <ref name="sgaatt.damaged.attribute.group"/>
+   </define>
+   <define name="sgaatt.damaged.attribute.agent">
+      <optional>
+         <attribute name="agent">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">categorizes the cause of the damage, if it can be identified.
+Sample values include: 1] rubbing; 2] mildew; 3] smoke</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.damaged.attribute.degree">
+      <optional>
+         <attribute name="degree">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a coded representation of the degree of damage, either as a number between 0 (undamaged) and 1 (very extensively damaged), or as one of the codes high, medium, low, or unknown. The damage element with the degree attribute should only be used where the text may be read with some confidence; text supplied from other sources should be tagged as supplied.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <choice>
+                  <value>high</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>medium</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>low</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unknown</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.damaged.attribute.group">
+      <optional>
+         <attribute name="group">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">assigns an arbitrary number to each stretch of damage regarded as forming part of the same physical phenomenon.</a:documentation>
+            <data type="nonNegativeInteger"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.breaking.attributes">
+      <ref name="sgaatt.breaking.attribute.break"/>
+   </define>
+   <define name="sgaatt.breaking.attribute.break">
+      <optional>
+         <attribute name="break">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether or not the element bearing this attribute should be considered to mark the end of an orthographic token in the same way as whitespace.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.cReferencing.attributes">
+      <ref name="sgaatt.cReferencing.attribute.cRef"/>
+   </define>
+   <define name="sgaatt.cReferencing.attribute.cRef">
+      <optional>
+         <attribute name="cRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(canonical reference) specifies the destination of the pointer by supplying a canonical reference expressed using the scheme defined in a refsDecl element in the TEI header</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attributes">
+      <ref name="sgaatt.datable.w3c.attribute.when"/>
+      <ref name="sgaatt.datable.w3c.attribute.notBefore"/>
+      <ref name="sgaatt.datable.w3c.attribute.notAfter"/>
+      <ref name="sgaatt.datable.w3c.attribute.from"/>
+      <ref name="sgaatt.datable.w3c.attribute.to"/>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.when">
+      <optional>
+         <attribute name="when">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of the date or time in a standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.notBefore">
+      <optional>
+         <attribute name="notBefore">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the earliest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.notAfter">
+      <optional>
+         <attribute name="notAfter">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the latest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.from">
+      <optional>
+         <attribute name="from">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the starting point of the period in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.to">
+      <optional>
+         <attribute name="to">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the ending point of the period in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable.w3c-att-datable-w3c-when-constraint-rule-1">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@when]">
+        <sch:report test="@notBefore|@notAfter|@from|@to" role="nonfatal">The @when attribute cannot be used with any other att.datable.w3c attributes.</sch:report>
+      </sch:rule>
+   </pattern>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable.w3c-att-datable-w3c-from-constraint-rule-2">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@from]">
+        <sch:report test="@notBefore" role="nonfatal">The @from and @notBefore attributes cannot be used together.</sch:report>
+      </sch:rule>
+   </pattern>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable.w3c-att-datable-w3c-to-constraint-rule-3">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@to]">
+        <sch:report test="@notAfter" role="nonfatal">The @to and @notAfter attributes cannot be used together.</sch:report>
+      </sch:rule>
+   </pattern>
+   <define name="sgaatt.datable.attributes">
+      <ref name="sgaatt.datable.w3c.attributes"/>
+      <ref name="sgaatt.datable.iso.attributes"/>
+      <ref name="sgaatt.datable.custom.attributes"/>
+      <ref name="sgaatt.datable.attribute.calendar"/>
+      <ref name="sgaatt.datable.attribute.period"/>
+   </define>
+   <define name="sgaatt.datable.attribute.calendar">
+      <optional>
+         <attribute name="calendar">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the system or calendar to which the date represented by the content of this element belongs.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable-calendar-calendar-constraint-rule-4">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@calendar]">
+            <sch:assert test="string-length(.) gt 0">
+@calendar indicates the system or calendar to which the date represented by the content of this element
+belongs, but this <sch:name/> element has no textual content.</sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.datable.attribute.period">
+      <optional>
+         <attribute name="period">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to some location defining a named period of time within which the datable item is understood to have occurred.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datcat.attributes">
+      <ref name="sgaatt.datcat.attribute.datcat"/>
+      <ref name="sgaatt.datcat.attribute.valueDatcat"/>
+   </define>
+   <define name="sgaatt.datcat.attribute.datcat">
+      <optional>
+         <attribute name="datcat" ns="http://www.isocat.org/ns/dcr">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a PID (persistent identifier) that aligns the given element with the appropriate Data Category (or categories) in ISOcat.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datcat.attribute.valueDatcat">
+      <optional>
+         <attribute name="valueDatcat" ns="http://www.isocat.org/ns/dcr">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a PID (persistent identifier) that aligns the content of the given element or the value of the given attribute with the appropriate simple Data Category (or categories) in ISOcat.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.declarable.attributes">
+      <ref name="sgaatt.declarable.attribute.default"/>
+   </define>
+   <define name="sgaatt.declarable.attribute.default">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="default"
+                    a:defaultValue="false">
+            <a:documentation>indicates whether or not this element is selected by default when its parent is selected.</a:documentation>
+            <choice>
+               <value>true</value>
+               <a:documentation>This element is selected if its parent is selected</a:documentation>
+               <value>false</value>
+               <a:documentation>This element can only be selected explicitly, unless it is the only one of its kind, in which case it is selected if its parent is selected.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.fragmentable.attributes">
+      <ref name="sgaatt.fragmentable.attribute.part"/>
+   </define>
+   <define name="sgaatt.fragmentable.attribute.part">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="part"
+                    a:defaultValue="N">
+            <a:documentation>specifies whether or not its parent element is fragmented in some way, typically by some other overlapping structure: for example a speech which is divided between two or more verse stanzas, a paragraph which is split across a page division, a verse line which is divided between two speakers.</a:documentation>
+            <choice>
+               <value>Y</value>
+               <a:documentation>(yes) the element is fragmented in some (unspecified) respect</a:documentation>
+               <value>N</value>
+               <a:documentation>(no) the element is not fragmented, or no claim is made as to its completeness</a:documentation>
+               <value>I</value>
+               <a:documentation>(initial) this is the initial part of a fragmented element</a:documentation>
+               <value>M</value>
+               <a:documentation>(medial) this is a medial part of a fragmented element</a:documentation>
+               <value>F</value>
+               <a:documentation>(final) this is the final part of a fragmented element</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.divLike.attributes">
+      <ref name="sgaatt.fragmentable.attributes"/>
+      <ref name="sgaatt.divLike.attribute.org"/>
+      <ref name="sgaatt.divLike.attribute.sample"/>
+   </define>
+   <define name="sgaatt.divLike.attribute.org">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="org"
+                    a:defaultValue="uniform">
+            <a:documentation>(organization) specifies how the content of the division is organized.</a:documentation>
+            <choice>
+               <value>composite</value>
+               <a:documentation>no claim is made about the sequence in which the immediate contents of this division are to be processed, or their inter-relationships.</a:documentation>
+               <value>uniform</value>
+               <a:documentation>the immediate contents of this element are regarded as forming a logical unit, to be processed in sequence.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.divLike.attribute.sample">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="sample"
+                    a:defaultValue="complete">
+            <a:documentation>indicates whether this division is a sample of the original source and if so, from which part.</a:documentation>
+            <choice>
+               <value>initial</value>
+               <a:documentation>division lacks material present at end in source.</a:documentation>
+               <value>medial</value>
+               <a:documentation>division lacks material at start and end.</a:documentation>
+               <value>final</value>
+               <a:documentation>division lacks material at start.</a:documentation>
+               <value>unknown</value>
+               <a:documentation>position of sampled material within original unknown.</a:documentation>
+               <value>complete</value>
+               <a:documentation>division is not a sample.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.docStatus.attributes">
+      <ref name="sgaatt.docStatus.attribute.status"/>
+   </define>
+   <define name="sgaatt.docStatus.attribute.status">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="status"
+                    a:defaultValue="draft">
+            <a:documentation>describes the status of a document either currently or, when associated with a dated element, at the time indicated.
+Sample values include: 1] approved; 2] candidate; 3] cleared; 4] deprecated; 5] draft; 6] embargoed; 7] expired; 8] frozen; 9] galley; 10] proposed; 11] published; 12] recommendation; 13] submitted; 14] unfinished; 15] withdrawn</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.responsibility.attributes">
+      <ref name="sgaatt.global.responsibility.attribute.cert"/>
+      <ref name="sgaatt.global.responsibility.attribute.resp"/>
+   </define>
+   <define name="sgaatt.global.responsibility.attribute.cert">
+      <optional>
+         <attribute name="cert">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(certainty) signifies the degree of certainty associated with the intervention or interpretation.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <choice>
+                  <value>high</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>medium</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>low</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unknown</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.responsibility.attribute.resp">
+      <optional>
+         <attribute name="resp">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsible party) indicates the agency responsible for the intervention or interpretation, for example an editor or transcriber.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.editLike.attributes">
+      <ref name="sgaatt.dimensions.attributes"/>
+      <ref name="sgaatt.editLike.attribute.evidence"/>
+      <ref name="sgaatt.editLike.attribute.instant"/>
+   </define>
+   <define name="sgaatt.editLike.attribute.evidence">
+      <optional>
+         <attribute name="evidence">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the nature of the evidence supporting the reliability or accuracy of the intervention or interpretation.
+Suggested values include: 1] internal; 2] external; 3] conjecture</a:documentation>
+            <list>
+               <oneOrMore>
+                  <choice>
+                     <value>internal</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">there is internal evidence to support the intervention.</a:documentation>
+                     <value>external</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">there is external evidence to support the intervention.</a:documentation>
+                     <value>conjecture</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the intervention or interpretation has been made by the editor, cataloguer, or scholar on the basis of their expertise.</a:documentation>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </choice>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.editLike.attribute.instant">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="instant"
+                    a:defaultValue="false">
+            <a:documentation>indicates whether this is an instant revision or not.</a:documentation>
+            <choice>
+               <data type="boolean"/>
+               <choice>
+                  <value>unknown</value>
+                  <a:documentation/>
+                  <value>inapplicable</value>
+                  <a:documentation/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.rendition.attributes">
+      <ref name="sgaatt.global.rendition.attribute.rend"/>
+      <ref name="sgaatt.global.rendition.attribute.style"/>
+      <ref name="sgaatt.global.rendition.attribute.rendition"/>
+   </define>
+   <define name="sgaatt.global.rendition.attribute.rend">
+      <optional>
+         <attribute name="rend">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rendition) indicates how the element in question was rendered or presented in the source text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.rendition.attribute.style">
+      <optional>
+         <attribute name="style">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an expression in some formal style definition language which defines the rendering or presentation used for this element in the source text</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.rendition.attribute.rendition">
+      <optional>
+         <attribute name="rendition">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a description of the rendering or presentation used for this element in the source text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.source.attributes">
+      <ref name="sgaatt.global.source.attribute.source"/>
+   </define>
+   <define name="sgaatt.global.source.attribute.source">
+      <optional>
+         <attribute name="source">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the source from which some aspect of this element is drawn.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attributes">
+      <ref name="sgaatt.global.rendition.attributes"/>
+      <ref name="sgaatt.global.linking.attributes"/>
+      <ref name="sgaatt.global.facs.attributes"/>
+      <ref name="sgaatt.global.responsibility.attributes"/>
+      <ref name="sgaatt.global.source.attributes"/>
+      <ref name="sgaatt.global.attribute.el-target"/>
+      <ref name="sgaatt.global.attribute.att-target"/>
+      <ref name="sgaatt.global.attribute.att-value"/>
+      <ref name="sgaatt.global.attribute.xmlid"/>
+      <ref name="sgaatt.global.attribute.n"/>
+      <ref name="sgaatt.global.attribute.xmllang"/>
+      <ref name="sgaatt.global.attribute.xmlbase"/>
+      <ref name="sgaatt.global.attribute.xmlspace"/>
+   </define>
+   <define name="sgaatt.global.attribute.el-target">
+      <optional>
+         <attribute name="el-target" ns="http://shelleygodwinarchive.org/ns/1.0">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A convenience attribute for indicating what text-centric element a document-centric element should be transformed to</a:documentation>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.att-target">
+      <optional>
+         <attribute name="att-target" ns="http://shelleygodwinarchive.org/ns/1.0">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A convenience attribute for indicating what attribute should be added in transforming from document- to text-centric markup. By convention the attribute is placed on the element specified in a preceding el-target attribute</a:documentation>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.att-value">
+      <optional>
+         <attribute name="att-value" ns="http://shelleygodwinarchive.org/ns/1.0">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If an attribute created during a document- to text-centric markup conversion should have a particular value, please indicate</a:documentation>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmlid">
+      <optional>
+         <attribute name="xml:id">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) provides a unique identifier for the element bearing the attribute.</a:documentation>
+            <data type="ID"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.n">
+      <optional>
+         <attribute name="n">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) gives a number (or other label) for an element, which is not necessarily unique within the document.</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmllang">
+      <optional>
+         <attribute name="xml:lang">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language) indicates the language of the element content using a tag generated according to BCP 47.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmlbase">
+      <optional>
+         <attribute name="xml:base">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a base URI reference with which applications can resolve relative URI references into absolute URI references.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmlspace">
+      <optional>
+         <attribute name="xml:space">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">signals an intention about how white space should be managed by applications.</a:documentation>
+            <choice>
+               <value>default</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">signals that the application's default white-space processing modes are acceptable</a:documentation>
+               <value>preserve</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the intent that applications preserve all white space</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attributes">
+      <ref name="sgaatt.handFeatures.attribute.scribe"/>
+      <ref name="sgaatt.handFeatures.attribute.scribeRef"/>
+      <ref name="sgaatt.handFeatures.attribute.script"/>
+      <ref name="sgaatt.handFeatures.attribute.scriptRef"/>
+      <ref name="sgaatt.handFeatures.attribute.medium"/>
+      <ref name="sgaatt.handFeatures.attribute.scope"/>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scribe">
+      <optional>
+         <attribute name="scribe">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives a name or other identifier for the scribe believed to be responsible for this hand.</a:documentation>
+            <data type="Name"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scribeRef">
+      <optional>
+         <attribute name="scribeRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a full description of the scribe concerned, typically supplied by a person element elsewhere in the description.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.script">
+      <optional>
+         <attribute name="script">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the particular script or writing style used by this hand, for example secretary, copperplate, Chancery, Italian, etc.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="Name"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scriptRef">
+      <optional>
+         <attribute name="scriptRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a full description of the script or writing style used by this hand, typically supplied by a scriptNote element elsewhere in the description.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.medium">
+      <optional>
+         <attribute name="medium">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the tint or type of ink, e.g. brown, or other writing medium, e.g. pencil</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scope">
+      <optional>
+         <attribute name="scope">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies how widely this hand is used in the manuscript.</a:documentation>
+            <choice>
+               <value>sole</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">only this hand is used throughout the manuscript</a:documentation>
+               <value>major</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">this hand is used through most of the manuscript</a:documentation>
+               <value>minor</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">this hand is used occasionally in the manuscript</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.internetMedia.attributes">
+      <ref name="sgaatt.internetMedia.attribute.mimeType"/>
+   </define>
+   <define name="sgaatt.internetMedia.attribute.mimeType">
+      <optional>
+         <attribute name="mimeType">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.media.attributes">
+      <ref name="sgaatt.internetMedia.attributes"/>
+      <ref name="sgaatt.media.attribute.width"/>
+      <ref name="sgaatt.media.attribute.height"/>
+      <ref name="sgaatt.media.attribute.scale"/>
+   </define>
+   <define name="sgaatt.media.attribute.width">
+      <optional>
+         <attribute name="width">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates the display width</a:documentation>
+            <data type="token">
+               <param name="pattern">[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|gd|rem|vw|vh|vm)</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.media.attribute.height">
+      <optional>
+         <attribute name="height">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates the display height</a:documentation>
+            <data type="token">
+               <param name="pattern">[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|gd|rem|vw|vh|vm)</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.media.attribute.scale">
+      <optional>
+         <attribute name="scale">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates a scale factor to be applied when generating the desired display size</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.resourced.attributes">
+      <ref name="sgaatt.resourced.attribute.url"/>
+   </define>
+   <define name="sgaatt.resourced.attribute.url">
+      <attribute name="url">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(uniform resource locator) specifies the URL from which the media concerned may be obtained.</a:documentation>
+         <data type="anyURI"/>
+      </attribute>
+   </define>
+   <define name="sgaatt.measurement.attributes">
+      <ref name="sgaatt.measurement.attribute.unit"/>
+      <ref name="sgaatt.measurement.attribute.quantity"/>
+      <ref name="sgaatt.measurement.attribute.commodity"/>
+   </define>
+   <define name="sgaatt.measurement.attribute.unit">
+      <optional>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the units used for the measurement, usually using the standard symbol for the desired units.
+Suggested values include: 1] m(metre) ; 2] kg(kilogram) ; 3] s(second) ; 4] Hz(hertz) ; 5] Pa(pascal) ; 6] Ω(ohm) ; 7] L(litre) ; 8] t(tonne) ; 9] ha(hectare) ; 10] Å(ångström) ; 11] mL(millilitre) ; 12] cm(centimetre) ; 13] dB(decibel) ; 14] kbit(kilobit) ; 15] Kibit(kibibit) ; 16] kB(kilobyte) ; 17] KiB(kibibyte) ; 18] MB(megabyte) ; 19] MiB(mebibyte) </a:documentation>
+            <choice>
+               <value>m</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(metre) SI base unit of length</a:documentation>
+               <value>kg</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kilogram) SI base unit of mass</a:documentation>
+               <value>s</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(second) SI base unit of time</a:documentation>
+               <value>Hz</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(hertz) SI unit of frequency</a:documentation>
+               <value>Pa</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pascal) SI unit of pressure or stress</a:documentation>
+               <value>Ω</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ohm) SI unit of electric resistance</a:documentation>
+               <value>L</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(litre) 1 dm³</a:documentation>
+               <value>t</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(tonne) 10³ kg</a:documentation>
+               <value>ha</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(hectare) 1 hm²</a:documentation>
+               <value>Å</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ångström) 10⁻¹⁰ m</a:documentation>
+               <value>mL</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(millilitre) </a:documentation>
+               <value>cm</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(centimetre) </a:documentation>
+               <value>dB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(decibel) see remarks, below</a:documentation>
+               <value>kbit</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kilobit) 10³ or 1000 bits</a:documentation>
+               <value>Kibit</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kibibit) 2¹⁰ or 1024 bits</a:documentation>
+               <value>kB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kilobyte) 10³ or 1000 bytes</a:documentation>
+               <value>KiB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kibibyte) 2¹⁰ or 1024 bytes</a:documentation>
+               <value>MB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(megabyte) 10⁶ or 1 000 000 bytes</a:documentation>
+               <value>MiB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(mebibyte) 2²⁰ or 1 048 576 bytes</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.measurement.attribute.quantity">
+      <optional>
+         <attribute name="quantity">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of the specified units that comprise the measurement</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.measurement.attribute.commodity">
+      <optional>
+         <attribute name="commodity">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the substance that is being measured</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.naming.attributes">
+      <ref name="sgaatt.canonical.attributes"/>
+      <ref name="sgaatt.naming.attribute.role"/>
+      <ref name="sgaatt.naming.attribute.nymRef"/>
+   </define>
+   <define name="sgaatt.naming.attribute.role">
+      <optional>
+         <attribute name="role">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">may be used to specify further information about the entity referenced by this name in the form of a set of whitespace-separated values, for example the occupation of a person, or the status of a place.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.naming.attribute.nymRef">
+      <optional>
+         <attribute name="nymRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference to the canonical name) provides a means of locating the canonical form (nym) of the names associated with the object named by the element bearing it.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.placement.attributes">
+      <ref name="sgaatt.placement.attribute.place"/>
+   </define>
+   <define name="sgaatt.placement.attribute.place">
+      <optional>
+         <attribute name="place">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies where this item is placed.
+Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6] overleaf; 7] above; 8] end; 9] inline; 10] inspace</a:documentation>
+            <list>
+               <oneOrMore>
+                  <choice>
+                     <value>below</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">below the line</a:documentation>
+                     <value>bottom</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">at the foot of the page</a:documentation>
+                     <value>margin</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in the margin (left, right, or both)</a:documentation>
+                     <value>top</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">at the top of the page</a:documentation>
+                     <value>opposite</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">on the opposite, i.e. facing, page</a:documentation>
+                     <value>overleaf</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">on the other side of the leaf</a:documentation>
+                     <value>above</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">above the line</a:documentation>
+                     <value>end</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">at the end of e.g. chapter or volume.</a:documentation>
+                     <value>inline</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">within the body of the text.</a:documentation>
+                     <value>inspace</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in a predefined space, for example left by an earlier scribe.</a:documentation>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </choice>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.typed.attributes">
+      <ref name="sgaatt.typed.attribute.type"/>
+      <ref name="sgaatt.typed.attribute.subtype"/>
+   </define>
+   <define name="sgaatt.typed.attribute.type">
+      <optional>
+         <attribute name="type">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.typed.attribute.subtype">
+      <optional>
+         <attribute name="subtype">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a sub-categorization of the element, if needed</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.typed-subtypeTyped-constraint-rule-5">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@subtype]">
+        <sch:assert test="@type">The <sch:name/> element should not be categorized in detail with @subtype unless also categorized in general with @type</sch:assert>
+      </sch:rule>
+   </pattern>
+   <define name="sgaatt.pointing.attributes">
+      <ref name="sgaatt.pointing.attribute.targetLang"/>
+      <ref name="sgaatt.pointing.attribute.target"/>
+      <ref name="sgaatt.pointing.attribute.evaluate"/>
+   </define>
+   <define name="sgaatt.pointing.attribute.targetLang">
+      <optional>
+         <attribute name="targetLang">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the language of the content to be found at the destination referenced by target, using a language tag generated according to BCP 47.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.pointing-targetLang-targetLang-constraint-rule-6">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[not(self::tei:schemaSpec)][@targetLang]">
+            <sch:assert test="@target">@targetLang should only be used on <sch:name/> if @target is specified.</sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.pointing.attribute.target">
+      <optional>
+         <attribute name="target">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the destination of the reference by supplying one or more URI References</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.pointing.attribute.evaluate">
+      <optional>
+         <attribute name="evaluate">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the intended meaning when the target of a pointer is itself a pointer.</a:documentation>
+            <choice>
+               <value>all</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">if the element pointed to is itself a pointer, then the target of that pointer will be taken, and so on, until an element is found which is not a pointer.</a:documentation>
+               <value>one</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">if the element pointed to is itself a pointer, then its target (whether a pointer or not) is taken as the target of this pointer.</a:documentation>
+               <value>none</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">no further evaluation of targets is carried out beyond that needed to find the element specified in the pointer's target.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.pointing.group.attributes">
+      <ref name="sgaatt.pointing.attributes"/>
+      <ref name="sgaatt.typed.attributes"/>
+      <ref name="sgaatt.pointing.group.attribute.domains"/>
+      <ref name="sgaatt.pointing.group.attribute.targFunc"/>
+   </define>
+   <define name="sgaatt.pointing.group.attribute.domains">
+      <optional>
+         <attribute name="domains">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">optionally specifies the identifiers of the elements within which all elements indicated by the contents of this element lie.</a:documentation>
+            <list>
+               <data type="anyURI"/>
+               <data type="anyURI"/>
+               <zeroOrMore>
+                  <data type="anyURI"/>
+               </zeroOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.pointing.group.attribute.targFunc">
+      <optional>
+         <attribute name="targFunc">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(target function) describes the function of each of the values of the target attribute of the enclosed link, join, or alt tags.</a:documentation>
+            <list>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+               <zeroOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </zeroOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.segLike.attributes">
+      <ref name="sgaatt.datcat.attributes"/>
+      <ref name="sgaatt.fragmentable.attributes"/>
+      <ref name="sgaatt.segLike.attribute.function"/>
+   </define>
+   <define name="sgaatt.segLike.attribute.function">
+      <optional>
+         <attribute name="function">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the function of the segment.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.sortable.attributes">
+      <ref name="sgaatt.sortable.attribute.sortKey"/>
+   </define>
+   <define name="sgaatt.sortable.attribute.sortKey">
+      <optional>
+         <attribute name="sortKey">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the sort key for this element in an index, list or group which contains it.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.edition.attributes">
+      <ref name="sgaatt.edition.attribute.ed"/>
+      <ref name="sgaatt.edition.attribute.edRef"/>
+   </define>
+   <define name="sgaatt.edition.attribute.ed">
+      <optional>
+         <attribute name="ed">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition) supplies a sigil or other arbitrary identifier for the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.edition.attribute.edRef">
+      <optional>
+         <attribute name="edRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition reference) provides a pointer to the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.spanning.attributes">
+      <ref name="sgaatt.spanning.attribute.spanTo"/>
+   </define>
+   <define name="sgaatt.spanning.attribute.spanTo">
+      <optional>
+         <attribute name="spanTo">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the end of a span initiated by the element bearing this attribute.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.spanning-spanTo-spanTo-2-constraint-rule-7">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@spanTo]">
+            <sch:assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]">
+The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow the current element <sch:name/>
+                  </sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.styleDef.attributes">
+      <ref name="sgaatt.styleDef.attribute.scheme"/>
+      <ref name="sgaatt.styleDef.attribute.schemeVersion"/>
+   </define>
+   <define name="sgaatt.styleDef.attribute.scheme">
+      <optional>
+         <attribute name="scheme">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the language used to describe the rendition.</a:documentation>
+            <choice>
+               <value>css</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Cascading Stylesheet Language</a:documentation>
+               <value>xslfo</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Extensible Stylesheet Language Formatting Objects</a:documentation>
+               <value>free</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Informal free text description</a:documentation>
+               <value>other</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A user-defined rendition description language</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.styleDef.attribute.schemeVersion">
+      <optional>
+         <attribute name="schemeVersion">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a version number for the style language provided in scheme.</a:documentation>
+            <data type="token">
+               <param name="pattern">[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.styleDef-schemeVersion-schemeVersionRequiresScheme-constraint-rule-8">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@schemeVersion]">
+            <sch:assert test="@scheme and not(@scheme = 'free')">
+              @schemeVersion can only be used if @scheme is specified.
+            </sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.timed.attributes">
+      <ref name="sgaatt.timed.attribute.start"/>
+      <ref name="sgaatt.timed.attribute.end"/>
+   </define>
+   <define name="sgaatt.timed.attribute.start">
+      <optional>
+         <attribute name="start">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location within a temporal alignment at which this element begins.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.timed.attribute.end">
+      <optional>
+         <attribute name="end">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location within a temporal alignment at which this element ends.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.transcriptional.attributes">
+      <ref name="sgaatt.editLike.attributes"/>
+      <ref name="sgaatt.written.attributes"/>
+      <ref name="sgaatt.transcriptional.attribute.cause"/>
+      <ref name="sgaatt.transcriptional.attribute.seq"/>
+   </define>
+   <define name="sgaatt.transcriptional.attribute.cause">
+      <optional>
+         <attribute name="cause">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">documents the presumed cause for the intervention.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.transcriptional.attribute.seq">
+      <optional>
+         <attribute name="seq">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sequence) assigns a sequence number related to the order in which the encoded features carrying this attribute are believed to have occurred.</a:documentation>
+            <data type="nonNegativeInteger"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.translatable.attributes">
+      <ref name="sgaatt.translatable.attribute.versionDate"/>
+   </define>
+   <define name="sgaatt.translatable.attribute.versionDate">
+      <optional>
+         <attribute name="versionDate">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the date on which the source text was extracted and sent to the translator</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.citing.attributes">
+      <ref name="sgaatt.citing.attribute.unit"/>
+      <ref name="sgaatt.citing.attribute.from"/>
+      <ref name="sgaatt.citing.attribute.to"/>
+   </define>
+   <define name="sgaatt.citing.attribute.unit">
+      <optional>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the unit of information conveyed by the element, e.g. columns, pages, volume, entry.
+Suggested values include: 1] volume; 2] issue; 3] page; 4] line; 5] chapter; 6] part; 7] column; 8] entry</a:documentation>
+            <choice>
+               <value>volume</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a volume number.</a:documentation>
+               <value>issue</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains an issue number, or volume and issue numbers.</a:documentation>
+               <value>page</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a page number or page range.</a:documentation>
+               <value>line</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a line number or line range.</a:documentation>
+               <value>chapter</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a chapter indication (number and/or title)</a:documentation>
+               <value>part</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a part of a book or collection.</a:documentation>
+               <value>column</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies an entry number or label in a list of entries.</a:documentation>
+               <value>entry</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a column.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.citing.attribute.from">
+      <optional>
+         <attribute name="from">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the starting point of the range of units indicated by the unit attribute.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.citing.attribute.to">
+      <optional>
+         <attribute name="to">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the end-point of the range of units indicated by the unit attribute.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamodel.nameLike.agent">
+      <choice>
+         <ref name="sganame"/>
+         <ref name="sgaorgName"/>
+         <ref name="sgapersName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike.agent_alternation">
+      <choice>
+         <ref name="sganame"/>
+         <ref name="sgaorgName"/>
+         <ref name="sgapersName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequence">
+      <ref name="sganame"/>
+      <ref name="sgaorgName"/>
+      <ref name="sgapersName"/>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequenceOptional">
+      <optional>
+         <ref name="sganame"/>
+      </optional>
+      <optional>
+         <ref name="sgaorgName"/>
+      </optional>
+      <optional>
+         <ref name="sgapersName"/>
+      </optional>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sganame"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaorgName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgapersName"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sganame"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaorgName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgapersName"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.segLike">
+      <choice>
+         <ref name="sgaseg"/>
+         <ref name="sgac"/>
+      </choice>
+   </define>
+   <define name="sgamodel.hiLike">
+      <choice>
+         <ref name="sgahi"/>
+      </choice>
+   </define>
+   <define name="sgamodel.hiLike_alternation">
+      <choice>
+         <ref name="sgahi"/>
+      </choice>
+   </define>
+   <define name="sgamodel.hiLike_sequence">
+      <ref name="sgahi"/>
+   </define>
+   <define name="sgamodel.hiLike_sequenceOptional">
+      <optional>
+         <ref name="sgahi"/>
+      </optional>
+   </define>
+   <define name="sgamodel.hiLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgahi"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.hiLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgahi"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.emphLike">
+      <choice>
+         <ref name="sgaforeign"/>
+         <ref name="sgaemph"/>
+         <ref name="sgaterm"/>
+         <ref name="sgatitle"/>
+      </choice>
+   </define>
+   <define name="sgamodel.emphLike_alternation">
+      <choice>
+         <ref name="sgaforeign"/>
+         <ref name="sgaemph"/>
+         <ref name="sgaterm"/>
+         <ref name="sgatitle"/>
+      </choice>
+   </define>
+   <define name="sgamodel.emphLike_sequence">
+      <ref name="sgaforeign"/>
+      <ref name="sgaemph"/>
+      <ref name="sgaterm"/>
+      <ref name="sgatitle"/>
+   </define>
+   <define name="sgamodel.emphLike_sequenceOptional">
+      <optional>
+         <ref name="sgaforeign"/>
+      </optional>
+      <optional>
+         <ref name="sgaemph"/>
+      </optional>
+      <optional>
+         <ref name="sgaterm"/>
+      </optional>
+      <optional>
+         <ref name="sgatitle"/>
+      </optional>
+   </define>
+   <define name="sgamodel.emphLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaforeign"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaemph"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaterm"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgatitle"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.emphLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaforeign"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaemph"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaterm"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgatitle"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.highlighted">
+      <choice>
+         <ref name="sgamodel.hiLike"/>
+         <ref name="sgamodel.emphLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.dateLike">
+      <choice>
+         <ref name="sgadate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.dateLike_alternation">
+      <choice>
+         <ref name="sgadate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.dateLike_sequence">
+      <ref name="sgadate"/>
+   </define>
+   <define name="sgamodel.dateLike_sequenceOptional">
+      <optional>
+         <ref name="sgadate"/>
+      </optional>
+   </define>
+   <define name="sgamodel.dateLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgadate"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.dateLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgadate"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.dimLike">
+      <choice>
+         <ref name="sgaheight"/>
+         <ref name="sgadepth"/>
+         <ref name="sgawidth"/>
+      </choice>
+   </define>
+   <define name="sgamodel.measureLike">
+      <choice>
+         <ref name="sganum"/>
+         <ref name="sgameasureGrp"/>
+         <ref name="sgadim"/>
+         <ref name="sgaheight"/>
+         <ref name="sgadepth"/>
+         <ref name="sgawidth"/>
+         <ref name="sgageo"/>
+      </choice>
+   </define>
+   <define name="sgamodel.measureLike_alternation">
+      <choice>
+         <ref name="sganum"/>
+         <ref name="sgameasureGrp"/>
+         <ref name="sgadim"/>
+         <ref name="sgaheight"/>
+         <ref name="sgadepth"/>
+         <ref name="sgawidth"/>
+         <ref name="sgageo"/>
+      </choice>
+   </define>
+   <define name="sgamodel.measureLike_sequence">
+      <ref name="sganum"/>
+      <ref name="sgameasureGrp"/>
+      <ref name="sgadim"/>
+      <ref name="sgaheight"/>
+      <ref name="sgadepth"/>
+      <ref name="sgawidth"/>
+      <ref name="sgageo"/>
+   </define>
+   <define name="sgamodel.measureLike_sequenceOptional">
+      <optional>
+         <ref name="sganum"/>
+      </optional>
+      <optional>
+         <ref name="sgameasureGrp"/>
+      </optional>
+      <optional>
+         <ref name="sgadim"/>
+      </optional>
+      <optional>
+         <ref name="sgaheight"/>
+      </optional>
+      <optional>
+         <ref name="sgadepth"/>
+      </optional>
+      <optional>
+         <ref name="sgawidth"/>
+      </optional>
+      <optional>
+         <ref name="sgageo"/>
+      </optional>
+   </define>
+   <define name="sgamodel.measureLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sganum"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgameasureGrp"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadim"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaheight"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadepth"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgawidth"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgageo"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.measureLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sganum"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgameasureGrp"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadim"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaheight"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadepth"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgawidth"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgageo"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.egLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.egLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.egLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.egLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.egLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.egLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.graphicLike">
+      <choice>
+         <ref name="sgamedia"/>
+         <ref name="sgagraphic"/>
+      </choice>
+   </define>
+   <define name="sgamodel.offsetLike">
+      <choice>
+         <ref name="sgaoffset"/>
+         <ref name="sgageogFeat"/>
+      </choice>
+   </define>
+   <define name="sgamodel.offsetLike_alternation">
+      <choice>
+         <ref name="sgaoffset"/>
+         <ref name="sgageogFeat"/>
+      </choice>
+   </define>
+   <define name="sgamodel.offsetLike_sequence">
+      <ref name="sgaoffset"/>
+      <ref name="sgageogFeat"/>
+   </define>
+   <define name="sgamodel.offsetLike_sequenceOptional">
+      <optional>
+         <ref name="sgaoffset"/>
+      </optional>
+      <optional>
+         <ref name="sgageogFeat"/>
+      </optional>
+   </define>
+   <define name="sgamodel.offsetLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaoffset"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgageogFeat"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.offsetLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaoffset"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgageogFeat"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.pPart.msdesc">
+      <choice>
+         <ref name="sgacatchwords"/>
+         <ref name="sgadimensions"/>
+         <ref name="sgaheraldry"/>
+         <ref name="sgalocus"/>
+         <ref name="sgalocusGrp"/>
+         <ref name="sgamaterial"/>
+         <ref name="sgaobjectType"/>
+         <ref name="sgaorigDate"/>
+         <ref name="sgaorigPlace"/>
+         <ref name="sgasecFol"/>
+         <ref name="sgasignatures"/>
+         <ref name="sgastamp"/>
+         <ref name="sgawatermark"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.editorial">
+      <choice>
+         <ref name="sgasubst"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.editorial_alternation">
+      <choice>
+         <ref name="sgasubst"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequence">
+      <ref name="sgasubst"/>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequenceOptional">
+      <optional>
+         <ref name="sgasubst"/>
+      </optional>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgasubst"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgasubst"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.pPart.transcriptional">
+      <choice>
+         <ref name="sgaadd"/>
+         <ref name="sgadel"/>
+         <ref name="sgaunclear"/>
+         <ref name="sgadamage"/>
+         <ref name="sgahandShift"/>
+         <ref name="sgarestore"/>
+         <ref name="sgasecl"/>
+         <ref name="sgamod"/>
+         <ref name="sgaretrace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_alternation">
+      <choice>
+         <ref name="sgaadd"/>
+         <ref name="sgadel"/>
+         <ref name="sgaunclear"/>
+         <ref name="sgadamage"/>
+         <ref name="sgahandShift"/>
+         <ref name="sgarestore"/>
+         <ref name="sgasecl"/>
+         <ref name="sgamod"/>
+         <ref name="sgaretrace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequence">
+      <ref name="sgaadd"/>
+      <ref name="sgadel"/>
+      <ref name="sgaunclear"/>
+      <ref name="sgadamage"/>
+      <ref name="sgahandShift"/>
+      <ref name="sgarestore"/>
+      <ref name="sgasecl"/>
+      <ref name="sgamod"/>
+      <ref name="sgaretrace"/>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequenceOptional">
+      <optional>
+         <ref name="sgaadd"/>
+      </optional>
+      <optional>
+         <ref name="sgadel"/>
+      </optional>
+      <optional>
+         <ref name="sgaunclear"/>
+      </optional>
+      <optional>
+         <ref name="sgadamage"/>
+      </optional>
+      <optional>
+         <ref name="sgahandShift"/>
+      </optional>
+      <optional>
+         <ref name="sgarestore"/>
+      </optional>
+      <optional>
+         <ref name="sgasecl"/>
+      </optional>
+      <optional>
+         <ref name="sgamod"/>
+      </optional>
+      <optional>
+         <ref name="sgaretrace"/>
+      </optional>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaadd"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadel"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaunclear"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadamage"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgahandShift"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgarestore"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgasecl"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamod"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaretrace"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaadd"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadel"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaunclear"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadamage"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgahandShift"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgarestore"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgasecl"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamod"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaretrace"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.pPart.edit">
+      <choice>
+         <ref name="sgamodel.pPart.editorial"/>
+         <ref name="sgamodel.pPart.transcriptional"/>
+      </choice>
+   </define>
+   <define name="sgamodel.linePart">
+      <choice>
+         <ref name="sgamodel.hiLike"/>
+         <ref name="sgaadd"/>
+         <ref name="sgadel"/>
+         <ref name="sgaunclear"/>
+         <ref name="sgazone"/>
+         <ref name="sgadamage"/>
+         <ref name="sgahandShift"/>
+         <ref name="sgarestore"/>
+         <ref name="sgaline"/>
+         <ref name="sgamod"/>
+         <ref name="sgaretrace"/>
+         <ref name="sgaseg"/>
+         <ref name="sgac"/>
+      </choice>
+   </define>
+   <define name="sgamodel.ptrLike">
+      <choice>
+         <ref name="sgaptr"/>
+         <ref name="sgaref"/>
+      </choice>
+   </define>
+   <define name="sgamodel.lPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.global.meta">
+      <choice>
+         <ref name="sgaindex"/>
+         <ref name="sgasubstJoin"/>
+         <ref name="sgalistTranspose"/>
+         <ref name="sgalink"/>
+         <ref name="sgalinkGrp"/>
+         <ref name="sgajoin"/>
+         <ref name="sgajoinGrp"/>
+         <ref name="sgaalt"/>
+      </choice>
+   </define>
+   <define name="sgamodel.milestoneLike">
+      <choice>
+         <ref name="sgamilestone"/>
+         <ref name="sgaanchor"/>
+      </choice>
+   </define>
+   <define name="sgamodel.gLike">
+      <choice>
+         <ref name="sgag"/>
+      </choice>
+   </define>
+   <define name="sgamodel.oddDecl">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.oddDecl_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.oddDecl_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.oddDecl_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.oddDecl_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.oddDecl_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.phrase.xml">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.specDescLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.biblLike">
+      <choice>
+         <ref name="sgabibl"/>
+         <ref name="sgabiblFull"/>
+         <ref name="sgamsDesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.biblLike_alternation">
+      <choice>
+         <ref name="sgabibl"/>
+         <ref name="sgabiblFull"/>
+         <ref name="sgamsDesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.biblLike_sequence">
+      <ref name="sgabibl"/>
+      <ref name="sgabiblFull"/>
+      <ref name="sgamsDesc"/>
+   </define>
+   <define name="sgamodel.biblLike_sequenceOptional">
+      <optional>
+         <ref name="sgabibl"/>
+      </optional>
+      <optional>
+         <ref name="sgabiblFull"/>
+      </optional>
+      <optional>
+         <ref name="sgamsDesc"/>
+      </optional>
+   </define>
+   <define name="sgamodel.biblLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgabibl"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgabiblFull"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamsDesc"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.biblLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgabibl"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgabiblFull"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamsDesc"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.headLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.headLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.headLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.headLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.headLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.headLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.labelLike">
+      <choice>
+         <ref name="sgadesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.labelLike_alternation">
+      <choice>
+         <ref name="sgadesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.labelLike_sequence">
+      <ref name="sgadesc"/>
+   </define>
+   <define name="sgamodel.labelLike_sequenceOptional">
+      <optional>
+         <ref name="sgadesc"/>
+      </optional>
+   </define>
+   <define name="sgamodel.labelLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgadesc"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.labelLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgadesc"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.listLike">
+      <choice>
+         <ref name="sgalist"/>
+         <ref name="sgalistOrg"/>
+         <ref name="sgalistEvent"/>
+         <ref name="sgalistPerson"/>
+         <ref name="sgalistPlace"/>
+         <ref name="sgalistRelation"/>
+         <ref name="sgalistNym"/>
+      </choice>
+   </define>
+   <define name="sgamodel.listLike_alternation">
+      <choice>
+         <ref name="sgalist"/>
+         <ref name="sgalistOrg"/>
+         <ref name="sgalistEvent"/>
+         <ref name="sgalistPerson"/>
+         <ref name="sgalistPlace"/>
+         <ref name="sgalistRelation"/>
+         <ref name="sgalistNym"/>
+      </choice>
+   </define>
+   <define name="sgamodel.listLike_sequence">
+      <ref name="sgalist"/>
+      <ref name="sgalistOrg"/>
+      <ref name="sgalistEvent"/>
+      <ref name="sgalistPerson"/>
+      <ref name="sgalistPlace"/>
+      <ref name="sgalistRelation"/>
+      <ref name="sgalistNym"/>
+   </define>
+   <define name="sgamodel.listLike_sequenceOptional">
+      <optional>
+         <ref name="sgalist"/>
+      </optional>
+      <optional>
+         <ref name="sgalistOrg"/>
+      </optional>
+      <optional>
+         <ref name="sgalistEvent"/>
+      </optional>
+      <optional>
+         <ref name="sgalistPerson"/>
+      </optional>
+      <optional>
+         <ref name="sgalistPlace"/>
+      </optional>
+      <optional>
+         <ref name="sgalistRelation"/>
+      </optional>
+      <optional>
+         <ref name="sgalistNym"/>
+      </optional>
+   </define>
+   <define name="sgamodel.listLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgalist"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistOrg"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistEvent"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistPerson"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistPlace"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistRelation"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistNym"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.listLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgalist"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistOrg"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistEvent"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistPerson"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistPlace"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistRelation"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistNym"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.noteLike">
+      <choice>
+         <ref name="sganote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.lLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.lLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.lLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.lLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.lLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.lLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.pLike">
+      <choice>
+         <ref name="sgap"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pLike_alternation">
+      <choice>
+         <ref name="sgap"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pLike_sequence">
+      <ref name="sgap"/>
+   </define>
+   <define name="sgamodel.pLike_sequenceOptional">
+      <optional>
+         <ref name="sgap"/>
+      </optional>
+   </define>
+   <define name="sgamodel.pLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgap"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.pLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgap"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.stageLike">
+      <choice>
+         <ref name="sgastage"/>
+      </choice>
+   </define>
+   <define name="sgamodel.stageLike_alternation">
+      <choice>
+         <ref name="sgastage"/>
+      </choice>
+   </define>
+   <define name="sgamodel.stageLike_sequence">
+      <ref name="sgastage"/>
+   </define>
+   <define name="sgamodel.stageLike_sequenceOptional">
+      <optional>
+         <ref name="sgastage"/>
+      </optional>
+   </define>
+   <define name="sgamodel.stageLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgastage"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.stageLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgastage"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.entryPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.eventLike">
+      <choice>
+         <ref name="sgaevent"/>
+         <ref name="sgalistEvent"/>
+      </choice>
+   </define>
+   <define name="sgamodel.global.edit">
+      <choice>
+         <ref name="sgagap"/>
+         <ref name="sgaaddSpan"/>
+         <ref name="sgadamageSpan"/>
+         <ref name="sgadelSpan"/>
+         <ref name="sgaspace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divPart">
+      <choice>
+         <ref name="sgamodel.lLike"/>
+         <ref name="sgamodel.pLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.persStateLike">
+      <choice>
+         <ref name="sgapersName"/>
+         <ref name="sgaaffiliation"/>
+         <ref name="sgaage"/>
+         <ref name="sgaeducation"/>
+         <ref name="sgafaith"/>
+         <ref name="sgafloruit"/>
+         <ref name="sgalangKnowledge"/>
+         <ref name="sganationality"/>
+         <ref name="sgaoccupation"/>
+         <ref name="sgapersona"/>
+         <ref name="sgaresidence"/>
+         <ref name="sgasex"/>
+         <ref name="sgasocecStatus"/>
+         <ref name="sgastate"/>
+         <ref name="sgatrait"/>
+      </choice>
+   </define>
+   <define name="sgamodel.personLike">
+      <choice>
+         <ref name="sgaorg"/>
+         <ref name="sgaperson"/>
+         <ref name="sgapersonGrp"/>
+      </choice>
+   </define>
+   <define name="sgamodel.personPart">
+      <choice>
+         <ref name="sgamodel.biblLike"/>
+         <ref name="sgamodel.eventLike"/>
+         <ref name="sgamodel.persStateLike"/>
+         <ref name="sganame"/>
+         <ref name="sgaidno"/>
+         <ref name="sgabirth"/>
+         <ref name="sgadeath"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeNamePart">
+      <choice>
+         <ref name="sgaplaceName"/>
+         <ref name="sgabloc"/>
+         <ref name="sgacountry"/>
+         <ref name="sgaregion"/>
+         <ref name="sgasettlement"/>
+         <ref name="sgadistrict"/>
+         <ref name="sgageogName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeNamePart_alternation">
+      <choice>
+         <ref name="sgaplaceName"/>
+         <ref name="sgabloc"/>
+         <ref name="sgacountry"/>
+         <ref name="sgaregion"/>
+         <ref name="sgasettlement"/>
+         <ref name="sgadistrict"/>
+         <ref name="sgageogName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeNamePart_sequence">
+      <ref name="sgaplaceName"/>
+      <ref name="sgabloc"/>
+      <ref name="sgacountry"/>
+      <ref name="sgaregion"/>
+      <ref name="sgasettlement"/>
+      <ref name="sgadistrict"/>
+      <ref name="sgageogName"/>
+   </define>
+   <define name="sgamodel.placeNamePart_sequenceOptional">
+      <optional>
+         <ref name="sgaplaceName"/>
+      </optional>
+      <optional>
+         <ref name="sgabloc"/>
+      </optional>
+      <optional>
+         <ref name="sgacountry"/>
+      </optional>
+      <optional>
+         <ref name="sgaregion"/>
+      </optional>
+      <optional>
+         <ref name="sgasettlement"/>
+      </optional>
+      <optional>
+         <ref name="sgadistrict"/>
+      </optional>
+      <optional>
+         <ref name="sgageogName"/>
+      </optional>
+   </define>
+   <define name="sgamodel.placeNamePart_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaplaceName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgabloc"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgacountry"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaregion"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgasettlement"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadistrict"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgageogName"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.placeNamePart_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaplaceName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgabloc"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgacountry"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaregion"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgasettlement"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadistrict"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgageogName"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.placeStateLike">
+      <choice>
+         <ref name="sgamodel.placeNamePart"/>
+         <ref name="sgaclimate"/>
+         <ref name="sgalocation"/>
+         <ref name="sgapopulation"/>
+         <ref name="sgastate"/>
+         <ref name="sgaterrain"/>
+         <ref name="sgatrait"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeStateLike_alternation">
+      <choice>
+         <ref name="sgamodel.placeNamePart_alternation"/>
+         <ref name="sgaclimate"/>
+         <ref name="sgalocation"/>
+         <ref name="sgapopulation"/>
+         <ref name="sgastate"/>
+         <ref name="sgaterrain"/>
+         <ref name="sgatrait"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeStateLike_sequence">
+      <ref name="sgamodel.placeNamePart_sequence"/>
+      <ref name="sgaclimate"/>
+      <ref name="sgalocation"/>
+      <ref name="sgapopulation"/>
+      <ref name="sgastate"/>
+      <ref name="sgaterrain"/>
+      <ref name="sgatrait"/>
+   </define>
+   <define name="sgamodel.placeStateLike_sequenceOptional">
+      <optional>
+         <ref name="sgamodel.placeNamePart_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgaclimate"/>
+      </optional>
+      <optional>
+         <ref name="sgalocation"/>
+      </optional>
+      <optional>
+         <ref name="sgapopulation"/>
+      </optional>
+      <optional>
+         <ref name="sgastate"/>
+      </optional>
+      <optional>
+         <ref name="sgaterrain"/>
+      </optional>
+      <optional>
+         <ref name="sgatrait"/>
+      </optional>
+   </define>
+   <define name="sgamodel.placeStateLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgamodel.placeNamePart_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaclimate"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalocation"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgapopulation"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgastate"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaterrain"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgatrait"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.placeStateLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgamodel.placeNamePart_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaclimate"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalocation"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgapopulation"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgastate"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaterrain"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgatrait"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.orgPart">
+      <choice>
+         <ref name="sgamodel.eventLike"/>
+         <ref name="sgalistOrg"/>
+         <ref name="sgalistPerson"/>
+         <ref name="sgalistPlace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.publicationStmtPart.agency">
+      <choice>
+         <ref name="sgadistributor"/>
+         <ref name="sgaauthority"/>
+      </choice>
+   </define>
+   <define name="sgamodel.publicationStmtPart.detail">
+      <choice>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgaaddress"/>
+         <ref name="sgadate"/>
+         <ref name="sgapubPlace"/>
+         <ref name="sgaidno"/>
+         <ref name="sgaavailability"/>
+      </choice>
+   </define>
+   <define name="sgamodel.availabilityPart">
+      <choice>
+         <ref name="sgalicence"/>
+      </choice>
+   </define>
+   <define name="sgamodel.certLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.descLike">
+      <choice>
+         <ref name="sgadesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.glossLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.quoteLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.quoteLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.quoteLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.quoteLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.quoteLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.quoteLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.qLike">
+      <choice>
+         <ref name="sgamodel.quoteLike"/>
+         <ref name="sgafloatingText"/>
+      </choice>
+   </define>
+   <define name="sgamodel.qLike_alternation">
+      <choice>
+         <ref name="sgamodel.quoteLike_alternation"/>
+         <ref name="sgafloatingText"/>
+      </choice>
+   </define>
+   <define name="sgamodel.qLike_sequence">
+      <ref name="sgamodel.quoteLike_sequence"/>
+      <ref name="sgafloatingText"/>
+   </define>
+   <define name="sgamodel.qLike_sequenceOptional">
+      <optional>
+         <ref name="sgamodel.quoteLike_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgafloatingText"/>
+      </optional>
+   </define>
+   <define name="sgamodel.qLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgamodel.quoteLike_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgafloatingText"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.qLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgamodel.quoteLike_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgafloatingText"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.respLike">
+      <choice>
+         <ref name="sgaauthor"/>
+         <ref name="sgarespStmt"/>
+         <ref name="sgasponsor"/>
+         <ref name="sgafunder"/>
+         <ref name="sgaprincipal"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divWrapper">
+      <choice>
+         <ref name="sgabyline"/>
+         <ref name="sgadateline"/>
+         <ref name="sgaargument"/>
+         <ref name="sgaepigraph"/>
+         <ref name="sgasalute"/>
+         <ref name="sgadocAuthor"/>
+         <ref name="sgadocDate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divTopPart">
+      <choice>
+         <ref name="sgamodel.headLike"/>
+         <ref name="sgaopener"/>
+         <ref name="sgasigned"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divTop">
+      <choice>
+         <ref name="sgamodel.divWrapper"/>
+         <ref name="sgamodel.divTopPart"/>
+      </choice>
+   </define>
+   <define name="sgamodel.frontPart.drama">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.pLike.front">
+      <choice>
+         <ref name="sgabyline"/>
+         <ref name="sgaargument"/>
+         <ref name="sgaepigraph"/>
+         <ref name="sgadocTitle"/>
+         <ref name="sgatitlePart"/>
+         <ref name="sgadocAuthor"/>
+         <ref name="sgadocEdition"/>
+         <ref name="sgadocImprint"/>
+         <ref name="sgadocDate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divBottomPart">
+      <choice>
+         <ref name="sgatrailer"/>
+         <ref name="sgacloser"/>
+         <ref name="sgasigned"/>
+         <ref name="sgapostscript"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divBottom">
+      <choice>
+         <ref name="sgamodel.divWrapper"/>
+         <ref name="sgamodel.divBottomPart"/>
+      </choice>
+   </define>
+   <define name="sgamodel.titlepagePart">
+      <choice>
+         <ref name="sgagraphic"/>
+         <ref name="sgabyline"/>
+         <ref name="sgaargument"/>
+         <ref name="sgaepigraph"/>
+         <ref name="sgadocTitle"/>
+         <ref name="sgatitlePart"/>
+         <ref name="sgadocAuthor"/>
+         <ref name="sgaimprimatur"/>
+         <ref name="sgadocEdition"/>
+         <ref name="sgadocImprint"/>
+         <ref name="sgadocDate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.msQuoteLike">
+      <choice>
+         <ref name="sgatitle"/>
+         <ref name="sgacolophon"/>
+         <ref name="sgaexplicit"/>
+         <ref name="sgafinalRubric"/>
+         <ref name="sgaincipit"/>
+         <ref name="sgarubric"/>
+      </choice>
+   </define>
+   <define name="sgamodel.msItemPart">
+      <choice>
+         <ref name="sgamodel.biblLike"/>
+         <ref name="sgamodel.quoteLike"/>
+         <ref name="sgamodel.respLike"/>
+         <ref name="sgamodel.msQuoteLike"/>
+         <ref name="sgaidno"/>
+         <ref name="sgafiliation"/>
+         <ref name="sgamsItem"/>
+         <ref name="sgamsItemStruct"/>
+         <ref name="sgadecoNote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.imprintPart">
+      <choice>
+         <ref name="sgapubPlace"/>
+         <ref name="sgadistributor"/>
+      </choice>
+   </define>
+   <define name="sgamodel.catDescPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.addressLike">
+      <choice>
+         <ref name="sgaaddress"/>
+         <ref name="sgaaffiliation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.addressLike_alternation">
+      <choice>
+         <ref name="sgaaddress"/>
+         <ref name="sgaaffiliation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.addressLike_sequence">
+      <ref name="sgaaddress"/>
+      <ref name="sgaaffiliation"/>
+   </define>
+   <define name="sgamodel.addressLike_sequenceOptional">
+      <optional>
+         <ref name="sgaaddress"/>
+      </optional>
+      <optional>
+         <ref name="sgaaffiliation"/>
+      </optional>
+   </define>
+   <define name="sgamodel.addressLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaaddress"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaaffiliation"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.addressLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaaddress"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaaffiliation"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.nameLike">
+      <choice>
+         <ref name="sgamodel.nameLike.agent"/>
+         <ref name="sgamodel.offsetLike"/>
+         <ref name="sgamodel.placeStateLike"/>
+         <ref name="sgars"/>
+         <ref name="sgaidno"/>
+         <ref name="sgamodel.persNamePart"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike_alternation">
+      <choice>
+         <ref name="sgamodel.nameLike.agent_alternation"/>
+         <ref name="sgamodel.offsetLike_alternation"/>
+         <ref name="sgamodel.placeStateLike_alternation"/>
+         <ref name="sgars"/>
+         <ref name="sgaidno"/>
+         <ref name="sgamodel.persNamePart_alternation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike_sequence">
+      <ref name="sgamodel.nameLike.agent_sequence"/>
+      <ref name="sgamodel.offsetLike_sequence"/>
+      <ref name="sgamodel.placeStateLike_sequence"/>
+      <ref name="sgars"/>
+      <ref name="sgaidno"/>
+      <ref name="sgamodel.persNamePart_sequence"/>
+   </define>
+   <define name="sgamodel.nameLike_sequenceOptional">
+      <optional>
+         <ref name="sgamodel.nameLike.agent_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgamodel.offsetLike_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgamodel.placeStateLike_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgars"/>
+      </optional>
+      <optional>
+         <ref name="sgaidno"/>
+      </optional>
+      <optional>
+         <ref name="sgamodel.persNamePart_sequenceOptional"/>
+      </optional>
+   </define>
+   <define name="sgamodel.nameLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgamodel.nameLike.agent_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamodel.offsetLike_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamodel.placeStateLike_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgars"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaidno"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamodel.persNamePart_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.nameLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgamodel.nameLike.agent_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamodel.offsetLike_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamodel.placeStateLike_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgars"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaidno"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamodel.persNamePart_sequenceRepeatable"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.global">
+      <choice>
+         <ref name="sgamodel.global.meta"/>
+         <ref name="sgamodel.milestoneLike"/>
+         <ref name="sgamodel.noteLike"/>
+         <ref name="sgamodel.global.edit"/>
+         <ref name="sgametamark"/>
+         <ref name="sgafigure"/>
+      </choice>
+   </define>
+   <define name="sgamodel.biblPart">
+      <choice>
+         <ref name="sgamodel.respLike"/>
+         <ref name="sgamodel.imprintPart"/>
+         <ref name="sgacitedRange"/>
+         <ref name="sgabibl"/>
+         <ref name="sgarelatedItem"/>
+         <ref name="sgaedition"/>
+         <ref name="sgaextent"/>
+         <ref name="sgaavailability"/>
+         <ref name="sgamsIdentifier"/>
+         <ref name="sgalistRelation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.frontPart">
+      <choice>
+         <ref name="sgamodel.frontPart.drama"/>
+         <ref name="sgatitlePage"/>
+      </choice>
+   </define>
+   <define name="sgamodel.addrPart">
+      <choice>
+         <ref name="sgamodel.nameLike"/>
+         <ref name="sgaaddrLine"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.data">
+      <choice>
+         <ref name="sgamodel.dateLike"/>
+         <ref name="sgamodel.measureLike"/>
+         <ref name="sgamodel.addressLike"/>
+         <ref name="sgamodel.nameLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.inter">
+      <choice>
+         <ref name="sgamodel.egLike"/>
+         <ref name="sgamodel.oddDecl"/>
+         <ref name="sgamodel.biblLike"/>
+         <ref name="sgamodel.labelLike"/>
+         <ref name="sgamodel.listLike"/>
+         <ref name="sgamodel.stageLike"/>
+         <ref name="sgamodel.qLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.common">
+      <choice>
+         <ref name="sgamodel.divPart"/>
+         <ref name="sgamodel.inter"/>
+      </choice>
+   </define>
+   <define name="sgamodel.phrase">
+      <choice>
+         <ref name="sgamodel.segLike"/>
+         <ref name="sgamodel.highlighted"/>
+         <ref name="sgamodel.graphicLike"/>
+         <ref name="sgamodel.pPart.msdesc"/>
+         <ref name="sgamodel.pPart.edit"/>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgamodel.lPart"/>
+         <ref name="sgamodel.phrase.xml"/>
+         <ref name="sgamodel.specDescLike"/>
+         <ref name="sgamodel.pPart.data"/>
+      </choice>
+   </define>
+   <define name="sgamodel.limitedPhrase">
+      <choice>
+         <ref name="sgamodel.hiLike"/>
+         <ref name="sgamodel.emphLike"/>
+         <ref name="sgamodel.pPart.msdesc"/>
+         <ref name="sgamodel.pPart.editorial"/>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgamodel.phrase.xml"/>
+         <ref name="sgamodel.pPart.data"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divLike">
+      <choice>
+         <ref name="sgadiv"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divGenLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.div1Like">
+      <choice>
+         <ref name="sgadiv1"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div2Like">
+      <choice>
+         <ref name="sgadiv2"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div3Like">
+      <choice>
+         <ref name="sgadiv3"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div4Like">
+      <choice>
+         <ref name="sgadiv4"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div5Like">
+      <choice>
+         <ref name="sgadiv5"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div6Like">
+      <choice>
+         <ref name="sgadiv6"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div7Like">
+      <choice>
+         <ref name="sgadiv7"/>
+      </choice>
+   </define>
+   <define name="sgamodel.applicationLike">
+      <choice>
+         <ref name="sgaapplication"/>
+      </choice>
+   </define>
+   <define name="sgamodel.teiHeaderPart">
+      <choice>
+         <ref name="sgaencodingDesc"/>
+         <ref name="sgaprofileDesc"/>
+         <ref name="sgaxenoData"/>
+      </choice>
+   </define>
+   <define name="sgamodel.sourceDescPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.encodingDescPart">
+      <choice>
+         <ref name="sgacharDecl"/>
+         <ref name="sgaschemaRef"/>
+         <ref name="sgaprojectDesc"/>
+         <ref name="sgasamplingDecl"/>
+         <ref name="sgaeditorialDecl"/>
+         <ref name="sgatagsDecl"/>
+         <ref name="sgastyleDefDecl"/>
+         <ref name="sgarefsDecl"/>
+         <ref name="sgalistPrefixDef"/>
+         <ref name="sgaclassDecl"/>
+         <ref name="sgageoDecl"/>
+         <ref name="sgaappInfo"/>
+      </choice>
+   </define>
+   <define name="sgamodel.editorialDeclPart">
+      <choice>
+         <ref name="sgacorrection"/>
+         <ref name="sganormalization"/>
+         <ref name="sgaquotation"/>
+         <ref name="sgahyphenation"/>
+         <ref name="sgasegmentation"/>
+         <ref name="sgastdVals"/>
+         <ref name="sgainterpretation"/>
+         <ref name="sgapunctuation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.profileDescPart">
+      <choice>
+         <ref name="sgahandNotes"/>
+         <ref name="sgalistTranspose"/>
+         <ref name="sgaabstract"/>
+         <ref name="sgacreation"/>
+         <ref name="sgalangUsage"/>
+         <ref name="sgatextClass"/>
+         <ref name="sgacalendarDesc"/>
+         <ref name="sgacorrespDesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.correspActionPart">
+      <choice>
+         <ref name="sgamodel.dateLike"/>
+         <ref name="sgamodel.addressLike"/>
+         <ref name="sgamodel.nameLike"/>
+         <ref name="sganote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.correspContextPart">
+      <choice>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgamodel.pLike"/>
+         <ref name="sganote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.correspDescPart">
+      <choice>
+         <ref name="sganote"/>
+         <ref name="sgacorrespAction"/>
+         <ref name="sgacorrespContext"/>
+      </choice>
+   </define>
+   <define name="sgamodel.resourceLike">
+      <choice>
+         <ref name="sgafacsimile"/>
+         <ref name="sgasourceDoc"/>
+         <ref name="sgatext"/>
+      </choice>
+   </define>
+   <define name="sgaatt.personal.attributes">
+      <ref name="sgaatt.naming.attributes"/>
+      <ref name="sgaatt.personal.attribute.full"/>
+      <ref name="sgaatt.personal.attribute.sort"/>
+   </define>
+   <define name="sgaatt.personal.attribute.full">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="full"
+                    a:defaultValue="yes">
+            <a:documentation>indicates whether the name component is given in full, as an abbreviation or simply as an initial.</a:documentation>
+            <choice>
+               <value>yes</value>
+               <a:documentation>the name component is spelled out in full.</a:documentation>
+               <value>abb</value>
+               <a:documentation>(abbreviated) the name component is given in an abbreviated form.</a:documentation>
+               <value>init</value>
+               <a:documentation>(initial letter) the name component is indicated only by one initial.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.personal.attribute.sort">
+      <optional>
+         <attribute name="sort">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sort order of the name component in relation to others within the name.</a:documentation>
+            <data type="nonNegativeInteger"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamodel.placeLike">
+      <choice>
+         <ref name="sgaplace"/>
+      </choice>
+   </define>
+   <define name="sgaatt.milestoneUnit.attributes">
+      <ref name="sgaatt.milestoneUnit.attribute.unit"/>
+   </define>
+   <define name="sgaatt.milestoneUnit.attribute.unit">
+      <attribute name="unit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a conventional name for the kind of section changing at this milestone.
+Suggested values include: 1] page; 2] column; 3] line; 4] book; 5] poem; 6] canto; 7] speaker; 8] stanza; 9] act; 10] scene; 11] section; 12] absent; 13] unnumbered</a:documentation>
+         <choice>
+            <value>page</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">physical page breaks (synonymous with the pb element).</a:documentation>
+            <value>column</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">column breaks.</a:documentation>
+            <value>line</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">line breaks (synonymous with the lb element).</a:documentation>
+            <value>book</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">any units termed book, liber, etc.</a:documentation>
+            <value>poem</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">individual poems in a collection.</a:documentation>
+            <value>canto</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">cantos or other major sections of a poem.</a:documentation>
+            <value>speaker</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">changes of speaker or narrator.</a:documentation>
+            <value>stanza</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">stanzas within a poem, book, or canto.</a:documentation>
+            <value>act</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">acts within a play.</a:documentation>
+            <value>scene</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">scenes within a play or act.</a:documentation>
+            <value>section</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">sections of any kind.</a:documentation>
+            <value>absent</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">passages not present in the reference edition.</a:documentation>
+            <value>unnumbered</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">passages present in the text, but not to be included as part of the reference.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </choice>
+      </attribute>
+   </define>
+   <define name="sgap">
+      <element name="p">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(paragraph) marks paragraphs in prose. [3.1. Paragraphs 7.2.5. Speech Contents]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-p-abstractModel-p-constraint-report-4">
+            <rule context="tei:p">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="not(ancestor::floatingText) and (ancestor::tei:p or ancestor::tei:ab)          and not(parent::tei:exemplum                |parent::tei:item                |parent::tei:note                |parent::tei:q                |parent::tei:quote                |parent::tei:remarks                |parent::tei:said                |parent::tei:sp                |parent::tei:stage                |parent::tei:cell                |parent::tei:figure                )">
+        Abstract model violation: Paragraphs may not contain other paragraphs or ab elements.
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-p-abstractModel-structure-l-constraint-report-5">
+            <rule context="tei:p">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="ancestor::tei:l[not(.//tei:note//tei:p[. = current()])]">
+        Abstract model violation: Lines may not contain higher-level structural elements such as div, p, or ab.
+      </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.fragmentable.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaforeign">
+      <element name="foreign">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a word or phrase as belonging to some language other than that of the surrounding text. [3.3.2.1. Foreign Words or Expressions]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaemph">
+      <element name="emph">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(emphasized) marks words or phrases which are stressed or emphasized for linguistic or rhetorical effect. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahi">
+      <element name="hi">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(highlighted) marks a word or phrase as graphically distinct from the surrounding text, for reasons concerning which no claim is made. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.written.attributes"/>
+         <attribute name="rend">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>hyphenated</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>underline</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>double-underline</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>bold</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>caps</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>italic</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>sup</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>sub</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadesc">
+      <element name="desc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description) contains a brief description of the object documented by its parent element, typically a documentation element or an entity. [22.4.1. Description of Components]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.translatable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaterm">
+      <element name="term">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single-word, multi-word, or symbolic designation which is regarded as a technical term. [3.3.4. Terms, Glosses, Equivalents, and Descriptions]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.cReferencing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagap">
+      <element name="gap">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates a point where material has been omitted in a transcription, whether for editorial reasons described in the TEI header, as part of sampling practice, or because the material is illegible, invisible, or inaudible. [3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.timed.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <optional>
+            <attribute name="reason">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the reason for omission
+Suggested values include: 1] cancelled; 2] deleted; 3] editorial; 4] illegible; 5] inaudible; 6] irrelevant; 7] sampling</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <choice>
+                        <value>cancelled</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>deleted</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>editorial</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">for features omitted from transcription due to editorial policy</a:documentation>
+                        <value>illegible</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>inaudible</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>irrelevant</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>sampling</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <data type="token">
+                           <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                        </data>
+                     </choice>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="hand">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in the case of text omitted from the transcription because of deliberate deletion by an identifiable hand, indicates the hand which made the deletion.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="agent">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in the case of text omitted because of damage, categorizes the cause of the damage, if it can be identified.
+Sample values include: 1] rubbing; 2] mildew; 3] smoke</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadd">
+      <element name="add">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(addition) contains letters, words, or phrases inserted in the source text by an author, scribe, or a previous annotator or corrector. [3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="place">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>superlinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>intralinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>sublinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>interlinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>alternative</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadel">
+      <element name="del">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deletion) contains a letter, word, or passage deleted, marked as deleted, or otherwise indicated as superfluous or spurious in the copy text by an author, scribe, or a previous annotator or corrector. [3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.transcriptional.attribute.cause"/>
+         <ref name="sgaatt.transcriptional.attribute.seq"/>
+         <ref name="sgaatt.editLike.attribute.evidence"/>
+         <ref name="sgaatt.editLike.attribute.instant"/>
+         <ref name="sgaatt.dimensions.attribute.unit"/>
+         <ref name="sgaatt.dimensions.attribute.quantity"/>
+         <ref name="sgaatt.dimensions.attribute.extent"/>
+         <ref name="sgaatt.dimensions.attribute.precision"/>
+         <ref name="sgaatt.dimensions.attribute.scope"/>
+         <ref name="sgaatt.ranging.attribute.atLeast"/>
+         <ref name="sgaatt.ranging.attribute.atMost"/>
+         <ref name="sgaatt.ranging.attribute.min"/>
+         <ref name="sgaatt.ranging.attribute.max"/>
+         <ref name="sgaatt.ranging.attribute.confidence"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>strikethrough</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>overwritten</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>smear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>erased</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>vertical_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unmarked</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaunclear">
+      <element name="unclear">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word, phrase, or passage which cannot be transcribed with certainty because it is illegible or inaudible in the source. [11.3.3.1. Damage, Illegibility, and Supplied Text 3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <optional>
+            <attribute name="reason">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates why the material is hard to transcribe.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="hand">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the difficulty in transcription arises from action (partial deletion, etc.) assignable to an identifiable hand, signifies the hand responsible for the action.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="agent">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the difficulty in transcription arises from damage, categorizes the cause of the damage, if it can be identified.
+Sample values include: 1] rubbing; 2] mildew; 3] smoke</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganame">
+      <element name="name">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name, proper noun) contains a proper noun or noun phrase. [3.5.1. Referring Strings]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgars">
+      <element name="rs">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(referencing string) contains a general purpose name or referring string. [13.2.1. Personal Names 3.5.1. Referring Strings]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddress">
+      <element name="address">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a postal address, for example of a publisher, an organization, or an individual. [3.5.2. Addresses 2.2.4. Publication, Distribution, Licensing, etc. 3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <oneOrMore>
+               <group>
+        
+                  <ref name="sgamodel.addrPart"/>
+        
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </oneOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddrLine">
+      <element name="addrLine">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(address line) contains one line of a postal address. [3.5.2. Addresses 2.2.4. Publication, Distribution, Licensing, etc. 3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganum">
+      <element name="num">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) contains a number, written in any form. [3.5.3. Numbers and
+Measures]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.ranging.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the type of numeric value.
+Suggested values include: 1] cardinal; 2] ordinal; 3] fraction; 4] percentage</a:documentation>
+               <choice>
+                  <value>cardinal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">absolute number, e.g. 21, 21.5</a:documentation>
+                  <value>ordinal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">ordinal number, e.g. 21st</a:documentation>
+                  <value>fraction</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">fraction, e.g. one half or three-quarters</a:documentation>
+                  <value>percentage</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a percentage</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="value">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of the number in standard form.</a:documentation>
+               <choice>
+                  <data type="double"/>
+                  <data type="token">
+                     <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+                  </data>
+                  <data type="decimal"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgameasureGrp">
+      <element name="measureGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure group) contains a group of dimensional specifications which relate to the same object, for example the height and width of a manuscript page. [10.3.4. Dimensions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.measureLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.measurement.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadate">
+      <element name="date">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a date in any format. [3.5.4. Dates and Times 2.2.4. Publication, Distribution, Licensing, etc. 2.6. The Revision Description 3.11.2.4. Imprint, Size of a Document, and Reprint Information 15.2.3. The Setting Description 13.3.6. Dates and Times]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaptr">
+      <element name="ptr">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pointer) defines a pointer to another location. [3.6. Simple Links and Cross-References 16.1. Links]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-ptr-ptrAtts-constraint-report-6">
+            <rule context="tei:ptr">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@target and @cRef">Only one of the
+attributes @target and @cRef may be supplied on <name/>.</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.internetMedia.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.cReferencing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaref">
+      <element name="ref">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) defines a reference to another location, possibly modified by additional text or comment. [3.6. Simple Links and Cross-References 16.1. Links]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-ref-refAtts-constraint-report-7">
+            <rule context="tei:ref">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@target and @cRef">Only one of the
+	attributes @target' and @cRef' may be supplied on <name/>
+               </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.internetMedia.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.cReferencing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalist">
+      <element name="list">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any sequence of items organized as a list. [3.7. Lists]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+          
+                  <ref name="sgamodel.divTop"/>
+          
+          
+                  <ref name="sgamodel.global"/>
+          
+               </choice>
+            </zeroOrMore>
+      
+            <choice>
+               <oneOrMore>
+                  <group>
+                     <ref name="sgaitem"/>
+          
+                     <zeroOrMore>
+                        <ref name="sgamodel.global"/>
+                     </zeroOrMore>
+          
+                  </group>
+               </oneOrMore>
+               <group>
+          
+            
+          
+          
+            
+          
+                  <oneOrMore>
+                     <group>
+            
+            
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+            
+                        <ref name="sgaitem"/>
+            
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+            
+                     </group>
+                  </oneOrMore>
+               </group>
+            </choice>
+      
+            <zeroOrMore>
+               <group>
+          
+                  <ref name="sgamodel.divBottom"/>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+          
+               </group>
+            </zeroOrMore>
+      
+         </group>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-list-gloss-list-must-have-labels-constraint-rule-9">
+            <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="tei:list[@type='gloss']">
+	              <sch:assert test="tei:label">The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element</sch:assert>
+            </sch:rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the nature of the items in the list.
+Suggested values include: 1] gloss; 2] index; 3] instructions; 4] litany; 5] syllogism</a:documentation>
+               <choice>
+                  <value>gloss</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item glosses some term or concept, which is given by a label element preceding the list item.</a:documentation>
+                  <value>index</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is an entry in an index such as the alphabetical topical index at the back of a print volume.</a:documentation>
+                  <value>instructions</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is a step in a sequence of instructions, as in a recipe.</a:documentation>
+                  <value>litany</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is one of a sequence of petitions, supplications or invocations, typically in a religious ritual.</a:documentation>
+                  <value>syllogism</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is part of an argument consisting of two or more propositions and a final conclusion derived from them.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaitem">
+      <element name="item">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains one component of a list. [3.7. Lists 2.6. The Revision Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganote">
+      <element name="note">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a note or annotation. [3.8.1. Notes and Simple Annotation 2.2.6. The Notes Statement 3.11.2.8. Notes and Statement of Language 9.3.5.4. Notes within Entries]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="anchored"
+                       a:defaultValue="true">
+               <a:documentation>indicates whether the copy text shows the exact place of reference for the note.</a:documentation>
+               <data type="boolean"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="targetEnd">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the end of the span to which the note is attached, if the note is not embedded in the text at that point.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaindex">
+      <element name="index">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(index entry) marks a location to be indexed for whatever purpose. [3.8.2. Index Entries]</a:documentation>
+         <zeroOrMore>
+            <group>
+               <ref name="sgaterm"/>
+        
+               <optional>
+                  <ref name="sgaindex"/>
+               </optional>
+        
+            </group>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <optional>
+            <attribute name="indexName">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a single word which follows the rules defining a legal XML name (see ), supplying a name to specify which index (of several) the index entry belongs to.</a:documentation>
+               <data type="Name"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamedia">
+      <element name="media">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of any form of external media such as an audio or video clip etc. [3.9. Graphics and Other Non-textual Components]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.descLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.media.attribute.width"/>
+         <ref name="sgaatt.media.attribute.height"/>
+         <ref name="sgaatt.media.attribute.scale"/>
+         <ref name="sgaatt.resourced.attributes"/>
+         <ref name="sgaatt.timed.attributes"/>
+         <attribute name="mimeType">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagraphic">
+      <element name="graphic">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of a graphic or illustration, either forming part of a text, or providing an image of it. [3.9. Graphics and Other Non-textual Components 11.1. Digital Facsimiles]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.descLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.media.attributes"/>
+         <ref name="sgaatt.resourced.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamilestone">
+      <element name="milestone">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">marks a boundary point separating any kind of section of a text, typically but not necessarily indicating a point at which some part of a standard reference system changes, where the change is not represented by a structural element. [3.10.3. Milestone
+Elements]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.edition.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <ref name="sgaatt.breaking.attributes"/>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>tei:div</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:p</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:lg</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:l</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:date</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:speaker</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:q</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:stage</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:seg</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:note</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:head</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:div[@type='scene']</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:div[@type='act']</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaauthor">
+      <element name="author">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in a bibliographic reference, contains the name(s) of an author, personal or corporate, of a work; for example in the same form as that provided by a recognized bibliographic name authority. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarespStmt">
+      <element name="respStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(statement of responsibility) supplies a statement of responsibility for the intellectual content of a text, edition, recording, or series, where the specialized elements for authors, editors, etc. do not suffice or do not apply. May also be used to encode information about individuals or organizations which have played a role in the production or distribution of a bibliographic work. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.2. The Edition Statement 2.2.5. The Series Statement]</a:documentation>
+         <group>
+            <choice>
+               <group>
+          
+                  <oneOrMore>
+                     <ref name="sgaresp"/>
+                  </oneOrMore>
+          
+          
+                  <oneOrMore>
+                     <ref name="sgamodel.nameLike.agent"/>
+                  </oneOrMore>
+          
+               </group>
+               <group>
+          
+                  <oneOrMore>
+                     <ref name="sgamodel.nameLike.agent"/>
+                  </oneOrMore>
+          
+          
+                  <oneOrMore>
+                     <ref name="sgaresp"/>
+                  </oneOrMore>
+          
+               </group>
+            </choice>
+            <zeroOrMore>
+               <ref name="sganote"/>
+            </zeroOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaresp">
+      <element name="resp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsibility) contains a phrase describing the nature of a person's intellectual responsibility, or an organization's role in the production or distribution of a work. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.2. The Edition Statement 2.2.5. The Series Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitle">
+      <element name="title">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a title for any kind of work. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.5. The Series Statement]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the title according to some convenient typology.
+Sample values include: 1] main; 2] sub(subordinate) ; 3] alt(alternate) ; 4] short; 5] desc(descriptive) </a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="level">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the bibliographic level for a title, that is, whether it identifies an article, book, journal, series, or unpublished material.</a:documentation>
+               <choice>
+                  <value>a</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(analytic) the title applies to an analytic item, such as an article, poem, or other work published as part of a larger item.</a:documentation>
+                  <value>m</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(monographic) the title applies to a monograph such as a book or other item considered to be a distinct publication, including single volumes of multi-volume works</a:documentation>
+                  <value>j</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(journal) the title applies to any serial or periodical publication such as a journal, magazine, or newspaper</a:documentation>
+                  <value>s</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series) the title applies to a series of otherwise distinct publications such as a collection</a:documentation>
+                  <value>u</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unpublished) the title applies to any unpublished material (including theses and dissertations unless published by a commercial press)</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacitedRange">
+      <element name="citedRange">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cited range) defines the range of cited content, often represented by pages or other units [3.11.2.5. Scopes and Ranges in Bibliographic Citations]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.citing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapubPlace">
+      <element name="pubPlace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication place) contains the name of the place where a bibliographic item was published. [3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabibl">
+      <element name="bibl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(bibliographic citation) contains a loosely-structured bibliographic citation of which the sub-components may or may not be explicitly tagged. [3.11.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.highlighted"/>
+               <ref name="sgamodel.pPart.data"/>
+               <ref name="sgamodel.pPart.edit"/>
+               <ref name="sgamodel.segLike"/>
+               <ref name="sgamodel.ptrLike"/>
+               <ref name="sgamodel.biblPart"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarelatedItem">
+      <element name="relatedItem">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains or references some other bibliographic item which is related to the present one in some specified manner, for example as a constituent or alternative version of it. [3.11.2.7. Related Items]</a:documentation>
+         <optional>
+            <choice>
+               <ref name="sgamodel.biblLike"/>
+               <ref name="sgamodel.ptrLike"/>
+            </choice>
+         </optional>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relatedItem-targetorcontent1-constraint-report-8">
+            <rule context="tei:relatedItem">
+               <sch:report xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@target and count( child::* ) &gt; 0">
+If the @target attribute on <sch:name/> is used, the
+relatedItem element must be empty</sch:report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relatedItem-targetorcontent1-constraint-assert-7">
+            <rule context="tei:relatedItem">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@target or child::*">A relatedItem element should have either a 'target' attribute
+        or a child element to indicate the related bibliographic item</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the related bibliographic element by means of an absolute or relative URI reference</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastage">
+      <element name="stage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(stage direction) contains any kind of stage direction within a dramatic text or fragment. [3.12.2. Core Tags for Drama 3.12. Passages of Verse or Drama 7.2.4. Stage Directions]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.ascribed.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the kind of stage direction.
+Suggested values include: 1] setting; 2] entrance; 3] exit; 4] business; 5] novelistic; 6] delivery; 7] modifier; 8] location; 9] mixed</a:documentation>
+               <list>
+                  <zeroOrMore>
+                     <choice>
+                        <value>setting</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a setting.</a:documentation>
+                        <value>entrance</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes an entrance.</a:documentation>
+                        <value>exit</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes an exit.</a:documentation>
+                        <value>business</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes stage business.</a:documentation>
+                        <value>novelistic</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">is a narrative, motivating stage direction.</a:documentation>
+                        <value>delivery</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes how a character speaks.</a:documentation>
+                        <value>modifier</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives some detail about a character.</a:documentation>
+                        <value>location</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a location.</a:documentation>
+                        <value>mixed</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">more than one of the above</a:documentation>
+                        <data type="token">
+                           <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                        </data>
+                     </choice>
+                  </zeroOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.global.facs.attributes">
+      <ref name="sgaatt.global.facs.attribute.facs"/>
+   </define>
+   <define name="sgaatt.global.facs.attribute.facs">
+      <optional>
+         <attribute name="facs">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(facsimile) points to all or part of an image which corresponds with the content of the element.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attributes">
+      <ref name="sgaatt.coordinated.attribute.start"/>
+      <ref name="sgaatt.coordinated.attribute.ulx"/>
+      <ref name="sgaatt.coordinated.attribute.uly"/>
+      <ref name="sgaatt.coordinated.attribute.lrx"/>
+      <ref name="sgaatt.coordinated.attribute.lry"/>
+      <ref name="sgaatt.coordinated.attribute.points"/>
+   </define>
+   <define name="sgaatt.coordinated.attribute.start">
+      <optional>
+         <attribute name="start">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the element within a transcription of the text containing at least the start of the writing represented by this zone or surface.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.ulx">
+      <optional>
+         <attribute name="ulx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.uly">
+      <optional>
+         <attribute name="uly">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.lrx">
+      <optional>
+         <attribute name="lrx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.lry">
+      <optional>
+         <attribute name="lry">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.points">
+      <optional>
+         <attribute name="points">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a two dimensional area within the bounding box specified by the other attributes by means of a series of pairs of numbers, each of which gives the x,y coordinates of a point on a line enclosing the area.</a:documentation>
+            <list>
+               <data type="token">
+                  <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+               </data>
+               <data type="token">
+                  <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+               </data>
+               <data type="token">
+                  <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+               </data>
+               <zeroOrMore>
+                  <data type="token">
+                     <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+                  </data>
+               </zeroOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgafacsimile">
+      <element name="facsimile">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a representation of some written source in the form of a set of images rather than as transcribed or encoded text. [11.1. Digital Facsimiles]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgafront"/>
+            </optional>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.graphicLike"/>
+                  <ref name="sgasurface"/>
+                  <ref name="sgasurfaceGrp"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <optional>
+               <ref name="sgaback"/>
+            </optional>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasourceDoc">
+      <element name="sourceDoc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a transcription or other representation of a single source document potentially forming part of a dossier génétique or collection of sources. [11.1. Digital Facsimiles 11.2.2. Embedded Transcription]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.global"/>
+               <ref name="sgamodel.graphicLike"/>
+               <ref name="sgasurface"/>
+               <ref name="sgasurfaceGrp"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurface">
+      <element name="surface">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines a written surface as a two-dimensional coordinate space, optionally grouping one or more graphic representations of that space, zones of interest within that space, and transcriptions of the writing within them. [11.1. Digital Facsimiles 11.2.2. Embedded Transcription]</a:documentation>
+         <group>
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.graphicLike"/>
+               </choice>
+            </zeroOrMore>
+            <zeroOrMore>
+               <group>
+                  <choice>
+                     <ref name="sgazone"/>
+                     <ref name="sgaline"/>
+                  </choice>
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+               </group>
+            </zeroOrMore>
+         </group>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="tei"
+             uri="http://www.tei-c.org/ns/1.0"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.rend"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.coordinated.attribute.start"/>
+         <ref name="sgaatt.coordinated.attribute.points"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <attribute name="xml:id">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) provides a unique identifier for the element bearing the attribute.</a:documentation>
+            <data type="ID"/>
+         </attribute>
+         <optional>
+            <attribute name="n">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) gives a number (or other label) for an element, which is not necessarily unique within the document.</a:documentation>
+               <data type="string"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="partOf">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(corresponds) Syntactic sugar attribute—should refer to the id of the sourceDoc element with which this surface should be associated</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <attribute name="ulx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <attribute name="uly">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <attribute name="lrx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <attribute name="lry">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute name="shelfmark" ns="http://mith.umd.edu/sc/ns1#">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="folio" ns="http://mith.umd.edu/sc/ns1#">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurfaceGrp">
+      <element name="surfaceGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines any kind of useful grouping of written surfaces, for example the recto and verso of a single leaf, which the encoder wishes to treat as a single unit. [11.1. Digital Facsimiles]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.global"/>
+               <ref name="sgasurface"/>
+               <ref name="sgasurfaceGrp"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgazone">
+      <element name="zone">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines any two-dimensional area within a surface element. [11.1. Digital Facsimiles 11.2.2. Embedded Transcription]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.graphicLike"/>
+               <ref name="sgamodel.milestoneLike"/>
+               <ref name="sgamodel.noteLike"/>
+               <ref name="sgamodel.global.edit"/>
+               <ref name="sgametamark"/>
+               <ref name="sgamodel.linePart"/>
+               <ref name="sgaalt"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.coordinated.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.written.attributes"/>
+         <attribute name="type">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>top</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Material that can appear at the top of a manuscript page—like headings or notes</a:documentation>
+               <value>left_margin</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Zone for marginal additions, deletions, and other modifications. More than one zone with this type may appear in a document if marginal zones are distinct interventions.</a:documentation>
+               <value>main</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The main block of text on a page</a:documentation>
+               <value>pagination</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">For segments of a page where page numbers have been added in one or more original hands; distinct from later additions by librarians/collectors</a:documentation>
+               <value>library</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A zone of writing which appears to have been added by librarians/collectors at a later date—often page numbers</a:documentation>
+               <value>sketch</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A zone identifying a sketch or doodle</a:documentation>
+               <value>calculation</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A zone identifying a written calculation</a:documentation>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="rotate"
+                       a:defaultValue="0">
+               <a:documentation>indicates the amount by which this zone has been rotated clockwise, with respect to the normal orientation of the parent surface element as implied by the dimensions given in the msDesc element or by the coordinates of the surface itself. The orientation is expressed in arc degrees.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddSpan">
+      <element name="addSpan">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(added span of text) marks the beginning of a longer sequence of text added by an author, scribe, annotator or corrector (see also add). [11.3.1.4. Additions and Deletions]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-addSpan-spanTo-constraint-assert-8">
+            <rule context="tei:addSpan">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@spanTo">The @spanTo attribute of <sch:name/> is required.</sch:assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-addSpan-spanTo_fr-constraint-assert-9">
+            <rule context="tei:addSpan">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@spanTo">L'attribut spanTo est requis.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadamage">
+      <element name="damage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an area of damage to the text witness. [11.3.3.1. Damage, Illegibility, and Supplied Text]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.damaged.attributes"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>inkblot</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>tear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>cut</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadamageSpan">
+      <element name="damageSpan">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(damaged span of text) marks the beginning of a longer sequence of text which is damaged in some way but still legible. [11.3.3.1. Damage, Illegibility, and Supplied Text]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-damageSpan-spanTo-constraint-assert-10">
+            <rule context="tei:damageSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">
+The @spanTo attribute of <name/> is required.</assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-damageSpan-spanTo_fr-constraint-assert-11">
+            <rule context="tei:damageSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">L'attribut spanTo est requis.</assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.damaged.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadelSpan">
+      <element name="delSpan">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deleted span of text) marks the beginning of a longer sequence of text deleted, marked as deleted, or otherwise signaled as superfluous or spurious by an author, scribe, annotator, or corrector. [11.3.1.4. Additions and Deletions]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-delSpan-spanTo-constraint-assert-12">
+            <rule context="tei:delSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">The @spanTo attribute of <name/> is required.</assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-delSpan-spanTo_fr-constraint-assert-13">
+            <rule context="tei:delSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">L'attribut spanTo est requis.</assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandNotes">
+      <element name="handNotes">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains one or more handNote elements documenting the different hands identified within the source texts. [11.3.2.1. Document Hands]</a:documentation>
+         <oneOrMore>
+            <ref name="sgahandNote"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandShift">
+      <element name="handShift">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">marks the beginning of a sequence of text written in a new hand, or the beginning of a scribal stint. [11.3.2.1. Document Hands]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attribute.scribe"/>
+         <ref name="sgaatt.handFeatures.attribute.scribeRef"/>
+         <ref name="sgaatt.handFeatures.attribute.script"/>
+         <ref name="sgaatt.handFeatures.attribute.scriptRef"/>
+         <ref name="sgaatt.handFeatures.attribute.scope"/>
+         <attribute name="medium">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>pen</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>pencil</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <attribute name="new">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>#pbs</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>#mws</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>#library</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarestore">
+      <element name="restore">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates restoration of text to an earlier state by cancellation of an editorial or authorial marking or instruction. [11.3.1.6. Cancellation of Deletions and Other Markings]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>stetdots</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>smear_strikethrough</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>underline</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaspace">
+      <element name="space">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of a significant space in the text. [11.5.1. Space]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.rend"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <optional>
+            <attribute name="resp">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsible party) (responsible party) indicates the individual responsible for identifying and measuring the space</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="dim">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(dimension) indicates whether the space is horizontal or vertical.</a:documentation>
+               <choice>
+                  <value>horizontal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the space is horizontal.</a:documentation>
+                  <value>vertical</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the space is vertical.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasubst">
+      <element name="subst">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution) groups one or more deletions with one or more additions when the combination is to be regarded as a single intervention in the text. [11.3.1.5. Substitutions]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgaadd"/>
+               <ref name="sgadel"/>
+               <ref name="sgamodel.milestoneLike"/>
+            </choice>
+         </oneOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-subst-substContents1-constraint-assert-14">
+            <rule context="tei:subst">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="child::tei:add and child::tei:del">
+                  <name/> must have at least one child add and at least one child del</assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.transcriptional.attribute.seq"/>
+         <ref name="sgaatt.editLike.attribute.evidence"/>
+         <ref name="sgaatt.editLike.attribute.instant"/>
+         <ref name="sgaatt.dimensions.attribute.unit"/>
+         <ref name="sgaatt.dimensions.attribute.quantity"/>
+         <ref name="sgaatt.dimensions.attribute.extent"/>
+         <ref name="sgaatt.dimensions.attribute.precision"/>
+         <ref name="sgaatt.dimensions.attribute.scope"/>
+         <ref name="sgaatt.ranging.attribute.atLeast"/>
+         <ref name="sgaatt.ranging.attribute.atMost"/>
+         <ref name="sgaatt.ranging.attribute.min"/>
+         <ref name="sgaatt.ranging.attribute.max"/>
+         <ref name="sgaatt.ranging.attribute.confidence"/>
+         <optional>
+            <attribute name="cause">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>clarify</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>fix</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="hand">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>#pbs</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>#mws</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>#library</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasubstJoin">
+      <element name="substJoin">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution join) identifies a series of possibly fragmented additions, deletions or other revisions on a manuscript that combine to make up a single intervention in the text [11.3.1.5. Substitutions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasecl">
+      <element name="secl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(secluded text) Secluded. Marks text present in the source which the editor believes to be genuine but out of its original place (which is unknown). [11.3.1.7. Text Omitted from or Supplied in the Transcription]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <optional>
+            <attribute name="reason">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">one or more words indicating why this text has been secluded, e.g. interpolated etc.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaline">
+      <element name="line">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the transcription of a topographic line in the source document [11.2.2. Embedded Transcription]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.global"/>
+               <ref name="sgamodel.segLike"/>
+               <ref name="sgamodel.hiLike"/>
+               <ref name="sgazone"/>
+               <ref name="sgaline"/>
+               <ref name="sgadel"/>
+               <ref name="sgaadd"/>
+               <ref name="sgaunclear"/>
+               <ref name="sgadamage"/>
+               <ref name="sgahandShift"/>
+               <ref name="sgamod"/>
+               <ref name="sgaretrace"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.coordinated.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <choice>
+                     <value>right</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>center</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>left</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+                  <data type="string">
+                     <param name="pattern">indent\d</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistTranspose">
+      <element name="listTranspose">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a list of transpositions, each of which is indicated at some point in a document typically by means of metamarks. [11.3.4.5. Transpositions]</a:documentation>
+         <oneOrMore>
+            <ref name="sgatranspose"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgametamark">
+      <element name="metamark">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains or describes any kind of graphic or written signal within a document the function of which is to determine how it should be read rather than forming part of the actual content of the document. [11.3.4.2. Metamarks]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+Suggested values include: 1] line; 2] short_line; 3] wavey_short_line; 4] left_bracket_short_line; 5] short_vertical_line; 6] top_left_bracket; 7] caret; 8] left_caret; 9] cross; 10] star</a:documentation>
+               <choice>
+                  <value>line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A line, often used to separate content.</a:documentation>
+                  <value>short_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A short line, similar to an underline, but often used to separate content, not for emphasis (in which case hi[@rend="underline"] is used</a:documentation>
+                  <value>wavey_short_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A wavey short line, similar to an underline, but often used to separate content, not for emphasis (in which case hi[@rend="underline"] is used</a:documentation>
+                  <value>left_bracket_short_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A line wrapping some text starting from the top left corner, then curving to underline the text. Often used to separate content.</a:documentation>
+                  <value>short_vertical_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A short vertical line, often used inline to separate words or to indicate insertion.</a:documentation>
+                  <value>top_left_bracket</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A corner bracket located in the top left of a word.</a:documentation>
+                  <value>caret</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A caret pointing upwards. This is often encoded literally in SGA for convenience. This value provides an alternative way of encoding it.</a:documentation>
+                  <value>left_caret</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A caret pointing left.</a:documentation>
+                  <value>cross</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A cross, often used for displacement. This is often encoded literally in SGA for convenience. This value provides an alternative way of encoding it.</a:documentation>
+                  <value>star</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A star or asterisk, often used for displacement. This is often encoded literally in SGA for convenience. This value provides an alternative way of encoding it.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="function">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>count</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>insert</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>separate</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>paragraph</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>displacement</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>transpose</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>sequence</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>alternate</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unclear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>math_operation</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Perform a mathematical operation (e.g. a sum). Usually rendered a as line</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies one or more elements to which the metamark applies.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamod">
+      <element name="mod">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">represents any kind of modification identified within a single document. [11.3.4.1. Generic Modification]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.inter"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-mod-modContents-constraint-rule-10">
+            <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="tei:mod">
+                                    <sch:report test="not(@spanTo) and not(tei:restore) and not(count(node()) gt 1)">The mod element is
+                                        intended to group a series of related changes to the
+                                        manuscript. Thus, mod must have more than one child
+                                        element. If only a single addition or deletion is being
+                                        encoded, mod is not required.</sch:report>
+                                </sch:rule>
+         </pattern>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.rendition.attribute.rend"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <optional>
+            <attribute name="xml:space">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>preserve</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>additions</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>deletions</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaretrace">
+      <element name="retrace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a sequence of writing which has been retraced, for example by over-inking, to clarify or fix it. [11.3.4.3. Fixation and Clarification]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatranspose">
+      <element name="transpose">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a single textual transposition as an ordered list of at least two pointers specifying the order in which the elements indicated should be re-combined. [11.3.4.5. Transpositions]</a:documentation>
+         <group>
+            <ref name="sgaptr"/>
+      
+            <oneOrMore>
+               <ref name="sgaptr"/>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgag">
+      <element name="g">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character or glyph) represents a glyph, or a non-standard character. [5. Characters, Glyphs, and Writing Modes]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="ref">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a description of the character or glyph intended.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgachar">
+      <element name="char">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character) provides descriptive information about a character. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgacharName"/>
+            </optional>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.descLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgacharProp"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamapping"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgafigure"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.graphicLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.noteLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacharName">
+      <element name="charName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character name) contains the name of a character, expressed following Unicode conventions. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacharProp">
+      <element name="charProp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character property) provides a name and value for some property of the parent character or glyph. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+            <choice>
+               <ref name="sgaunicodeName"/>
+               <ref name="sgalocalName"/>
+            </choice>
+            <ref name="sgavalue"/>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacharDecl">
+      <element name="charDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character declarations) provides information about nonstandard characters and glyphs. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgadesc"/>
+            </optional>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgachar"/>
+                  <ref name="sgaglyph"/>
+               </choice>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaglyph">
+      <element name="glyph">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character glyph) provides descriptive information about a character glyph. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgaglyphName"/>
+            </optional>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.descLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgacharProp"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamapping"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgafigure"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.graphicLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.noteLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaglyphName">
+      <element name="glyphName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character glyph name) contains the name of a glyph, expressed following Unicode conventions for character names. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocalName">
+      <element name="localName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(locally-defined property name) contains a locally defined name for some property. [5.2.1. Character Properties]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamapping">
+      <element name="mapping">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character mapping) contains one or more characters which are related to the parent character or glyph in some respect, as specified by the type attribute. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaunicodeName">
+      <element name="unicodeName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unicode property name) contains the name of a registered Unicode normative or informative property. [5.2.1. Character Properties]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="version">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the version number of the Unicode Standard in which this property name is defined.</a:documentation>
+               <data type="token">
+                  <param name="pattern">[\d]+(\.[\d]+){0,2}</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgavalue">
+      <element name="value">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single value for some property, attribute, or other analysis. [5.2.1. Character Properties]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.global.linking.attributes">
+      <ref name="sgaatt.global.linking.attribute.corresp"/>
+      <ref name="sgaatt.global.linking.attribute.next"/>
+      <ref name="sgaatt.global.linking.attribute.prev"/>
+   </define>
+   <define name="sgaatt.global.linking.attribute.corresp">
+      <optional>
+         <attribute name="corresp">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(corresponds) points to elements that correspond to the current element in some way.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.linking.attribute.next">
+      <optional>
+         <attribute name="next">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the next element of a virtual aggregate of which the current element is part.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.linking.attribute.prev">
+      <optional>
+         <attribute name="prev">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(previous) points to the previous element of a virtual aggregate of which the current element is part.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgalink">
+      <element name="link">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines an association or hypertextual link among elements or passages, of some type not more precisely specifiable by other elements. [16.1. Links]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-link-linkTargets3-constraint-assert-15">
+            <rule context="tei:link">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="contains(normalize-space(@target),' ')">You must supply at least two values for @target or  on <sch:name/>
+               </sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalinkGrp">
+      <element name="linkGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(link group) defines a collection of associations or hypertextual links. [16.1. Links]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgalink"/>
+               <ref name="sgaptr"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.group.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaanchor">
+      <element name="anchor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anchor point) attaches an identifier to a point within a text, whether or not it corresponds with a textual element. [8.4.2. Synchronization and Overlap 16.5. Correspondence and Alignment]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaseg">
+      <element name="seg">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(arbitrary segment) represents any segmentation of text below the chunk level. [16.3. Blocks, Segments, and Anchors 6.2. Components of the Verse Line 7.2.5. Speech Contents]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.segLike.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.written.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>alternative</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgajoin">
+      <element name="join">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a possibly fragmented segment of text, by pointing at the possibly discontiguous elements which compose it. [16.7. Aggregation]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-join-joinTargets3-constraint-assert-16">
+            <rule context="tei:join">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="contains(@target,' ')">
+You must supply at least two values for @target on <name/>
+               </assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="result">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the name of an element which this aggregation may be understood to represent.</a:documentation>
+               <data type="Name"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="scope"
+                       a:defaultValue="root">
+               <a:documentation>indicates whether the targets to be joined include the entire element indicated (the entire subtree including its root), or just the children of the target (the branches of the subtree).</a:documentation>
+               <choice>
+                  <value>root</value>
+                  <a:documentation>the rooted subtrees indicated by the target attribute are joined, each subtree become a child of the virtual element created by the join</a:documentation>
+                  <value>branches</value>
+                  <a:documentation>the children of the subtrees indicated by the target attribute become the children of the virtual element (i.e. the roots of the subtrees are discarded)</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgajoinGrp">
+      <element name="joinGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(join group) groups a collection of join elements and possibly pointers. [16.7. Aggregation]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.glossLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgajoin"/>
+                  <ref name="sgaptr"/>
+               </choice>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.group.attributes"/>
+         <optional>
+            <attribute name="result">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the default value for the result on each join included within the group.</a:documentation>
+               <data type="Name"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaalt">
+      <element name="alt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternation) identifies an alternation or a set of choices among elements or passages. [16.8. Alternation]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attribute.targetLang"/>
+         <ref name="sgaatt.pointing.attribute.evaluate"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the destination of the reference by supplying one or more URI References</a:documentation>
+               <list>
+                  <data type="anyURI"/>
+                  <data type="anyURI"/>
+                  <zeroOrMore>
+                     <data type="anyURI"/>
+                  </zeroOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="mode">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">states whether the alternations gathered in this collection are exclusive or inclusive.</a:documentation>
+               <choice>
+                  <value>excl</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(exclusive) indicates that the alternation is exclusive, i.e. that at most one of the alternatives occurs.</a:documentation>
+                  <value>incl</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(inclusive) indicates that the alternation is not exclusive, i.e. that one or more of the alternatives occur.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="weights">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If mode is excl, each weight states the probability that the corresponding alternative occurs. If mode is incl each weight states the probability that the corresponding alternative occurs given that at least one of the other alternatives occurs.</a:documentation>
+               <list>
+                  <data type="double"/>
+                  <data type="double"/>
+                  <zeroOrMore>
+                     <data type="double"/>
+                  </zeroOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafigure">
+      <element name="figure">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups elements representing or containing graphic information such as an illustration, formula, or figure. [14.4. Specific Elements for Graphic Images]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.headLike"/>
+               <ref name="sgamodel.common"/>
+               <ref name="sgafigDesc"/>
+               <ref name="sgamodel.graphicLike"/>
+               <ref name="sgamodel.global"/>
+               <ref name="sgamodel.divBottom"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafigDesc">
+      <element name="figDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of figure) contains a brief prose description of the appearance or content of a graphic figure, for use when documenting an image without displaying it. [14.4. Specific Elements for Graphic Images]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.patternReplacement.attributes">
+      <ref name="sgaatt.patternReplacement.attribute.matchPattern"/>
+      <ref name="sgaatt.patternReplacement.attribute.replacementPattern"/>
+   </define>
+   <define name="sgaatt.patternReplacement.attribute.matchPattern">
+      <attribute name="matchPattern">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a regular expression against which the values of other attributes can be matched.</a:documentation>
+         <data type="token"/>
+      </attribute>
+   </define>
+   <define name="sgaatt.patternReplacement.attribute.replacementPattern">
+      <attribute name="replacementPattern">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a replacement pattern, that is, the skeleton of a relative or absolute URI containing references to groups in the matchPattern which, once subpattern substitution has been performed, complete the URI.</a:documentation>
+         <text/>
+      </attribute>
+   </define>
+   <define name="sgateiHeader">
+      <element name="teiHeader">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI header) supplies descriptive and declarative metadata associated with a digital resource or set of resources. [2.1.1. The TEI Header and Its Components 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+            <ref name="sgafileDesc"/>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.teiHeaderPart"/>
+            </zeroOrMore>
+      
+      
+            <optional>
+               <ref name="sgarevisionDesc"/>
+            </optional>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafileDesc">
+      <element name="fileDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file description) contains a full bibliographic description of an electronic file. [2.2. The File Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <group>
+            <group>
+               <ref name="sgatitleStmt"/>
+        
+               <optional>
+                  <ref name="sgaeditionStmt"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgaextent"/>
+               </optional>
+        
+               <ref name="sgapublicationStmt"/>
+        
+               <optional>
+                  <ref name="sgaseriesStmt"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sganotesStmt"/>
+               </optional>
+        
+            </group>
+      
+            <oneOrMore>
+               <ref name="sgasourceDesc"/>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitleStmt">
+      <element name="titleStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title statement) groups information about the title of a work and those responsible for its content. [2.2.1. The Title Statement 2.2. The File Description]</a:documentation>
+         <group>
+      
+            <oneOrMore>
+               <ref name="sgatitle"/>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.respLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasponsor">
+      <element name="sponsor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the name of a sponsoring organization or institution. [2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafunder">
+      <element name="funder">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(funding body) specifies the name of an individual, institution, or organization responsible for the funding of a project or text. [2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprincipal">
+      <element name="principal">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(principal researcher) supplies the name of the principal researcher responsible for the creation of an electronic text. [2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaeditionStmt">
+      <element name="editionStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition statement) groups information relating to one edition of a text. [2.2.2. The Edition Statement 2.2. The File Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+               <ref name="sgaedition"/>
+        
+               <zeroOrMore>
+                  <ref name="sgamodel.respLike"/>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaedition">
+      <element name="edition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the particularities of one edition of a text. [2.2.2. The Edition Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaextent">
+      <element name="extent">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the approximate size of a text stored on some carrier medium or of some other object, digital or non-digital, specified in any convenient units. [2.2.3. Type and Extent of File 2.2. The File Description 3.11.2.4. Imprint, Size of a Document, and Reprint Information 10.7.1. Object Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapublicationStmt">
+      <element name="publicationStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication statement) groups information concerning the publication or distribution of an electronic or other text. [2.2.4. Publication, Distribution, Licensing, etc. 2.2. The File Description]</a:documentation>
+         <choice>
+      
+	           <oneOrMore>
+               <group>
+	  
+	                 <ref name="sgamodel.publicationStmtPart.agency"/>
+	  
+	  
+	                 <zeroOrMore>
+                     <ref name="sgamodel.publicationStmtPart.detail"/>
+                  </zeroOrMore>
+	  
+	              </group>
+            </oneOrMore>
+      
+      
+	           <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadistributor">
+      <element name="distributor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the name of a person or other agency responsible for the distribution of a text. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaauthority">
+      <element name="authority">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(release authority) supplies the name of a person or other agency responsible for making a work available, other than a publisher or distributor. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaidno">
+      <element name="idno">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) supplies any form of identifier used to identify some object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized way. [2.2.4. Publication, Distribution, Licensing, etc. 2.2.5. The Series Statement 3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgaidno"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">categorizes the identifier, for example as an ISBN, Social Security number, etc.
+Suggested values include: 1] ISBN; 2] ISSN; 3] DOI; 4] URI; 5] VIAF; 6] ESTC; 7] OCLC</a:documentation>
+               <choice>
+                  <value>ISBN</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">International Standard Book Number: a 13- or (if assigned prior to 2007) 10-digit identifying number assigned by the publishing industry to a published book or similar item, registered with the International ISBN Agency.</a:documentation>
+                  <value>ISSN</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">International Standard Serial Number: an eight-digit number to uniquely identify a serial publication.</a:documentation>
+                  <value>DOI</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Digital Object Identifier: a unique string of letters and numbers assigned to an electronic document.</a:documentation>
+                  <value>URI</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Uniform Resource Identifier: a string of characters to uniquely identify a resource which usually contains indication of the means of accessing that resource, the name of its host, and its filepath.</a:documentation>
+                  <value>VIAF</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A data number in the Virtual Internet Authority File assigned to link different names in catalogs around the world for the same entity.</a:documentation>
+                  <value>ESTC</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">English Short-Title Catalogue number: an identifying number assigned to a document in English printed in the British Isles or North America before 1801.</a:documentation>
+                  <value>OCLC</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">union catalog number in WorldCat representing a resource held by one or more of the member libraries in the global cooperative Online Computer Library Center.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaavailability">
+      <element name="availability">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies information about the availability of a text, for example any restrictions on its use or distribution, its copyright status, any licence applying to it, etc. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.availabilityPart"/>
+               <ref name="sgamodel.pLike"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="status"
+                       a:defaultValue="unknown">
+               <a:documentation>supplies a code identifying the current availability of the text.</a:documentation>
+               <choice>
+                  <value>free</value>
+                  <a:documentation>the text is freely available.</a:documentation>
+                  <value>unknown</value>
+                  <a:documentation>the status of the text is unknown.</a:documentation>
+                  <value>restricted</value>
+                  <a:documentation>the text is not freely available.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalicence">
+      <element name="licence">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a licence or other legal agreement applicable to the text. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaseriesStmt">
+      <element name="seriesStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series statement) groups information about the series, if any, to which a publication belongs. [2.2.5. The Series Statement 2.2. The File Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <oneOrMore>
+                  <ref name="sgatitle"/>
+               </oneOrMore>
+        
+        
+               <zeroOrMore>
+                  <choice>
+            
+                     <ref name="sgarespStmt"/>
+                  </choice>
+               </zeroOrMore>
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgaidno"/>
+            
+                  </choice>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganotesStmt">
+      <element name="notesStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(notes statement) collects together any notes providing information about a text additional to that recorded in other parts of the bibliographic description. [2.2.6. The Notes Statement 2.2. The File Description]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.noteLike"/>
+               <ref name="sgarelatedItem"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasourceDesc">
+      <element name="sourceDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source description) describes the source from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as "born digital" for a text which has no previous existence. [2.2.7. The Source Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgamodel.sourceDescPart"/>
+                  <ref name="sgamodel.listLike"/>
+               </choice>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabiblFull">
+      <element name="biblFull">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(fully-structured bibliographic citation) contains a fully-structured bibliographic citation, in which all components of the TEI file description are present. [3.11.1. Methods of Encoding Bibliographic References and Lists of References 2.2. The File Description 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
+         <choice>
+            <group>
+               <group>
+                  <ref name="sgatitleStmt"/>
+                  <optional>
+                     <ref name="sgaeditionStmt"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaextent"/>
+                  </optional>
+                  <ref name="sgapublicationStmt"/>
+                  <optional>
+                     <ref name="sgaseriesStmt"/>
+                  </optional>
+                  <optional>
+                     <ref name="sganotesStmt"/>
+                  </optional>
+               </group>
+               <zeroOrMore>
+                  <ref name="sgasourceDesc"/>
+               </zeroOrMore>
+            </group>
+            <group>
+               <ref name="sgafileDesc"/>
+               <ref name="sgaprofileDesc"/>
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaencodingDesc">
+      <element name="encodingDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(encoding description) documents the relationship between an electronic text and the source or sources from which it was derived. [2.3. The Encoding Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.encodingDescPart"/>
+               <ref name="sgamodel.pLike"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaschemaRef">
+      <element name="schemaRef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(schema reference) describes or points to a related customization or schema file [2.3.9. The Schema Specification]</a:documentation>
+         <optional>
+            <ref name="sgamodel.descLike"/>
+         </optional>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.resourced.attributes"/>
+         <optional>
+            <attribute name="key">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the identifier used for the customization or schema</a:documentation>
+               <data type="NCName"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprojectDesc">
+      <element name="projectDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(project description) describes in detail the aim or purpose for which an electronic file was encoded, together with any other relevant information concerning the process by which it was assembled or collected. [2.3.1. The Project Description 2.3. The Encoding Description 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasamplingDecl">
+      <element name="samplingDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sampling declaration) contains a prose description of the rationale and methods used in sampling texts in the creation of a corpus or collection. [2.3.2. The Sampling Declaration 2.3. The Encoding Description 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaeditorialDecl">
+      <element name="editorialDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(editorial practice declaration) provides details of editorial principles and practices applied during the encoding of a text. [2.3.3. The Editorial Practices Declaration 2.3. The Encoding Description 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgamodel.editorialDeclPart"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrection">
+      <element name="correction">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correction principles) states how and under what circumstances corrections have been made in the text. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="status"
+                       a:defaultValue="unknown">
+               <a:documentation>indicates the degree of correction applied to the text.</a:documentation>
+               <choice>
+                  <value>high</value>
+                  <a:documentation>the text has been thoroughly checked and proofread.</a:documentation>
+                  <value>medium</value>
+                  <a:documentation>the text has been checked at least once.</a:documentation>
+                  <value>low</value>
+                  <a:documentation>the text has not been checked.</a:documentation>
+                  <value>unknown</value>
+                  <a:documentation>the correction status of the text is unknown.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="method"
+                       a:defaultValue="silent">
+               <a:documentation>indicates the method adopted to indicate corrections within the text.</a:documentation>
+               <choice>
+                  <value>silent</value>
+                  <a:documentation>corrections have been made silently</a:documentation>
+                  <value>markup</value>
+                  <a:documentation>corrections have been represented using markup</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganormalization">
+      <element name="normalization">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the extent of normalization or regularization of the original source carried out in converting it to electronic form. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="method"
+                       a:defaultValue="silent">
+               <a:documentation>indicates the method adopted to indicate normalizations within the text.</a:documentation>
+               <choice>
+                  <value>silent</value>
+                  <a:documentation>normalization made silently</a:documentation>
+                  <value>markup</value>
+                  <a:documentation>normalization represented using markup</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaquotation">
+      <element name="quotation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies editorial practice adopted with respect to quotation marks in the original. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-quotation-quotationContents-constraint-report-10">
+            <rule context="tei:quotation">
+               <report xmlns:xi="http://www.w3.org/2001/XInclude"
+                       xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="not(@marks) and not (tei:p)">
+On <name/>, either the @marks attribute should be used, or a paragraph of description provided</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute name="marks">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(quotation marks) indicates whether or not quotation marks have been retained as content within the text.</a:documentation>
+               <choice>
+                  <value>none</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">no quotation marks have been retained</a:documentation>
+                  <value>some</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">some quotation marks have been retained</a:documentation>
+                  <value>all</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">all quotation marks have been retained</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahyphenation">
+      <element name="hyphenation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">summarizes the way in which hyphenation in a source text has been treated in an encoded version of it. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="eol"
+                       a:defaultValue="some">
+               <a:documentation>(end-of-line) indicates whether or not end-of-line hyphenation has been retained in a text.</a:documentation>
+               <choice>
+                  <value>all</value>
+                  <a:documentation>all end-of-line hyphenation has been retained, even though the lineation of the original may not have been.</a:documentation>
+                  <value>some</value>
+                  <a:documentation>end-of-line hyphenation has been retained in some cases.</a:documentation>
+                  <value>hard</value>
+                  <a:documentation>all soft end-of-line hyphenation has been removed: any remaining end-of-line hyphenation should be retained.</a:documentation>
+                  <value>none</value>
+                  <a:documentation>all end-of-line hyphenation has been removed: any remaining hyphenation occurred within the line.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasegmentation">
+      <element name="segmentation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the principles according to which the text has been segmented, for example into sentences, tone-units, graphemic strata, etc. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastdVals">
+      <element name="stdVals">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(standard values) specifies the format used when standardized date or number values are supplied. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgainterpretation">
+      <element name="interpretation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the scope of any analytic or interpretive information added to the text in addition to the transcription. [2.3.3. The Editorial Practices Declaration]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapunctuation">
+      <element name="punctuation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies editorial practice adopted with respect to punctuation marks in the original. [2.3.3. The Editorial Practices Declaration 3.2. Treatment of Punctuation]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="marks">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether or not punctation marks have been retained as content within the text.</a:documentation>
+               <choice>
+                  <value>none</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">no punctuation marks have been retained</a:documentation>
+                  <value>some</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">some punctuation marks have been retained</a:documentation>
+                  <value>all</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">all punctuation marks have been retained</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="placement">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether punctation marks have been captured inside or outside of an adjacent element.</a:documentation>
+               <choice>
+                  <value>internal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">punctuation marks are captured inside adjacent elements</a:documentation>
+                  <value>external</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">punctuation marks are captured outside adjacent elements</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatagsDecl">
+      <element name="tagsDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(tagging declaration) provides detailed information about the tagging applied to a document. [2.3.4. The Tagging Declaration 2.3. The Encoding Description]</a:documentation>
+         <group>      
+            <zeroOrMore>
+               <ref name="sgarendition"/>
+            </zeroOrMore>
+            <zeroOrMore>
+               <ref name="sganamespace"/>
+            </zeroOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="partial">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether the element types listed exhaustively include all those found within text, or represent only a subset.</a:documentation>
+               <data type="boolean"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatagUsage">
+      <element name="tagUsage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">documents the usage of a specific element within a specified document. [2.3.4. The Tagging Declaration]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="gi">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(generic identifier) specifies the name (generic identifier) of the element indicated by the tag, within the namespace indicated by the parent namespace element.</a:documentation>
+            <data type="Name"/>
+         </attribute>
+         <optional>
+            <attribute name="occurs">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of occurrences of this element within the text.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="withId">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(with unique identifier) specifies the number of occurrences of this element within the text which bear a distinct value for the global xml:id attribute.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganamespace">
+      <element name="namespace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the formal name of the namespace to which the elements documented by its children belong. [2.3.4. The Tagging Declaration]</a:documentation>
+         <oneOrMore>
+            <ref name="sgatagUsage"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="name">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the full formal name of the namespace concerned.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarendition">
+      <element name="rendition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies information about the rendition or appearance of one or more elements in the source text. [2.3.4. The Tagging Declaration]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.styleDef.attributes"/>
+         <optional>
+            <attribute name="scope">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where CSS is used, provides a way of defining pseudo-elements, that is, styling rules applicable to specific sub-portions of an element.
+Sample values include: 1] first-line; 2] first-letter; 3] before; 4] after</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="selector">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a selector or series of selectors specifying the elements to which the contained style description applies, expressed in the language specified in the scheme attribute.</a:documentation>
+               <data type="string"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastyleDefDecl">
+      <element name="styleDefDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(style definition language declaration) specifies the name of the formal language in which style or renditional information is supplied elsewhere in the document. The specific version of the scheme may also be supplied. [2.3.5. The Default Style Definition Language Declaration]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.styleDef.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarefsDecl">
+      <element name="refsDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(references declaration) specifies how canonical references are constructed for this text. [2.3.6.3. Milestone Method 2.3. The Encoding Description 2.3.6. The Reference System Declaration]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgacRefPattern"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgarefState"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacRefPattern">
+      <element name="cRefPattern">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(canonical reference pattern) specifies an expression and replacement pattern for transforming a canonical reference into a URI. [2.3.6.3. Milestone Method 2.3.6. The Reference System Declaration 2.3.6.2. Search-and-Replace Method]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.patternReplacement.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprefixDef">
+      <element name="prefixDef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(prefix definition) defines a prefixing scheme used in data.pointer values, showing how abbreviated URIs using the scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.patternReplacement.attributes"/>
+         <attribute name="ident">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a name which functions as the prefix for an abbreviated pointing scheme such as a private URI scheme. The prefix constitutes the text preceding the first colon.</a:documentation>
+            <data type="token">
+               <param name="pattern">[a-z][a-z0-9\+\.\-]*</param>
+            </data>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistPrefixDef">
+      <element name="listPrefixDef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of prefix definitions) contains a list of definitions of prefixing schemes used in data.pointer values, showing how abbreviated URIs using each scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgaprefixDef"/>
+               <ref name="sgalistPrefixDef"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarefState">
+      <element name="refState">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference state) specifies one component of a canonical reference defined by the milestone method. [2.3.6.3. Milestone Method 2.3.6. The Reference System Declaration]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.milestoneUnit.attributes"/>
+         <ref name="sgaatt.edition.attributes"/>
+         <optional>
+            <attribute name="length">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the fixed length of the reference component.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="delim">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(delimiter) supplies a delimiting string following the reference component.</a:documentation>
+               <data type="string"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaclassDecl">
+      <element name="classDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(classification declarations) contains one or more taxonomies defining any classificatory codes used elsewhere in the text. [2.3.7. The Classification Declaration 2.3. The Encoding Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgataxonomy"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgataxonomy">
+      <element name="taxonomy">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines a typology either implicitly, by means of a bibliographic citation, or explicitly by a structured taxonomy. [2.3.7. The Classification Declaration]</a:documentation>
+         <choice>
+      
+      
+      
+      
+      
+      
+      
+      
+            <choice>
+	              <oneOrMore>
+                  <choice>
+                     <ref name="sgacategory"/>
+                     <ref name="sgataxonomy"/>
+	                 </choice>
+               </oneOrMore>
+	              <group>
+	                 <oneOrMore>
+                     <choice>
+                        <ref name="sgamodel.glossLike"/>
+                        <ref name="sgamodel.descLike"/>
+	                    </choice>
+                  </oneOrMore>
+	                 <zeroOrMore>
+                     <choice>
+                        <ref name="sgacategory"/>
+                        <ref name="sgataxonomy"/>
+	                    </choice>
+                  </zeroOrMore>
+	              </group>
+            </choice>
+            <group>
+               <ref name="sgamodel.biblLike"/>
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgacategory"/>
+                     <ref name="sgataxonomy"/>
+                  </choice>
+               </zeroOrMore>
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacategory">
+      <element name="category">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an individual descriptive category, possibly nested within a superordinate category, within a user-defined taxonomy. [2.3.7. The Classification Declaration]</a:documentation>
+         <group>
+            <choice>
+        
+               <oneOrMore>
+                  <ref name="sgacatDesc"/>
+               </oneOrMore>
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.descLike"/>
+                     <ref name="sgamodel.glossLike"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </choice>
+      
+            <zeroOrMore>
+               <ref name="sgacategory"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacatDesc">
+      <element name="catDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(category description) describes some category within a taxonomy or text typology, either in the form of a brief prose description or in terms of the situational parameters used by the TEI formal textDesc. [2.3.7. The Classification Declaration]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.limitedPhrase"/>
+               <ref name="sgamodel.catDescPart"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageoDecl">
+      <element name="geoDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographic coordinates declaration) documents the notation and the datum used for geographic coordinates expressed as content of the geo element elsewhere within the document. [2.3.8. The Geographic Coordinates Declaration]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="datum"
+                       a:defaultValue="WGS84">
+               <a:documentation>supplies a commonly used code name for the datum employed.
+Suggested values include: 1] WGS84(World Geodetic System) ; 2] MGRS(Military Grid Reference System) ; 3] OSGB36(ordnance survey great britain) ; 4] ED50(European Datum coordinate system) </a:documentation>
+               <choice>
+                  <value>WGS84</value>
+                  <a:documentation>(World Geodetic System) a pair of numbers to be interpreted as latitude followed by longitude according to the World Geodetic System.</a:documentation>
+                  <value>MGRS</value>
+                  <a:documentation>(Military Grid Reference System) the values supplied are geospatial entity object codes, based on</a:documentation>
+                  <value>OSGB36</value>
+                  <a:documentation>(ordnance survey great britain) the value supplied is to be interpreted as a British National Grid Reference.</a:documentation>
+                  <value>ED50</value>
+                  <a:documentation>(European Datum coordinate system) the value supplied is to be interpreted as latitude followed by longitude according to the European Datum coordinate system.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaappInfo">
+      <element name="appInfo">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(application information) records information about an application which has edited the TEI file. [2.3.10. The Application Information Element]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.applicationLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaapplication">
+      <element name="application">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about an application which has acted upon the document. [2.3.10. The Application Information Element]</a:documentation>
+         <group>
+      
+            <oneOrMore>
+               <ref name="sgamodel.labelLike"/>
+            </oneOrMore>
+      
+            <choice>
+        
+               <zeroOrMore>
+                  <ref name="sgamodel.ptrLike"/>
+               </zeroOrMore>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </zeroOrMore>
+        
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <attribute name="ident">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies an identifier for the application, independent of its version number or display name.</a:documentation>
+            <data type="Name"/>
+         </attribute>
+         <attribute name="version">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a version number for the application, independent of its identifier or display name.</a:documentation>
+            <data type="token">
+               <param name="pattern">[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}</param>
+            </data>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprofileDesc">
+      <element name="profileDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text-profile description) provides a detailed description of non-bibliographic aspects of a text, specifically the languages and sublanguages used, the situation in which it was produced, the participants and their setting. [2.4. The Profile Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.profileDescPart"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandNote">
+      <element name="handNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(note on hand) describes a particular style or hand distinguished within a manuscript. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaabstract">
+      <element name="abstract">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a summary or formal abstract prefixed to an existing source document by the encoder. [2.4.4. Abstracts]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgamodel.listLike"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacreation">
+      <element name="creation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the creation of a text. [2.4.1. Creation 2.4. The Profile Description]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.limitedPhrase"/>
+               <ref name="sgalistChange"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalangUsage">
+      <element name="langUsage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language usage) describes the languages, sublanguages, registers, dialects, etc. represented within a text. [2.4.2. Language Usage 2.4. The Profile Description 15.3.2. Declarable Elements]</a:documentation>
+         <choice>
+        
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+         
+          
+            <oneOrMore>
+               <ref name="sgalanguage"/>
+            </oneOrMore>
+        
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalanguage">
+      <element name="language">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes a single language or sublanguage used within a text. [2.4.2. Language Usage]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="ident">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) Supplies a language code constructed as defined in BCP 47 which is used to identify the language documented by this element, and which is referenced by the global xml:lang attribute.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute name="usage">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the approximate percentage (by volume) of the text which uses this language.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatextClass">
+      <element name="textClass">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text classification) groups information which describes the nature or topic of a text in terms of a standard classification scheme, thesaurus, etc. [2.4.3. The Text Classification]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgaclassCode"/>
+               <ref name="sgacatRef"/>
+               <ref name="sgakeywords"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgakeywords">
+      <element name="keywords">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a list of keywords or phrases identifying the topic or nature of a text. [2.4.3. The Text Classification]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgaterm"/>
+            </oneOrMore>
+      
+            <ref name="sgalist"/>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the controlled vocabulary within which the set of keywords concerned is defined, for example by a taxonomy element, or by some other resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaclassCode">
+      <element name="classCode">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(classification code) contains the classification code used for this text in some standard classification system. [2.4.3. The Text Classification]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="scheme">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the classification system in use, as defined by, e.g. a taxonomy element, or some other resource.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacatRef">
+      <element name="catRef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(category reference) specifies one or more defined categories within some taxonomy or text typology. [2.4.3. The Text Classification]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the classification scheme within which the set of categories concerned is defined, for example by a taxonomy element, or by some other resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacalendarDesc">
+      <element name="calendarDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(calendar description) contains a description of the calendar system used in any dating expression found in the text. [2.4. The Profile Description 2.4.5. Calendar Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgacalendar"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacalendar">
+      <element name="calendar">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a calendar or dating system used in a dating formula in the text. [2.4.5. Calendar Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrespDesc">
+      <element name="correspDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence
+    description) contains a description of the actions related to one act of correspondence. [2.4.6. Correspondence Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.correspDescPart"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrespAction">
+      <element name="correspAction">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence action) contains a structured description of the place, the name of a person/organization and the date related to the sending/receiving of a message or any other action related to the correspondence. [2.4.6. Correspondence Description]</a:documentation>
+         <choice>
+            <oneOrMore>
+               <ref name="sgamodel.correspActionPart"/>
+            </oneOrMore>
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the nature of the action.
+Suggested values include: 1] sent; 2] received; 3] transmitted; 4] redirected; 5] forwarded</a:documentation>
+               <choice>
+                  <value>sent</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the sending or dispatch of a message.</a:documentation>
+                  <value>received</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the receipt of a message.</a:documentation>
+                  <value>transmitted</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the transmission of a message, i.e. between the dispatch and the next receipt, redirect or forwarding.</a:documentation>
+                  <value>redirected</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the redirection of an unread message.</a:documentation>
+                  <value>forwarded</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the forwarding of a message.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrespContext">
+      <element name="correspContext">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence context) provides references to preceding or following correspondence related to this piece of correspondence. [2.4.6. Correspondence Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.correspContextPart"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaxenoData">
+      <element name="xenoData">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]</a:documentation>
+         <choice>
+            <text/>
+            <ref name="anyElement-xenoData"/>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarevisionDesc">
+      <element name="revisionDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(revision description) summarizes the revision history for a file. [2.6. The Revision Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <choice>
+            <ref name="sgalist"/>
+            <ref name="sgalistChange"/>
+      
+            <oneOrMore>
+               <ref name="sgachange"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgachange">
+      <element name="change">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">documents a change or set of changes made during the production of a source document, or during the revision of an electronic file. [2.6. The Revision Description 2.4.1. Creation 11.7. Identifying Changes and Revisions]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.ascribed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to one or more elements that belong to this change.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgascriptNote">
+      <element name="scriptNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a particular script distinguished within the description of a manuscript or similar resource. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistChange">
+      <element name="listChange">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups a number of change descriptions associated with either the creation of a source text or the revision of an encoded text. [2.6. The Revision Description 11.7. Identifying Changes and Revisions]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgalistChange"/>
+               <ref name="sgachange"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="ordered"
+                       a:defaultValue="true">
+               <a:documentation>indicates whether the ordering of its child change elements is to be considered significant or not</a:documentation>
+               <data type="boolean"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaTEI">
+      <element name="TEI">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI document) contains a single TEI-conformant document, combining a single TEI header with one or more members of the model.resourceLike class. Multiple TEI elements may be combined to form a teiCorpus element. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+            <ref name="sgateiHeader"/>
+            <oneOrMore>
+               <ref name="sgamodel.resourceLike"/>
+            </oneOrMore>
+         </group>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="tei"
+             uri="http://www.tei-c.org/ns/1.0"/>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="xs"
+             uri="http://www.w3.org/2001/XMLSchema"/>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="rng"
+             uri="http://relaxng.org/ns/structure/1.0"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="version">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the major version number of the TEI Guidelines against which this document is valid.</a:documentation>
+               <data type="token">
+                  <param name="pattern">[\d]+(\.[\d]+){0,2}</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatext">
+      <element name="text">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single text of any kind, whether unitary or composite, for example a poem or drama, a collection of essays, a novel, a dictionary, or a corpus sample. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgafront"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+            <choice>
+               <ref name="sgabody"/>
+               <ref name="sgagroup"/>
+            </choice>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgaback"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabody">
+      <element name="body">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text body) contains the whole body of a single unitary text, excluding any front or back matter. [4. Default Text Structure]</a:documentation>
+         <group>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+      
+      
+            <optional>
+               <group>
+          
+                  <ref name="sgamodel.divTop"/>
+          
+          
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.global"/>
+                        <ref name="sgamodel.divTop"/>
+                     </choice>
+                  </zeroOrMore>
+          
+               </group>
+            </optional>
+      
+      
+      
+            <optional>
+               <group>
+          
+                  <ref name="sgamodel.divGenLike"/>
+          
+          
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.global"/>
+                        <ref name="sgamodel.divGenLike"/>
+                     </choice>
+                  </zeroOrMore>
+          
+               </group>
+            </optional>
+      
+      
+        
+            <choice>
+          
+          
+               <oneOrMore>
+                  <group>
+              
+                     <ref name="sgamodel.divLike"/>
+              
+              
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.global"/>
+                           <ref name="sgamodel.divGenLike"/>
+                        </choice>
+                     </zeroOrMore>
+              
+                  </group>
+               </oneOrMore>
+          
+          
+          
+               <oneOrMore>
+                  <group>
+              
+                     <ref name="sgamodel.div1Like"/>
+              
+              
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.global"/>
+                           <ref name="sgamodel.divGenLike"/>
+                        </choice>
+                     </zeroOrMore>
+              
+                  </group>
+               </oneOrMore>
+          
+          
+               <group>
+                  <oneOrMore>
+                     <group>
+              
+                        <ref name="sgamodel.common"/>
+              
+              
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+              
+                     </group>
+                  </oneOrMore>
+            
+                  <optional>
+                     <choice>
+                
+                
+                        <oneOrMore>
+                           <group>
+                    
+                              <ref name="sgamodel.divLike"/>
+                    
+                    
+                              <zeroOrMore>
+                                 <choice>
+                                    <ref name="sgamodel.global"/>
+                                    <ref name="sgamodel.divGenLike"/>
+                                 </choice>
+                              </zeroOrMore>
+                    
+                           </group>
+                        </oneOrMore>
+                
+                
+                
+                        <oneOrMore>
+                           <group>
+                    
+                              <ref name="sgamodel.div1Like"/>
+                    
+                    
+                              <zeroOrMore>
+                                 <choice>
+                                    <ref name="sgamodel.global"/>
+                                    <ref name="sgamodel.divGenLike"/>
+                                 </choice>
+                              </zeroOrMore>
+                    
+                           </group>
+                        </oneOrMore>
+                
+                     </choice>
+                  </optional>
+            
+               </group>
+            </choice>
+        
+      
+      
+      
+            <zeroOrMore>
+               <group>
+          
+                  <ref name="sgamodel.divBottom"/>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+          
+               </group>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagroup">
+      <element name="group">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the body of a composite text, grouping together a sequence of distinct texts (or groups of such texts) which are regarded as a unit for some purpose, for example the collected works of an author, a sequence of prose essays, etc. [4. Default Text Structure 4.3.1. Grouped Texts 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <group>
+               <choice>
+                  <ref name="sgatext"/>
+                  <ref name="sgagroup"/>
+               </choice>
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgatext"/>
+                     <ref name="sgagroup"/>
+                     <ref name="sgamodel.global"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.divBottom"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafloatingText">
+      <element name="floatingText">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single text of any kind, whether unitary or composite, which interrupts the text containing it at any point and after which the surrounding text resumes. [4.3.2. Floating Texts]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgafront"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+            <choice>
+               <ref name="sgabody"/>
+               <ref name="sgagroup"/>
+            </choice>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgaback"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv">
+      <element name="div">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text division) contains a subdivision of the front, body, or back of a text. [4.1. Divisions of the Body]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+          
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+          
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.divLike"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+              
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+              
+                        </group>
+                     </oneOrMore>
+          
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.divLike"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-div-abstractModel-structure-l-constraint-report-11">
+            <rule context="tei:div">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="ancestor::tei:l">
+        Abstract model violation: Lines may not contain higher-level structural elements such as div.
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-div-abstractModel-structure-p-constraint-report-12">
+            <rule context="tei:div">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="ancestor::tei:p or ancestor::tei:ab and not(ancestor::tei:floatingText)">
+        Abstract model violation: p and ab may not contain higher-level structural elements such as div.
+      </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv1">
+      <element name="div1">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-1 text division) contains a first-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div2Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div2Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv2">
+      <element name="div2">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-2 text division) contains a second-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div3Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div3Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv3">
+      <element name="div3">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-3 text division) contains a third-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div4Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div4Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv4">
+      <element name="div4">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-4 text division) contains a fourth-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div5Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div5Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv5">
+      <element name="div5">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-5 text division) contains a fifth-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div6Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div6Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv6">
+      <element name="div6">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-6 text division) contains a sixth-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div7Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div7Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv7">
+      <element name="div7">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-7 text division) contains the smallest possible subdivision of the front, body or back of a text, larger than a paragraph. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <oneOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.common"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </oneOrMore>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatrailer">
+      <element name="trailer">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a closing title or footer appearing at the end of a division of a text. [4.2.4. Content of Textual Divisions 4.2. Elements Common to All Divisions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+	              <text/>
+	
+	              <ref name="sgamodel.gLike"/>
+	              <ref name="sgamodel.phrase"/>
+	              <ref name="sgamodel.inter"/>
+	              <ref name="sgamodel.lLike"/>
+	              <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabyline">
+      <element name="byline">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the primary statement of responsibility given for a work on its title page or at the head or end of the work. [4.2.2. Openers and Closers 4.5. Front Matter]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgadocAuthor"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadateline">
+      <element name="dateline">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a brief description of the place, date, time, etc. of production of a letter, newspaper story, or other work, prefixed or suffixed to it as a kind of heading or trailer. [4.2.2. Openers and Closers]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+               <ref name="sgadocDate"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaargument">
+      <element name="argument">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a formal list or prose description of the topics addressed by a subdivision of a text. [4.2. Elements Common to All Divisions 4.6. Title Pages]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.headLike"/>
+               </choice>
+            </zeroOrMore>
+      
+            <oneOrMore>
+               <group>
+        
+                  <ref name="sgamodel.common"/>
+        
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </oneOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaepigraph">
+      <element name="epigraph">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a quotation, anonymous or attributed, appearing at the start or end of a section or on a title page. [4.2.3. Arguments, Epigraphs, and Postscripts 4.2. Elements Common to All Divisions 4.6. Title Pages]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.common"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaopener">
+      <element name="opener">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups together dateline, byline, salutation, and similar phrases appearing as a preliminary group at the start of a division, especially of a letter. [4.2. Elements Common to All Divisions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+        
+               <ref name="sgaargument"/>
+               <ref name="sgabyline"/>
+               <ref name="sgadateline"/>
+               <ref name="sgaepigraph"/>
+               <ref name="sgasalute"/>
+               <ref name="sgasigned"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacloser">
+      <element name="closer">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups together salutations, datelines, and similar phrases appearing as a final group at the end of a division, especially of a letter. [4.2.2. Openers and Closers 4.2. Elements Common to All Divisions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgasigned"/>
+               <ref name="sgadateline"/>
+               <ref name="sgasalute"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasalute">
+      <element name="salute">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(salutation) contains a salutation or greeting prefixed to a foreword, dedicatory epistle, or other division of a text, or the salutation in the closing of a letter, preface, etc. [4.2.2. Openers and Closers]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasigned">
+      <element name="signed">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(signature) contains the closing salutation, etc., appended to a foreword, dedicatory epistle, or other division of a text. [4.2.2. Openers and Closers]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapostscript">
+      <element name="postscript">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a postscript, e.g. to a letter. [4.2. Elements Common to All Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.divTopPart"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <ref name="sgamodel.common"/>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.common"/>
+               </choice>
+            </zeroOrMore>
+      
+            <zeroOrMore>
+               <group>
+        
+                  <ref name="sgamodel.divBottomPart"/>
+        
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </zeroOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitlePage">
+      <element name="titlePage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title page) contains the title page of a text, appearing within the front or back matter. [4.6. Title Pages]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+      
+            <ref name="sgamodel.titlepagePart"/>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.titlepagePart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the title page according to any convenient typology.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocTitle">
+      <element name="docTitle">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document title) contains the title of a document, including all its constituents, as given on a title page. [4.6. Title Pages]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <oneOrMore>
+               <group>
+                  <ref name="sgatitlePart"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </oneOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitlePart">
+      <element name="titlePart">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a subsection or division of the title of a work, as indicated on a title page. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="type"
+                       a:defaultValue="main">
+               <a:documentation>specifies the role of this subdivision of the title.
+Suggested values include: 1] main; 2] sub(subordinate) ; 3] alt(alternate) ; 4] short; 5] desc(descriptive) </a:documentation>
+               <choice>
+                  <value>main</value>
+                  <a:documentation>main title of the work</a:documentation>
+                  <value>sub</value>
+                  <a:documentation>(subordinate) subtitle of the work</a:documentation>
+                  <value>alt</value>
+                  <a:documentation>(alternate) alternative title of the work</a:documentation>
+                  <value>short</value>
+                  <a:documentation>abbreviated form of title</a:documentation>
+                  <value>desc</value>
+                  <a:documentation>(descriptive) descriptive paraphrase of the work</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocAuthor">
+      <element name="docAuthor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document author) contains the name of the author of the document, as given on the title page (often but not always contained in a byline). [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaimprimatur">
+      <element name="imprimatur">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a formal statement authorizing the publication of a work, sometimes required to appear on a title page or its verso. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocEdition">
+      <element name="docEdition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document edition) contains an edition statement as presented on a title page of a document. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocImprint">
+      <element name="docImprint">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document imprint) contains the imprint statement (place and date of publication, publisher name), as given (usually) at the foot of a title page. [4.6. Title Pages]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgapubPlace"/>
+               <ref name="sgadocDate"/>
+        
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocDate">
+      <element name="docDate">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document date) contains the date of a document, as given on a title page or in a dateline. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="when">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the value of the date in standard form, i.e. YYYY-MM-DD.</a:documentation>
+               <choice>
+                  <data type="date"/>
+                  <data type="gYear"/>
+                  <data type="gMonth"/>
+                  <data type="gDay"/>
+                  <data type="gYearMonth"/>
+                  <data type="gMonthDay"/>
+                  <data type="time"/>
+                  <data type="dateTime"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafront">
+      <element name="front">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(front matter) contains any prefatory matter (headers, abstracts, title page, prefaces, dedications, etc.) found at the start of a document, before the main body. [4.6. Title Pages 4. Default Text Structure]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.frontPart"/>
+                  <ref name="sgamodel.pLike"/>
+                  <ref name="sgamodel.pLike.front"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+            <optional>
+               <group>
+                  <choice>
+          
+                     <group>
+                        <ref name="sgamodel.div1Like"/>
+                        <zeroOrMore>
+                           <choice>
+                              <ref name="sgamodel.div1Like"/>
+                              <ref name="sgamodel.frontPart"/>
+                              <ref name="sgamodel.global"/>
+                           </choice>
+                        </zeroOrMore>
+                     </group>
+          
+                     <group>
+                        <ref name="sgamodel.divLike"/>
+                        <zeroOrMore>
+                           <choice>
+                              <ref name="sgamodel.divLike"/>
+                              <ref name="sgamodel.frontPart"/>
+                              <ref name="sgamodel.global"/>
+                           </choice>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+        
+                  <optional>
+                     <group>
+                        <ref name="sgamodel.divBottom"/>
+                        <zeroOrMore>
+                           <choice>
+                              <ref name="sgamodel.divBottom"/>
+                              <ref name="sgamodel.global"/>
+                           </choice>
+                        </zeroOrMore>
+                     </group>
+                  </optional>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaback">
+      <element name="back">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(back matter) contains any appendixes, etc. following the main part of a text. [4.7. Back Matter 4. Default Text Structure]</a:documentation>
+         <group>
+
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.frontPart"/>
+                  <ref name="sgamodel.pLike.front"/>
+                  <ref name="sgamodel.pLike"/>
+                  <ref name="sgamodel.listLike"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+
+
+
+            <optional>
+               <choice>
+                  <group>
+
+                     <ref name="sgamodel.div1Like"/>
+
+
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.frontPart"/>
+                           <ref name="sgamodel.div1Like"/>
+                           <ref name="sgamodel.global"/>
+                        </choice>
+                     </zeroOrMore>
+
+                  </group>
+                  <group>
+
+                     <ref name="sgamodel.divLike"/>
+
+
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.frontPart"/>
+                           <ref name="sgamodel.divLike"/>
+                           <ref name="sgamodel.global"/>
+                        </choice>
+                     </zeroOrMore>
+
+                  </group>
+               </choice>
+            </optional>
+
+
+
+            <optional>
+               <group>
+
+                  <ref name="sgamodel.divBottomPart"/>
+
+
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.divBottomPart"/>
+                        <ref name="sgamodel.global"/>
+                     </choice>
+                  </zeroOrMore>
+
+               </group>
+            </optional>
+
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.msExcerpt.attributes">
+      <ref name="sgaatt.msExcerpt.attribute.defective"/>
+   </define>
+   <define name="sgaatt.msExcerpt.attribute.defective">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="defective"
+                    a:defaultValue="false">
+            <a:documentation>indicates whether the passage being quoted is defective, i.e. incomplete through loss or damage.</a:documentation>
+            <choice>
+               <data type="boolean"/>
+               <choice>
+                  <value>unknown</value>
+                  <a:documentation/>
+                  <value>inapplicable</value>
+                  <a:documentation/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.msClass.attributes">
+      <ref name="sgaatt.msClass.attribute.class"/>
+   </define>
+   <define name="sgaatt.msClass.attribute.class">
+      <optional>
+         <attribute name="class">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the text types or classifications applicable to this item by pointing to other elements or resources defining the classification concerned. </a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamsDesc">
+      <element name="msDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript description) contains a description of a single identifiable manuscript or other text-bearing object. [10.1. Overview]</a:documentation>
+         <group>
+            <ref name="sgamsIdentifier"/>
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+            <choice>
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+               <group>
+                  <optional>
+                     <ref name="sgamsContents"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaphysDesc"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgahistory"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaadditional"/>
+                  </optional>
+                  <choice>
+                     <zeroOrMore>
+                        <ref name="sgamsPart"/>
+                     </zeroOrMore>
+                     <zeroOrMore>
+                        <ref name="sgamsFrag"/>
+                     </zeroOrMore>
+                  </choice>
+               </group>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacatchwords">
+      <element name="catchwords">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the system used to ensure correct ordering of the quires making up a codex or incunable, typically by means of annotations at the foot of the page. [10.3.7. Catchwords, Signatures, Secundo Folio]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-catchwords-catchword_in_msDesc-constraint-assert-17">
+            <rule context="tei:catchwords">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="ancestor::tei:msDesc"
+                           role="nonfatal">WARNING: deprecated use of element — The <sch:name/> element will not be allowed outside of msDesc as of 2018-10-01.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadimensions">
+      <element name="dimensions">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a dimensional specification. [10.3.4. Dimensions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgadim"/>
+               <ref name="sgamodel.dimLike"/>
+            </choice>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-dimensions-duplicateDim-constraint-report-13">
+            <rule context="tei:dimensions">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="count(tei:width)&gt; 1">
+The element <name/> may appear once only
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-dimensions-duplicateDim-constraint-report-14">
+            <rule context="tei:dimensions">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="count(tei:height)&gt; 1">
+The element <name/> may appear once only
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-dimensions-duplicateDim-constraint-report-15">
+            <rule context="tei:dimensions">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="count(tei:depth)&gt; 1">
+The element <name/> may appear once only
+      </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates which aspect of the object is being measured.
+Sample values include: 1] leaves; 2] ruled; 3] pricked; 4] written; 5] miniatures; 6] binding; 7] box</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadim">
+      <element name="dim">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any single measurement forming part of a dimensional specification of some sort. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaheight">
+      <element name="height">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a measurement measured along the axis at right angles to the bottom of the written surface, i.e. parallel to the spine for a codex or book. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadepth">
+      <element name="depth">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a measurement measured across the spine of a book or codex, or (for other text-bearing objects) perpendicular to the measurement given by the width element. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgawidth">
+      <element name="width">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a measurement measured along the axis parallel to the bottom of the written surface, i.e. perpendicular to the spine of a book or codex. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaheraldry">
+      <element name="heraldry">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a heraldic formula or phrase, typically found as part of a blazon, coat of arms, etc.  [10.3.8. Heraldry]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocus">
+      <element name="locus">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines a location within a manuscript or manuscript part, usually as a (possibly discontinuous) sequence of folio references. [10.3.5. References to Locations within a Manuscript]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgahi"/>
+               <ref name="sgalocus"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the foliation scheme in terms of which the location is being specified by pointing to some foliation element defining it, or to some other equivalent resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="from">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the starting point of the location in a normalized form, typically a page number.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="to">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the end-point of the location in a normalized form, typically as a page number.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocusGrp">
+      <element name="locusGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups a number of locations which together form a distinct but discontinuous item within a manuscript or manuscript part, according to a specific foliation. [10.3.5. References to Locations within a Manuscript]</a:documentation>
+         <oneOrMore>
+            <ref name="sgalocus"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the foliation scheme in terms of which all the locations contained by the group are specified by pointing to some foliation element defining it, or to some other equivalent resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamaterial">
+      <element name="material">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing the material of which the object being described is composed. [10.3.2. Material and Object Type]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaobjectType">
+      <element name="objectType">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing the type of object being referred to. [10.3.2. Material and Object Type]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorigDate">
+      <element name="origDate">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(origin date) contains any form of date, used to identify the date of origin for a manuscript or manuscript part. [10.3.1. Origination]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorigPlace">
+      <element name="origPlace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(origin place) contains any form of place name, used to identify the place of origin for a manuscript or manuscript part. [10.3.1. Origination]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasecFol">
+      <element name="secFol">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(second folio) marks the word or words taken from a fixed point in a codex (typically the beginning of the second leaf) in order to provide a unique identifier for it.  [10.3.7. Catchwords, Signatures, Secundo Folio]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-secFol-secFol_in_msDesc-constraint-assert-18">
+            <rule context="tei:secFol">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="ancestor::tei:msDesc"
+                           role="nonfatal">WARNING: deprecated use of element — The <sch:name/> element will not be allowed outside of msDesc as of 2018-10-01.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasignatures">
+      <element name="signatures">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains discussion of the leaf or quire signatures found within a codex. [10.3.7. Catchwords, Signatures, Secundo Folio]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-signatures-signatures_in_msDesc-constraint-assert-19">
+            <rule context="tei:signatures">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="ancestor::tei:msDesc"
+                           role="nonfatal">WARNING: deprecated use of element — The <sch:name/> element will not be allowed outside of msDesc as of 2018-10-01.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastamp">
+      <element name="stamp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing a stamp or similar device. [10.3.3. Watermarks and Stamps]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgawatermark">
+      <element name="watermark">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing a watermark or similar device. [10.3.3. Watermarks and Stamps]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsIdentifier">
+      <element name="msIdentifier">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript identifier) contains the information required to identify the manuscript being described. [10.4. The Manuscript Identifier]</a:documentation>
+         <group>
+            <group>
+               <optional>
+                  <ref name="sgaplaceName"/>
+               </optional>
+               <optional>
+                  <ref name="sgabloc"/>
+               </optional>
+               <optional>
+                  <ref name="sgacountry"/>
+               </optional>
+               <optional>
+                  <ref name="sgaregion"/>
+               </optional>
+               <optional>
+                  <ref name="sgasettlement"/>
+               </optional>
+               <optional>
+                  <ref name="sgadistrict"/>
+               </optional>
+               <optional>
+                  <ref name="sgageogName"/>
+               </optional>
+        
+               <optional>
+                  <ref name="sgainstitution"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgarepository"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgacollection"/>
+               </zeroOrMore>
+        
+        
+               <optional>
+                  <ref name="sgaidno"/>
+               </optional>
+        
+            </group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamsName"/>
+                  <ref name="sgaaltIdentifier"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-msIdentifier-msId_minimal-constraint-report-16">
+            <rule context="tei:msIdentifier">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="not(parent::tei:msPart) and       (local-name(*[1])='idno' or       local-name(*[1])='altIdentifier' or       normalize-space(.)='')">An msIdentifier must contain either a repository or location of some type, or a manuscript name</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgainstitution">
+      <element name="institution">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of an organization such as a university or library, with which a manuscript is identified, generally its holding institution. [10.4. The Manuscript Identifier]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarepository">
+      <element name="repository">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a repository within which manuscripts are stored, possibly forming part of an institution. [10.4. The Manuscript Identifier]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacollection">
+      <element name="collection">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a collection of manuscripts, not necessarily located within a single repository. [10.4. The Manuscript Identifier]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaltIdentifier">
+      <element name="altIdentifier">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternative identifier) contains an alternative or former structured identifier used for a manuscript, such as a former catalogue number. [10.4. The Manuscript Identifier]</a:documentation>
+         <group>
+            <optional>
+               <ref name="sgaplaceName"/>
+            </optional>
+            <optional>
+               <ref name="sgabloc"/>
+            </optional>
+            <optional>
+               <ref name="sgacountry"/>
+            </optional>
+            <optional>
+               <ref name="sgaregion"/>
+            </optional>
+            <optional>
+               <ref name="sgasettlement"/>
+            </optional>
+            <optional>
+               <ref name="sgadistrict"/>
+            </optional>
+            <optional>
+               <ref name="sgageogName"/>
+            </optional>
+     
+            <optional>
+               <ref name="sgainstitution"/>
+            </optional>
+     
+     
+            <optional>
+               <ref name="sgarepository"/>
+            </optional>
+     
+     
+            <optional>
+               <ref name="sgacollection"/>
+            </optional>
+     
+            <ref name="sgaidno"/>
+     
+            <optional>
+               <ref name="sganote"/>
+            </optional>
+     
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsName">
+      <element name="msName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternative name) contains any form of unstructured alternative name used for a manuscript, such as an ocellus nominum, or nickname. [10.4. The Manuscript Identifier]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgars"/>
+               <ref name="sganame"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacolophon">
+      <element name="colophon">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the colophon of a manuscript item: that is, a statement providing information regarding the date, place, agency, or reason for production of the manuscript. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaexplicit">
+      <element name="explicit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the explicit of a manuscript item, that is, the closing words of the text proper, exclusive of any rubric or colophon which might follow it. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafiliation">
+      <element name="filiation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information concerning the manuscript's filiation, i.e. its relationship to other surviving manuscripts of the same text, its protographs, antigraphs and apographs. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafinalRubric">
+      <element name="finalRubric">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the string of words that denotes the end of a text division, often with an assertion as to its author and title, usually set off from the text itself by red ink, by a different size or type of script, or by some other such visual device. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaincipit">
+      <element name="incipit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the incipit of a manuscript item, that is the opening words of the text proper, exclusive of any rubric which might precede it, of sufficient length to identify the work uniquely; such incipits were, in former times, frequently used a means of reference to a work, in place of a title. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsContents">
+      <element name="msContents">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript contents) describes the intellectual content of a manuscript or manuscript part, either as a series of paragraphs or as a series of structured manuscript items. [10.6. Intellectual Content]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+          
+        
+        
+               <optional>
+                  <ref name="sgatitlePage"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamsItem"/>
+                     <ref name="sgamsItemStruct"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <ref name="sgaatt.msClass.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsItem">
+      <element name="msItem">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript item) describes an individual work or item within the intellectual content of a manuscript or manuscript part. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgalocus"/>
+                  <ref name="sgalocusGrp"/>
+               </choice>
+            </zeroOrMore>
+      
+            <choice>
+        
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+        
+        
+               <oneOrMore>
+                  <choice>
+                     <ref name="sgamodel.titlepagePart"/>
+                     <ref name="sgamodel.msItemPart"/>
+                     <ref name="sgamodel.global"/>
+                  </choice>
+               </oneOrMore>
+        
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <ref name="sgaatt.msClass.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsItemStruct">
+      <element name="msItemStruct">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(structured manuscript item) contains a structured description for an individual work or item within the intellectual content of a manuscript or manuscript part. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <group>
+      
+            <optional>
+               <choice>
+                  <ref name="sgalocus"/>
+                  <ref name="sgalocusGrp"/>
+               </choice>
+            </optional>
+      
+            <choice>
+        
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+        
+               <group>
+          
+                  <zeroOrMore>
+                     <ref name="sgaauthor"/>
+                  </zeroOrMore>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgarespStmt"/>
+                  </zeroOrMore>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgatitle"/>
+                  </zeroOrMore>
+          
+          
+                  <optional>
+                     <ref name="sgarubric"/>
+                  </optional>
+          
+          
+                  <optional>
+                     <ref name="sgaincipit"/>
+                  </optional>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgamsItemStruct"/>
+                  </zeroOrMore>
+          
+          
+                  <optional>
+                     <ref name="sgaexplicit"/>
+                  </optional>
+          
+          
+                  <optional>
+                     <ref name="sgafinalRubric"/>
+                  </optional>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgacolophon"/>
+                  </zeroOrMore>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgadecoNote"/>
+                  </zeroOrMore>
+          
+          
+            
+          
+          
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgabibl"/>
+              
+                     </choice>
+                  </zeroOrMore>
+          
+                  <optional>
+                     <ref name="sgafiliation"/>
+                  </optional>
+            
+                  <zeroOrMore>
+                     <ref name="sgamodel.noteLike"/>
+                  </zeroOrMore>
+          
+          
+            
+          
+               </group>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <ref name="sgaatt.msClass.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarubric">
+      <element name="rubric">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the text of any rubric or heading attached to a particular manuscript item, that is, a string of words through which a manuscript signals the beginning of a text division, often with an assertion as to its author and title, which is in some way set off from the text itself, usually in red ink, or by use of different size or type of script, or some other such visual device. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasummary">
+      <element name="summary">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an overview of the available information concerning some aspect of an item (for example, its intellectual content, history, layout, typography etc.) as a complement or alternative to the more detailed information carried by more specific elements. [10.6. Intellectual Content]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaphysDesc">
+      <element name="physDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical description) contains a full physical description of a manuscript or manuscript part, optionally subdivided using more specialized elements from the model.physDescPart class. [10.7. Physical Description]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.pLike"/>
+            </zeroOrMore>
+      
+      
+        
+            <optional>
+               <ref name="sgaobjectDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgahandDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgatypeDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgascriptDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgamusicNotation"/>
+            </optional>
+            <optional>
+               <ref name="sgadecoDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgaadditions"/>
+            </optional>
+            <optional>
+               <ref name="sgabindingDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgasealDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgaaccMat"/>
+            </optional>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaobjectDesc">
+      <element name="objectDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the physical components making up the object which is being described. [10.7.1. Object Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasupportDesc"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgalayoutDesc"/>
+               </optional>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="form">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a short project-specific name identifying the physical form of the carrier, for example as a codex, roll, fragment, partial leaf, cutting etc.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasupportDesc">
+      <element name="supportDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(support description) groups elements describing the physical support for the written part of a manuscript. [10.7.1. Object Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasupport"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgaextent"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgafoliation"/>
+               </zeroOrMore>
+        
+        
+               <optional>
+                  <ref name="sgacollation"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgacondition"/>
+               </optional>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="material">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a short project-defined name for the material composing the majority of the support
+Suggested values include: 1] paper; 2] parch(parchment) ; 3] mixed</a:documentation>
+               <choice>
+                  <value>paper</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>parch</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(parchment) </a:documentation>
+                  <value>mixed</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasupport">
+      <element name="support">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the materials etc. which make up the physical support for the written part of a manuscript. [10.7.1. Object Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacollation">
+      <element name="collation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of how the leaves or bifolia are physically arranged. [10.7.1. Object Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafoliation">
+      <element name="foliation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the numbering system or systems used to count the leaves or pages in a codex. [10.7.1.4. Foliation]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacondition">
+      <element name="condition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the physical condition of the manuscript. [10.7.1.5. Condition]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalayoutDesc">
+      <element name="layoutDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(layout description) collects the set of layout descriptions applicable to a manuscript. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgalayout"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalayout">
+      <element name="layout">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes how text is laid out on the page, including information about any ruling, pricking, or other evidence of page-preparation techniques. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="columns">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of columns per page</a:documentation>
+               <list>
+                  <data type="nonNegativeInteger"/>
+                  <optional>
+                     <data type="nonNegativeInteger"/>
+                  </optional>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="ruledLines">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of ruled lines per column</a:documentation>
+               <list>
+                  <data type="nonNegativeInteger"/>
+                  <optional>
+                     <data type="nonNegativeInteger"/>
+                  </optional>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="writtenLines">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of written lines per column</a:documentation>
+               <list>
+                  <data type="nonNegativeInteger"/>
+                  <optional>
+                     <data type="nonNegativeInteger"/>
+                  </optional>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandDesc">
+      <element name="handDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of hands) contains a description of all the different kinds of writing used in a manuscript. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgahandNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="hands">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of distinct hands identified within the manuscript</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatypeDesc">
+      <element name="typeDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the typefaces or other aspects of the printing of an incunable or other printed source. [10.7.2.1. Writing]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgatypeNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatypeNote">
+      <element name="typeNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a particular font or other significant typographic feature distinguished within the description of a printed resource. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgascriptDesc">
+      <element name="scriptDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the scripts used in a manuscript or similar source. [10.7.2.1. Writing]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgascriptNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamusicNotation">
+      <element name="musicNotation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains description of type of musical notation. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadecoDesc">
+      <element name="decoDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(decoration description) contains a description of the decoration of a manuscript, either as a sequence of paragraphs, or as a sequence of topically organized decoNote elements. [10.7.3. Bindings, Seals, and Additional Material]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgadecoNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadecoNote">
+      <element name="decoNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(note on decoration) contains a note describing either a decorative component of a manuscript, or a fairly homogenous class of such components. [10.7.3. Bindings, Seals, and Additional Material]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadditions">
+      <element name="additions">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of any significant additions found within a manuscript, such as marginalia or other annotations. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabindingDesc">
+      <element name="bindingDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(binding description) describes the present and former bindings of a manuscript, either as a series of paragraphs or as a series of distinct binding elements, one for each binding of the manuscript. [10.7.3.1. Binding Descriptions]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.pLike"/>
+                  <ref name="sgadecoNote"/>
+                  <ref name="sgacondition"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgabinding"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabinding">
+      <element name="binding">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of one binding, i.e. type of covering, boards, etc. applied to a manuscript. [10.7.3.1. Binding Descriptions]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgacondition"/>
+               <ref name="sgadecoNote"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <optional>
+            <attribute name="contemporary">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies whether or not the binding is contemporary with the majority of its contents</a:documentation>
+               <choice>
+                  <data type="boolean"/>
+                  <choice>
+                     <value>unknown</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>inapplicable</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasealDesc">
+      <element name="sealDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(seal description) describes the seals or other external items attached to a manuscript, either as a series of paragraphs or as a series of distinct seal elements, possibly with additional decoNotes. [10.7.3.2. Seals]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <choice>
+                     <ref name="sgadecoNote"/>
+                     <ref name="sgaseal"/>
+                     <ref name="sgacondition"/>
+                  </choice>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaseal">
+      <element name="seal">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of one seal or similar attachment applied to a manuscript. [10.7.3.2. Seals]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgadecoNote"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <optional>
+            <attribute name="contemporary">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies whether or not the seal is contemporary with the item to which it is affixed</a:documentation>
+               <choice>
+                  <data type="boolean"/>
+                  <choice>
+                     <value>unknown</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>inapplicable</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaccMat">
+      <element name="accMat">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(accompanying material) contains details of any significant additional material which may be closely associated with the manuscript being described, such as non-contemporaneous documents or fragments bound in with the manuscript at some earlier historical period. [10.7.3.3. Accompanying Material]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahistory">
+      <element name="history">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups elements describing the full history of a manuscript or manuscript part. [10.8. History]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgaorigin"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgaprovenance"/>
+               </zeroOrMore>
+        
+        
+               <optional>
+                  <ref name="sgaacquisition"/>
+               </optional>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorigin">
+      <element name="origin">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any descriptive or other information concerning the origin of a manuscript or manuscript part. [10.8. History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprovenance">
+      <element name="provenance">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any descriptive or other information concerning a single identifiable episode during the history of a manuscript or manuscript part, after its creation but before its acquisition. [10.8. History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaacquisition">
+      <element name="acquisition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any descriptive or other information concerning the process by which a manuscript or manuscript part entered the holding institution. [10.8. History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadditional">
+      <element name="additional">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups additional information, combining bibliographic information about a manuscript, or surrogate copies of it with curatorial or administrative information. [10.9. Additional Information]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgaadminInfo"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgasurrogates"/>
+            </optional>
+      
+      
+        
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadminInfo">
+      <element name="adminInfo">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(administrative information) contains information about the present custody and availability of the manuscript, and also about the record description itself. [10.9.1. Administrative Information]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgarecordHist"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgaavailability"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgacustodialHist"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgamodel.noteLike"/>
+            </optional>
+        
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarecordHist">
+      <element name="recordHist">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(recorded history) provides information about the source and revision status of the parent manuscript description itself. [10.9.1. Administrative Information]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+               <ref name="sgasource"/>
+        
+               <zeroOrMore>
+                  <ref name="sgachange"/>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasource">
+      <element name="source">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the original source for the information contained with a manuscript description. [10.9.1.1. Record History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacustodialHist">
+      <element name="custodialHist">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(custodial history) contains a description of a manuscript's custodial history, either as running prose or as a series of dated custodial events. [10.9.1.2. Availability and Custodial History]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgacustEvent"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacustEvent">
+      <element name="custEvent">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(custodial event) describes a single event during the custodial history of a manuscript. [10.9.1.2. Availability and Custodial History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurrogates">
+      <element name="surrogates">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about any representations of the manuscript being described which may exist in the holding institution or elsewhere. [10.9. Additional Information]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsPart">
+      <element name="msPart">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript part) contains information about an originally distinct manuscript or part of a manuscript, which is now part of a composite manuscript. [10.10. Manuscript Parts]</a:documentation>
+         <group>
+            <ref name="sgamsIdentifier"/>
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+            <choice>
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+               <group>
+                  <optional>
+                     <ref name="sgamsContents"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaphysDesc"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgahistory"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaadditional"/>
+                  </optional>
+                  <zeroOrMore>
+                     <ref name="sgamsPart"/>
+                  </zeroOrMore>
+               </group>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsFrag">
+      <element name="msFrag">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript fragment) contains information about a fragment of a scattered manuscript now held as a single unit or bound into a larger manuscript. [10.11. Manuscript Fragments]</a:documentation>
+         <group>
+            <choice>
+                <ref name="sgaaltIdentifier"/>
+                <ref name="sgamsIdentifier"/>
+            </choice>
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+            <choice>
+                <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+                <group>
+                    <optional>
+                     <ref name="sgamsContents"/>
+                  </optional>
+                    <optional>
+                     <ref name="sgaphysDesc"/>
+                  </optional>
+                    <optional>
+                     <ref name="sgahistory"/>
+                  </optional>
+                    <optional>
+                     <ref name="sgaadditional"/>
+                  </optional>
+                </group>
+            </choice>
+        </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.datable.custom.attributes">
+      <ref name="sgaatt.datable.custom.attribute.when-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.notBefore-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.notAfter-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.from-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.to-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.datingPoint"/>
+      <ref name="sgaatt.datable.custom.attribute.datingMethod"/>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.when-custom">
+      <optional>
+         <attribute name="when-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of a date or time in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.notBefore-custom">
+      <optional>
+         <attribute name="notBefore-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the earliest possible date for the event in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.notAfter-custom">
+      <optional>
+         <attribute name="notAfter-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the latest possible date for the event in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.from-custom">
+      <optional>
+         <attribute name="from-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the starting point of the period in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.to-custom">
+      <optional>
+         <attribute name="to-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the ending point of the period in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.datingPoint">
+      <optional>
+         <attribute name="datingPoint">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to some location defining a named point in time with reference to which the datable item is understood to have occurred</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.datingMethod">
+      <optional>
+         <attribute name="datingMethod">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to a calendar element or other means of interpreting the values of the custom dating attributes.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamodel.persNamePart">
+      <choice>
+         <ref name="sgasurname"/>
+         <ref name="sgaforename"/>
+         <ref name="sgagenName"/>
+         <ref name="sganameLink"/>
+         <ref name="sgaaddName"/>
+         <ref name="sgaroleName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.persNamePart_alternation">
+      <choice>
+         <ref name="sgasurname"/>
+         <ref name="sgaforename"/>
+         <ref name="sgagenName"/>
+         <ref name="sganameLink"/>
+         <ref name="sgaaddName"/>
+         <ref name="sgaroleName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.persNamePart_sequence">
+      <ref name="sgasurname"/>
+      <ref name="sgaforename"/>
+      <ref name="sgagenName"/>
+      <ref name="sganameLink"/>
+      <ref name="sgaaddName"/>
+      <ref name="sgaroleName"/>
+   </define>
+   <define name="sgamodel.persNamePart_sequenceOptional">
+      <optional>
+         <ref name="sgasurname"/>
+      </optional>
+      <optional>
+         <ref name="sgaforename"/>
+      </optional>
+      <optional>
+         <ref name="sgagenName"/>
+      </optional>
+      <optional>
+         <ref name="sganameLink"/>
+      </optional>
+      <optional>
+         <ref name="sgaaddName"/>
+      </optional>
+      <optional>
+         <ref name="sgaroleName"/>
+      </optional>
+   </define>
+   <define name="sgamodel.persNamePart_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgasurname"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaforename"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgagenName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sganameLink"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaaddName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaroleName"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.persNamePart_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgasurname"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaforename"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgagenName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sganameLink"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaaddName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaroleName"/>
+      </oneOrMore>
+   </define>
+   <define name="sgaatt.datable.iso.attributes">
+      <ref name="sgaatt.datable.iso.attribute.when-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.notBefore-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.notAfter-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.from-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.to-iso"/>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.when-iso">
+      <optional>
+         <attribute name="when-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of a date or time in a standard form.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.notBefore-iso">
+      <optional>
+         <attribute name="notBefore-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the earliest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.notAfter-iso">
+      <optional>
+         <attribute name="notAfter-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the latest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.from-iso">
+      <optional>
+         <attribute name="from-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the starting point of the period in standard form.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.to-iso">
+      <optional>
+         <attribute name="to-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the ending point of the period in standard form.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaorgName">
+      <element name="orgName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(organization name) contains an organizational name. [13.2.2. Organizational Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapersName">
+      <element name="persName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(personal name) contains a proper noun or proper-noun phrase referring to a person, possibly including one or more of the person's forenames, surnames, honorifics, added names, etc. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurname">
+      <element name="surname">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a family (inherited) name, as opposed to a given, baptismal, or nick name. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaforename">
+      <element name="forename">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a forename, given or baptismal name. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagenName">
+      <element name="genName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(generational name component) contains a name component used to distinguish otherwise similar names on the basis of the relative ages or generations of the persons named. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganameLink">
+      <element name="nameLink">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name link) contains a connecting phrase or link used within a name but not regarded as part of it, such as van der or of. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddName">
+      <element name="addName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(additional name) contains an additional name component, such as a nickname, epithet, or alias, or any other descriptive phrase used within a personal name. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaroleName">
+      <element name="roleName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a name component which indicates that the referent has a particular role or position in society, such as an official title or rank. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaplaceName">
+      <element name="placeName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an absolute or relative place name. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabloc">
+      <element name="bloc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a geo-political unit consisting of two or more nation states or countries. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacountry">
+      <element name="country">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a geo-political unit, such as a nation, country, colony, or commonwealth, larger than or administratively superior to a region and smaller than a bloc. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaregion">
+      <element name="region">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of an administrative unit such as a state, province, or county, larger than a settlement, but smaller than a country. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasettlement">
+      <element name="settlement">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a settlement such as a city, town, or village identified as a single geo-political or administrative unit. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadistrict">
+      <element name="district">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of any kind of subdivision of a settlement, such as a parish, ward, or other administrative or geographic unit. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaoffset">
+      <element name="offset">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">marks that part of a relative temporal or spatial expression which indicates the direction of the offset between the two place names, dates, or times involved in the expression. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageogName">
+      <element name="geogName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographical name) identifies a name associated with some geographical feature such as Windrush Valley or Mount Sinai. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageogFeat">
+      <element name="geogFeat">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographical feature name) contains a common noun identifying some geographical feature contained within a geographic name, such as valley, mount, etc. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaffiliation">
+      <element name="affiliation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an informal description of a person's present or past affiliation with some organization, for example an employer or sponsor. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] sponsor; 2] recommend; 3] discredit; 4] pledged</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaage">
+      <element name="age">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the age of a person. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] western; 2] sui; 3] subjective; 4] objective; 5] inWorld(in world) ; 6] chronological; 7] biological; 8] psychological; 9] functional</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="value">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a numeric code representing the age or age group</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabirth">
+      <element name="birth">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a person's birth, such as its date and place. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] caesarean(caesarean section) ; 2] vaginal(vaginal delivery) ; 3] exNihilo(ex nihilo) ; 4] incorporated; 5] founded; 6] established</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaclimate">
+      <element name="climate">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the physical climate of a place. [13.3.4.3. States, Traits, and Events]</a:documentation>
+         <group>
+      
+         
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+          
+        
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.labelLike"/>
+               </oneOrMore>
+          
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgaclimate"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadeath">
+      <element name="death">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a person's death, such as its date and place. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] proclaimed; 2] assumed; 3] verified; 4] clinical; 5] brain; 6] natural; 7] unnatural; 8] fragmentation; 9] dissolution</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaeducation">
+      <element name="education">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the educational experience of a person. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] secondary; 3] undergraduate; 4] graduate; 5] residency; 6] apprenticeship</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaevent">
+      <element name="event">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains data relating to any kind of significant event associated with a person, place, or organization. [13.3.1. Basic Principles]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+          
+        
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.labelLike"/>
+               </oneOrMore>
+          
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgalinkGrp"/>
+                  <ref name="sgalink"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgaevent"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="where">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of an event by pointing to a place element</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafaith">
+      <element name="faith">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the faith, religion, or belief set of a person. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] practicing; 2] clandestine; 3] patrilineal; 4] matrilineal; 5] convert</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafloruit">
+      <element name="floruit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a person's period of activity. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageo">
+      <element name="geo">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographical coordinates) contains any expression of a set of geographic coordinates, representing a point, line, or area on the surface of the earth in some notation. [13.3.4.1. Varieties of Location]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalangKnowledge">
+      <element name="langKnowledge">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language knowledge) summarizes the state of a person's linguistic knowledge, either as prose or by a list of langKnown elements. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <group>        
+       
+            <choice>
+	              <ref name="sgamodel.pLike"/>
+	              <oneOrMore>
+                  <ref name="sgalangKnown"/>
+               </oneOrMore>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] listening; 2] speaking; 3] reading; 4] writing</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="tags">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies one or more valid language tags for the languages specified</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <choice>
+                        <data type="language"/>
+                        <choice>
+                           <value/>
+                           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        </choice>
+                     </choice>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalangKnown">
+      <element name="langKnown">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language known) summarizes the state of a person's linguistic competence, i.e., knowledge of a single language. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <attribute name="tag">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a valid language tag for the language concerned.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute name="level">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a code indicating the person's level of knowledge for this language</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistOrg">
+      <element name="listOrg">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of organizations) contains a list of elements, each of which provides information about an identifiable organization. [13.2.2. Organizational Names]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgaorg"/>
+                  <ref name="sgalistOrg"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistEvent">
+      <element name="listEvent">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of events) contains a list of descriptions, each of which provides information about an identifiable event. [13.3.1. Basic Principles]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgaevent"/>
+                  <ref name="sgalistEvent"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistPerson">
+      <element name="listPerson">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of persons) contains a list of descriptions, each of which provides information about an identifiable person or a group of people, for example the participants in a language interaction, or the people referred to in a historical source. [13.3.2. The Person Element 15.2. Contextual Information 2.4. The Profile Description 15.3.2. Declarable Elements]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.personLike"/>
+                  <ref name="sgalistPerson"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistPlace">
+      <element name="listPlace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of places) contains a list of places, optionally followed by a list of relationships (other than containment) defined amongst them. [2.2.7. The Source Description 13.3.4. Places]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.placeLike"/>
+                  <ref name="sgalistPlace"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocation">
+      <element name="location">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines the location of a place as a set of geographical coordinates, in terms of other named geo-political entities, or as an address. [13.3.4. Places]</a:documentation>
+         <zeroOrMore>
+            <choice>
+        
+               <ref name="sgamodel.labelLike"/>
+               <ref name="sgamodel.placeNamePart"/>
+               <ref name="sgamodel.offsetLike"/>
+               <ref name="sgamodel.measureLike"/>
+               <ref name="sgamodel.addressLike"/>
+               <ref name="sgamodel.noteLike"/>
+               <ref name="sgamodel.biblLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganationality">
+      <element name="nationality">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an informal description of a person's present or past nationality or citizenship. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] birth; 2] naturalised; 3] self-assigned</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaoccupation">
+      <element name="occupation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an informal description of a person's trade, profession or occupation. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] other; 3] paid; 4] unpaid</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the classification system or taxonomy in use, for example by supplying the identifier of a taxonomy element, or pointing to some other resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="code">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies an occupation code defined within the classification system or taxonomy defined by the scheme attribute.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorg">
+      <element name="org">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(organization) provides information about an identifiable organization such as a business, a tribe, or any other grouping of people. [13.2.2. Organizational Names]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <zeroOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </zeroOrMore>
+          
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.labelLike"/>
+                     <ref name="sgamodel.nameLike"/>
+                     <ref name="sgamodel.placeLike"/>
+                     <ref name="sgamodel.orgPart"/>
+	                    <ref name="sgamodel.milestoneLike"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgalinkGrp"/>
+                  <ref name="sgalink"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.personLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a primary role or classification for the organization.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistRelation">
+      <element name="listRelation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about relationships identified amongst people, places, and organizations, either informally as prose or as formally expressed relation links. [13.3.2.3. Personal Relationships]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+               <ref name="sgamodel.pLike"/>
+        
+               <oneOrMore>
+                  <choice>
+                     <ref name="sgarelation"/>
+                     <ref name="sgalistRelation"/>
+                  </choice>
+               </oneOrMore>
+        
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaperson">
+      <element name="person">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about an identifiable individual, for example a participant in a language interaction, or a person referred to in a historical source. [13.3.2. The Person Element 15.2.2. The Participant Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.personPart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a primary role or classification for the person.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="sex">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of the person.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="age">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies an age group for the person.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapersona">
+      <element name="persona">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about one of the personalities identified for a given individual, where an individual has multiple personalities. [13.3.2. The Person Element]</a:documentation>
+         <choice>   
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.personPart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a primary role or classification for the persona.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="sex">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of the persona.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="age">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies an age group for the persona.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapersonGrp">
+      <element name="personGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(personal group) describes a group of individuals treated as a single person for analytic purposes. [15.2.2. The Participant Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.personPart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the role of this group of participants in the interaction.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="sex">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of the participant group.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="age">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the age group of the participants.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="size">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes informally the size or approximate size of the group for example by means of a number and an indication of accuracy e.g. approx 200.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaplace">
+      <element name="place">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains data about a geographic location [13.3.4. Places]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <zeroOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </zeroOrMore>
+          
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.labelLike"/>
+                     <ref name="sgamodel.placeStateLike"/>
+                     <ref name="sgamodel.eventLike"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgaidno"/>
+                  <ref name="sgalinkGrp"/>
+                  <ref name="sgalink"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.placeLike"/>
+                  <ref name="sgalistPlace"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapopulation">
+      <element name="population">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the population of a place. [13.3.4.3. States, Traits, and Events]</a:documentation>
+         <group>
+      
+         
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+          
+            
+                     <oneOrMore>
+                        <ref name="sgamodel.pLike"/>
+                     </oneOrMore>
+            
+          
+          
+            
+                     <oneOrMore>
+                        <ref name="sgamodel.labelLike"/>
+                     </oneOrMore>
+            
+          
+                  </choice>
+        
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.noteLike"/>
+                        <ref name="sgamodel.biblLike"/>
+                     </choice>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+      
+            <zeroOrMore>
+               <ref name="sgapopulation"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarelation">
+      <element name="relation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(relationship) describes any kind of relationship or linkage amongst a specified group of places, events, persons, objects or other items. [13.3.2.3. Personal Relationships]</a:documentation>
+         <optional>
+            <ref name="sgadesc"/>
+         </optional>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relation-reforkeyorname-constraint-assert-20">
+            <rule context="tei:relation">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="@ref or @key or @name">One of the attributes  'name', 'ref' or 'key' must be supplied</assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relation-activemutual-constraint-report-17">
+            <rule context="tei:relation">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@active and @mutual">Only one of the attributes
+@active and @mutual may be supplied</report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relation-activepassive-constraint-report-18">
+            <rule context="tei:relation">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="@passive and not(@active)">the attribute 'passive'
+	may be supplied only if the attribute 'active' is
+	supplied</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="name">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a name for the kind of relationship of which this is an instance.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <choice>
+            <optional>
+               <attribute name="active">
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the active participants in a non-mutual relationship, or all the participants in a mutual one.</a:documentation>
+                  <list>
+                     <oneOrMore>
+                        <data type="anyURI"/>
+                     </oneOrMore>
+                  </list>
+               </attribute>
+            </optional>
+            <optional>
+               <attribute name="mutual">
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a list of participants amongst all of whom the relationship holds equally.</a:documentation>
+                  <list>
+                     <oneOrMore>
+                        <data type="anyURI"/>
+                     </oneOrMore>
+                  </list>
+               </attribute>
+            </optional>
+         </choice>
+         <optional>
+            <attribute name="passive">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the passive participants in a non-mutual relationship.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaresidence">
+      <element name="residence">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a person's present or past places of residence. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] secondary; 3] temporary; 4] permanent</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasex">
+      <element name="sex">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of a person. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] explicit; 2] implicit</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="value">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a coded value for sex</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasocecStatus">
+      <element name="socecStatus">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(socio-economic status) contains an informal description of a person's perceived social or economic status. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] atBirth; 2] atDeath; 3] dependent; 4] inherited; 5] independent</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the classification system or taxonomy in use, for example by pointing to a locally-defined taxonomy element or by supplying a URI for an externally-defined system.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="code">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a status code defined within the classification system or taxonomy defined by the scheme attribute.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastate">
+      <element name="state">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of some status or quality attributed to a person, place, or organization often at some specific time or for a specific date range. [13.3.1. Basic Principles 13.3.2.1. Personal Characteristics]</a:documentation>
+         <group>
+        
+           
+        
+            <choice>
+           
+              <oneOrMore>
+                  <ref name="sgastate"/>
+               </oneOrMore>
+           
+               <group>
+              
+                 <zeroOrMore>
+                     <ref name="sgamodel.headLike"/>
+                  </zeroOrMore>
+              
+              
+                 <oneOrMore>
+                     <ref name="sgamodel.pLike"/>
+                  </oneOrMore>
+              
+              
+                 <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.noteLike"/>
+                        <ref name="sgamodel.biblLike"/>
+                     </choice>
+                  </zeroOrMore>
+              
+               </group>
+           
+              
+                 <zeroOrMore>
+                  <choice>
+                    <ref name="sgamodel.labelLike"/>
+                    <ref name="sgamodel.noteLike"/>
+                    <ref name="sgamodel.biblLike"/>
+                 </choice>
+               </zeroOrMore>
+              
+           
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaterrain">
+      <element name="terrain">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the physical terrain of a place. [13.3.4.3. States, Traits, and Events]</a:documentation>
+         <group>
+      
+         
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+          
+        
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.labelLike"/>
+               </oneOrMore>
+          
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgaterrain"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatrait">
+      <element name="trait">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of some status or quality attributed to a person, place, or organization typically, but not necessarily, independent of the volition or action of the holder and usually not at some specific time or for a specific date range. [13.3.1. Basic Principles 13.3.2.1. Personal Characteristics]</a:documentation>
+         <group>
+       
+          
+       
+            <choice>
+          
+               <oneOrMore>
+                  <ref name="sgatrait"/>
+               </oneOrMore>
+          
+               <group>
+             
+                  <zeroOrMore>
+                     <ref name="sgamodel.headLike"/>
+                  </zeroOrMore>
+             
+             
+                  <oneOrMore>
+                     <ref name="sgamodel.pLike"/>
+                  </oneOrMore>
+             
+             
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.noteLike"/>
+                        <ref name="sgamodel.biblLike"/>
+                     </choice>
+                  </zeroOrMore>
+             
+               </group>
+          
+             
+                <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.labelLike"/>
+                     <ref name="sgamodel.noteLike"/>
+                     <ref name="sgamodel.biblLike"/>
+                  </choice>
+               </zeroOrMore>
+             
+          
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganym">
+      <element name="nym">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(canonical name) contains the definition for a canonical name or name component of any kind. [13.3.5. Names and Nyms]</a:documentation>
+         <group>
+      
+        
+            <zeroOrMore>
+               <ref name="sgamodel.entryPart"/>
+            </zeroOrMore>
+        
+      
+      
+        
+            <zeroOrMore>
+               <ref name="sgamodel.pLike"/>
+            </zeroOrMore>
+        
+      
+      
+        
+            <zeroOrMore>
+               <ref name="sganym"/>
+            </zeroOrMore>
+        
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="parts">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to constituent nyms</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistNym">
+      <element name="listNym">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of canonical names) contains a list of nyms, that is, standardized names for any thing. [13.3.5. Names and Nyms]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sganym"/>
+                  <ref name="sgalistNym"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgac">
+      <element name="c">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character) represents a character. [17.1. Linguistic Segment Categories]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.segLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <start>
+      <choice>
+         <ref name="sgaTEI"/>
+      </choice>
+   </start>
+</grammar>

--- a/data/odd/shelley-godwin-FULL.odd
+++ b/data/odd/shelley-godwin-FULL.odd
@@ -1,0 +1,619 @@
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Shelley Godwin Archive Customization</title>
+        <author xml:id="tmunoz">Trevor Muñoz</author>
+        <author xml:id="rviglian">Raffaele Viglianti</author>
+      </titleStmt>
+      <publicationStmt>
+        <distributor>Shelley Godwin Archive (via website)</distributor>
+        <address>
+          <addrLine>mith@umd.edu</addrLine>
+        </address>
+        <date when="2011-10-17">October 17, 2011</date>
+        <availability status="restricted">
+          <p>This code was updated by Elisa Beshero-Bondar, building on work copyrighted by Trevor Muñoz, Raffaele Viglianti, and Maryland Institute for Technology in the
+            Humanities and licensed under a <ref target="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0
+              Unported License</ref>.</p>
+        </availability>
+        <pubPlace>College Park, MD USA</pubPlace>
+      </publicationStmt>
+      <sourceDesc>
+        <p>Based on <name type="file">geneticTEI.xml</name>, which can be found <ref target="http://tei.svn.sourceforge.net/viewvc/tei/trunk/P5/">Sourceforge</ref>.</p>
+      </sourceDesc>
+    </fileDesc>
+    <revisionDesc>
+      <change when="2011-10-16" who="tmunoz">First draft</change>
+      <change when="2011-11-14" who="tmunoz">Temporarily removing Genetic Editions stuff</change>
+      <change when="2011-11-21" who="tmunoz">Making additional header elements required</change>
+      <change when="2014-01-21" who="rviglian">Restructured to validate master files (metadata + xinlcluded content)</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <head>Rationale</head>
+        <p>To be added</p>
+      </div>
+      <div>
+        <head>Shelley Godwin ODD</head>
+        <p>The prefix in this schema stands for <expan>Shelley Godwin Archive</expan>, the project
+          for which this customization was developed.</p>
+        <schemaSpec ident="shelley_godwin_odd" prefix="sga" start="TEI">
+
+          <specGrp xml:base="shelley-godwin-page.odd" xml:id="modules">
+                        <moduleRef key="tei"></moduleRef>
+                        
+                        
+                        <moduleRef except="am ex fw supplied surplus redo undo" key="transcr"></moduleRef>
+                        <moduleRef key="gaiji"></moduleRef>
+                        <moduleRef except="ab altGrp timeline" key="linking"></moduleRef>
+                        
+                        <moduleRef include="figure figDesc" key="figures"></moduleRef>
+                        
+                        
+                        <elementRef key="c"></elementRef>
+                    </specGrp>
+          <specGrp xml:base="shelley-godwin-page.odd" xml:id="mainSpec">
+                        
+                    <classSpec ident="att.global" mode="change" type="atts">
+                        <attList>
+                            <attDef ident="el-target" mode="add" ns="http://shelleygodwinarchive.org/ns/1.0">
+                                <desc>A convenience attribute for indicating what text-centric
+                                    element a document-centric element should be transformed
+                                    to</desc>
+                                <datatype>
+                                    <dataRef key="string"></dataRef>
+                                </datatype>
+                            </attDef>
+                            <attDef ident="att-target" mode="add" ns="http://shelleygodwinarchive.org/ns/1.0">
+                                <desc>A convenience attribute for indicating what attribute should
+                                    be added in transforming from document- to text-centric markup.
+                                    By convention the attribute is placed on the element specified
+                                    in a preceding el-target attribute</desc>
+                                <datatype>
+                                    <dataRef key="string"></dataRef>
+                                </datatype>
+                            </attDef>
+                            <attDef ident="att-value" mode="add" ns="http://shelleygodwinarchive.org/ns/1.0">
+                                <desc>If an attribute created during a document- to text-centric
+                                    markup conversion should have a particular value, please
+                                    indicate</desc>
+                                <datatype>
+                                    <dataRef key="string"></dataRef>
+                                </datatype>
+                            </attDef>
+                        </attList>
+                    </classSpec>
+
+              <classSpec ident="att.transcriptional" type="atts" mode="change">
+                  <attList>
+                      <attDef ident="status" mode="delete"/>
+                      
+                  </attList>
+              </classSpec>
+              <!--2017-08-15 ebb: To resolve an error in the output RNG, I moved the specs for @hand from the pattern defining att.transcriptional to a new one, below, for its specific att class in the TEI. If we don't do this, we generate a duplicate rule for @hand in att.written and in att.transcriptional.-->
+              <classSpec ident="att.written" type="atts" mode="change">
+                  <attList> <attDef ident="hand" mode="replace">
+                      <valList type="closed" mode="replace">
+                          <valItem ident="#pbs">
+                              <gloss>Percy Shelley's handwriting</gloss>
+                              <desc>Text written in Percy Shelley's hand.</desc>
+                          </valItem>
+                          <valItem ident="#mws">
+                              <gloss>Mary Shelley's handwriting</gloss>
+                              <desc>Text written in Mary Shelley's hand.</desc>
+                          </valItem>
+                          <valItem ident="#comp">
+                              <gloss>compositor's handwriting</gloss>
+                              <desc>Text written in an (unknown?) compositor's hand.</desc>
+                          </valItem>
+                          <valItem ident="#library">
+                              <gloss>librarian's handwriting</gloss>
+                              <desc>Text written in an (unknown?) librarian's hand.</desc>
+                          </valItem>
+                          <valItem ident="http://viaf.org/viaf/95159449"/>
+                      </valList>
+                  </attDef></attList>
+              </classSpec>
+
+                    <classSpec ident="att.global.linking" mode="change" type="atts">
+                        <attList>
+                            <attDef ident="synch" mode="delete"></attDef>
+                            <attDef ident="sameAs" mode="delete"></attDef>
+                            <attDef ident="copyOf" mode="delete"></attDef>
+                            <attDef ident="exclude" mode="delete"></attDef>
+                            <attDef ident="select" mode="delete"></attDef>
+                        </attList>
+                    </classSpec>
+
+                    <classSpec ident="att.coordinated.attributes" mode="change" type="atts">
+                        <attList>
+                            <attDef ident="start" mode="delete"></attDef>
+                        </attList>
+                    </classSpec>
+
+                    
+                    <classSpec ident="att.global.analytic" mode="delete" type="atts"></classSpec>
+                    <classSpec ident="att.global.change" mode="delete" type="atts"></classSpec>
+                    <classSpec ident="att.declaring" mode="delete" type="atts"></classSpec>
+                    <classSpec ident="att.responsibility" mode="delete" type="atts"></classSpec>
+
+                    
+                    <dataSpec ident="sga_linerend" mode="add">
+                        <desc>Simple datatype for indentation values.
+                            When the indentation is numbered, each value should correspond 
+                            roughly 1/10 of the page.
+                        </desc>
+                        <content>
+                            <alternate>
+                                <valList>
+                                    <valItem ident="right"></valItem>
+                                    <valItem ident="center"></valItem>
+                                    <valItem ident="left"></valItem>
+                                </valList>
+                                <dataRef name="string" restriction="indent\d"></dataRef>
+                            </alternate>                            
+                        </content>
+                    </dataSpec>
+
+                    <elementSpec ident="surface" mode="change" module="transcr">
+                        <content>
+                            <sequence>
+                                
+                                <alternate maxOccurs="unbounded" minOccurs="0">
+                                    <classRef key="model.global"></classRef>
+                                    
+                                    <classRef key="model.graphicLike"></classRef>
+                                </alternate>
+                                
+                                <sequence maxOccurs="unbounded" minOccurs="0">
+                                    
+                                    <alternate>
+                                        <elementRef key="zone"></elementRef>
+                                        <elementRef key="line"></elementRef>
+                                        
+                                        
+                                    </alternate>
+                                    
+                                    
+                                    <classRef key="model.global" maxOccurs="unbounded" minOccurs="0"></classRef>
+                                    
+                                </sequence>
+                            </sequence>
+                        </content>
+                        
+                        <constraintSpec ident="add-ns-for-schema-fragment" scheme="isoschematron">
+                            <constraint>
+                                <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="tei" uri="http://www.tei-c.org/ns/1.0"></sch:ns>
+                            </constraint>
+                        </constraintSpec>
+                        <attList>
+                            <attDef ident="xml:id" mode="change" usage="req"></attDef>
+
+                            
+                            <attDef ident="ulx" mode="change" usage="req"></attDef>
+                            <attDef ident="uly" mode="change" usage="req"></attDef>
+                            <attDef ident="lrx" mode="change" usage="req"></attDef>
+                            <attDef ident="lry" mode="change" usage="req"></attDef>
+
+                            <attDef ident="n" mode="change" usage="rec"></attDef>
+
+                            <attDef ident="corresp" mode="change" usage="opt">
+                                <altIdent>partOf</altIdent>
+                                <desc>Syntactic sugar attribute—should refer to the id of the
+                                    sourceDoc element with which this surface should be
+                                    associated</desc>
+                            </attDef>
+                            
+                            <attDef ident="shelfmark" mode="add" ns="http://mith.umd.edu/sc/ns1#" usage="opt">
+                                <datatype>
+                                    <dataRef key="string"></dataRef>
+                                </datatype>
+                            </attDef>
+                            <attDef ident="folio" mode="add" ns="http://mith.umd.edu/sc/ns1#" usage="opt">
+                                <datatype>
+                                    <dataRef key="string"></dataRef>
+                                </datatype>
+                            </attDef>
+                            
+                            
+                            <attDef ident="attachment" mode="delete"></attDef>
+                            <attDef ident="flipping" mode="delete"></attDef>
+                        </attList>
+                    </elementSpec>
+
+                    
+                    <elementSpec ident="line" mode="change" module="transcr">
+                        <content>
+                            
+                            <alternate maxOccurs="unbounded" minOccurs="0">
+                                <textNode></textNode>
+                                <classRef key="model.global"></classRef>
+                                
+                                
+                                <classRef key="model.segLike"></classRef>
+                                <classRef key="model.hiLike"></classRef>
+                                <elementRef key="choice"></elementRef>
+                                <elementRef key="zone"></elementRef>
+                                <elementRef key="line"></elementRef>
+                                
+                                
+                                <elementRef key="del"></elementRef>
+                                <elementRef key="add"></elementRef>
+                                <elementRef key="unclear"></elementRef>
+                                <elementRef key="damage"></elementRef>
+                                <elementRef key="handShift"></elementRef>
+                                <elementRef key="mod"></elementRef>
+                                <elementRef key="retrace"></elementRef>
+                            </alternate>
+                            
+                        </content>
+                        
+                        <attList>
+                            <attDef ident="rend" mode="replace" usage="opt">
+                                <datatype>
+                                    <dataRef key="sga_linerend"></dataRef>
+                                </datatype>
+                            </attDef>
+                        </attList>
+                        <remarks>
+                            <p>For the purposes of diplomatic transcriptions, the content model of
+                                line has been restricted to remove more interpretive elements such
+                                as &lt;sic&gt;, and &lt;reg&gt;</p>
+                        </remarks>
+                    </elementSpec>
+
+                    <elementSpec ident="damage" mode="change" module="transcr">
+                        <attList>
+                            <attDef ident="rend" mode="replace" usage="opt">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="inkblot"></valItem>
+                                    <valItem ident="tear"></valItem>
+                                    <valItem ident="cut"></valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                    </elementSpec>
+
+                    <elementSpec ident="hi" mode="change" module="core">
+                        <attList>
+                            <attDef ident="rend" mode="replace" usage="req">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="hyphenated"></valItem>
+                                    <valItem ident="underline"></valItem>
+                                    <valItem ident="double-underline"></valItem>
+                                    <valItem ident="bold"></valItem>
+                                    <valItem ident="caps"></valItem>
+                                    <valItem ident="italic"></valItem>
+                                    <valItem ident="sup"></valItem>
+                                    <valItem ident="sub"></valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                        <remarks>
+                            <p>Attribute values adapted from the TEI P5 specification for the ENRICH
+                                project, http://enrich.manuscriptorium.com/</p>
+                        </remarks>
+                    </elementSpec>
+
+                    <elementSpec ident="add" mode="change" module="core">
+                        <attList>
+                            <attDef ident="place" mode="replace">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="superlinear"></valItem>
+                                    <valItem ident="intralinear"></valItem>
+                                    <valItem ident="sublinear"></valItem>
+                                    <valItem ident="interlinear"></valItem>
+                                </valList>
+                            </attDef>
+                            <attDef ident="type" mode="replace">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="alternative"></valItem>
+                                </valList>
+                            </attDef>
+                            <attDef ident="rend" mode="delete"></attDef>
+                            
+                        </attList>
+                    </elementSpec>
+
+                    <elementSpec ident="addSpan" mode="change" module="transcr">
+                        <classes mode="change">
+                            <memberOf key="att.responsibility" mode="add"></memberOf>
+                        </classes>
+                    </elementSpec>
+
+                    <elementSpec ident="delSpan" mode="change" module="transcr">
+                        <classes mode="change">
+                            <memberOf key="att.transcriptional" mode="delete"></memberOf>
+                            <memberOf key="att.responsibility" mode="add"></memberOf>
+                        </classes>
+                    </elementSpec>
+
+                    <elementSpec ident="del" mode="change" module="core">
+                        <attList>
+                            <attDef ident="rend" mode="replace">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="strikethrough"></valItem>
+                                    <valItem ident="overwritten"></valItem>
+                                    <valItem ident="smear"></valItem>
+                                    <valItem ident="erased"></valItem>
+                                    <valItem ident="vertical_line"></valItem>
+                                    <valItem ident="unmarked"></valItem>
+                                </valList>
+                            </attDef>
+                            <attDef ident="resp" mode="delete"></attDef>
+                            <attDef ident="hand" mode="delete"></attDef>
+                        </attList>
+                    </elementSpec>
+
+                    <elementSpec ident="milestone" mode="change" module="core">
+                        <attList>
+                            <attDef ident="unit" mode="replace" usage="req">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="tei:div"></valItem>
+                                    <valItem ident="tei:p"></valItem>
+                                    <valItem ident="tei:lg"></valItem>
+                                    <valItem ident="tei:l"></valItem>
+                                    <valItem ident="tei:date"></valItem>
+                                    <valItem ident="tei:speaker"></valItem>
+                                    <valItem ident="tei:q"></valItem>
+                                    <valItem ident="tei:stage"></valItem>
+                                    <valItem ident="tei:seg"></valItem>
+                                    <valItem ident="tei:note"></valItem>
+                                    <valItem ident="tei:head"></valItem>
+                                    <valItem ident="tei:div[@type='scene']"></valItem>
+                                    <valItem ident="tei:div[@type='act']"></valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                    </elementSpec>
+
+                    <elementSpec ident="zone" mode="change" module="transcr">
+                        <content>
+                            
+                            <alternate maxOccurs="unbounded" minOccurs="0">
+                                <textNode></textNode>
+                                <classRef key="model.graphicLike"></classRef>
+                                
+                                
+                                <classRef key="model.milestoneLike"></classRef>
+                                <classRef key="model.noteLike"></classRef>
+                                <classRef key="model.global.edit"></classRef>
+                                <elementRef key="metamark"></elementRef>
+                                
+                                <classRef key="model.linePart"></classRef>
+                                
+                                <elementRef key="alt"></elementRef>
+                            </alternate>
+                            
+                        </content>
+                        
+                        <attList>
+                            <attDef ident="type" mode="replace" usage="req">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="top">
+                                        <desc>Material that can appear at the top of a manuscript
+                                            page—like headings or notes</desc>
+                                    </valItem>
+                                    <valItem ident="left_margin">
+                                        <desc>Zone for marginal additions, deletions, and other
+                                            modifications. More than one zone with this type may
+                                            appear in a document if marginal zones are distinct
+                                            interventions.</desc>
+                                    </valItem>
+                                    <valItem ident="main">
+                                        <desc>The main block of text on a page</desc>
+                                    </valItem>
+                                    <valItem ident="pagination">
+                                        <desc>For segments of a page where page numbers have been
+                                            added in one or more original hands; distinct from later
+                                            additions by librarians/collectors</desc>
+                                    </valItem>
+                                    <valItem ident="library">
+                                        <desc>A zone of writing which appears to have been added by
+                                            librarians/collectors at a later date—often page
+                                            numbers</desc>
+                                    </valItem>
+                                    <valItem ident="sketch">
+                                        <desc>A zone identifying a sketch or doodle</desc>
+                                    </valItem>
+                                    <valItem ident="calculation">
+                                        <desc>A zone identifying a written calculation</desc>
+                                    </valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                    </elementSpec>
+
+                    <elementSpec ident="metamark" mode="change" module="transcr">
+                        <attList>
+                            <attDef ident="function" mode="replace">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="count"></valItem>
+                                    <valItem ident="insert"></valItem>
+                                    <valItem ident="separate"></valItem>
+                                    <valItem ident="paragraph"></valItem>
+                                    <valItem ident="displacement"></valItem>
+                                    <valItem ident="transpose"></valItem>
+                                    <valItem ident="sequence"></valItem>
+                                    <valItem ident="alternate"></valItem>
+                                    <valItem ident="unclear"></valItem>
+                                    <valItem ident="math_operation">
+                                        <desc>Perform a mathematical operation (e.g. a sum). Usually rendered a as line</desc>
+                                    </valItem>
+                                </valList>
+                            </attDef>
+                            <attDef ident="rend" mode="replace">
+                                <datatype>
+                                    <dataRef key="string"></dataRef>
+                                </datatype>
+                                <valList mode="replace" type="semi">
+                                    <valItem ident="line">
+                                        <desc>A line, often used to separate content.</desc>
+                                    </valItem>
+                                    <valItem ident="short_line">
+                                        <desc>A short line, similar to an underline, but often used to
+                                        separate content, not for emphasis (in which case hi[@rend="underline"] is used</desc>
+                                    </valItem>
+                                    <valItem ident="wavey_short_line">
+                                        <desc>A wavey short line, similar to an underline, but often used to
+                                            separate content, not for emphasis (in which case hi[@rend="underline"] is used</desc>
+                                    </valItem>
+                                    <valItem ident="left_bracket_short_line">
+                                        <desc>A line wrapping some text starting from the top left corner, then curving
+                                            to underline the text. Often used to separate content.</desc>
+                                    </valItem>
+                                    <valItem ident="short_vertical_line">
+                                        <desc>A short vertical line, often used inline to separate words or to indicate insertion.</desc>
+                                    </valItem>
+                                    <valItem ident="top_left_bracket">
+                                        <desc>A corner bracket located in the top left of a word.</desc>
+                                    </valItem>
+                                    <valItem ident="caret">
+                                        <desc>A caret pointing upwards. This is often encoded literally in SGA for convenience.
+                                        This value provides an alternative way of encoding it.</desc>
+                                    </valItem>
+                                    <valItem ident="left_caret">
+                                        <desc>A caret pointing left.</desc>
+                                    </valItem>
+                                    <valItem ident="cross">
+                                        <desc>A cross, often used for displacement. This is often encoded literally in SGA for convenience.
+                                            This value provides an alternative way of encoding it.</desc>
+                                    </valItem>
+                                    <valItem ident="star">
+                                        <desc>A star or asterisk, often used for displacement. This is often encoded literally in SGA for convenience.
+                                            This value provides an alternative way of encoding it.</desc>
+                                    </valItem>
+                                </valList>
+                            </attDef>
+                            
+                        </attList>
+                        <exemplum xml:lang="no"><egXML xmlns="http://www.tei-c.org/ns/Examples">
+                            <line><seg xml:id="tp-ib01">bör</seg><metamark function="transposition" place="above" rend="underline" target="#tp-ib01">2.</metamark>
+                                og <seg xml:id="tp-ib02">hör</seg><metamark function="transposition" place="above" rend="underline" target="#tp-ib02">1.</metamark></line></egXML></exemplum>
+                        
+                    </elementSpec>
+
+                    <elementSpec ident="mod" mode="change" module="transcr">
+                        <content>
+                            
+                            <alternate maxOccurs="unbounded" minOccurs="0">
+                                <classRef key="model.gLike"></classRef>
+                                <classRef key="model.phrase"></classRef>
+                                <classRef key="model.inter"></classRef>
+                                <classRef key="model.global"></classRef>
+                            </alternate>
+                        </content>
+                        <constraintSpec ident="modContents" scheme="isoschematron">
+                            <constraint>
+                                <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron" context="tei:mod">
+                                    <sch:report test="not(@spanTo) and not(tei:restore) and not(count(node()) gt 1)">The mod element is
+                                        intended to group a series of related changes to the
+                                        manuscript. Thus, mod must have more than one child
+                                        element. If only a single addition or deletion is being
+                                        encoded, mod is not required.</sch:report>
+                                </sch:rule>
+                            </constraint>
+                        </constraintSpec>
+                        <attList>
+                            <attDef ident="type" mode="replace" usage="opt">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="additions"></valItem>
+                                    <valItem ident="deletions"></valItem>
+                                </valList>
+                            </attDef>
+                            <attDef ident="xml:space" mode="replace" usage="opt">
+                                    <valList mode="replace" type="closed">
+                                        <valItem ident="preserve"/>
+                                    </valList>
+                                </attDef>
+                            
+                        </attList>
+                    </elementSpec>
+                    
+                    <elementSpec ident="ptr" mode="change" module="core">
+                        <constraintSpec ident="verify-ptr-targets" scheme="isoschematron">
+                            <constraint>
+                                
+                            </constraint>
+                        </constraintSpec>
+                    </elementSpec>
+                    
+               <elementSpec ident="subst" mode="change" module="transcr">
+                        <attList>
+                            <attDef ident="cause" mode="replace" usage="opt">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="clarify"></valItem>
+                                    <valItem ident="fix"></valItem>
+                                </valList>
+                            </attDef>
+                            <attDef ident="hand" mode="replace" usage="opt">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="#pbs"></valItem>
+                                    <valItem ident="#mws"></valItem>
+                                    <valItem ident="#library"></valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                    </elementSpec>
+                    
+                    <elementSpec ident="restore" mode="change" module="transcr">
+                        <attList>
+                            <attDef ident="type" mode="replace" usage="opt">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="stetdots"></valItem>
+                                    <valItem ident="smear_strikethrough"></valItem>
+                                    <valItem ident="underline"></valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                    </elementSpec>
+                    
+                    <elementSpec ident="seg" mode="change" module="linking">
+                        <attList>
+                            <attDef ident="type" mode="replace" usage="opt">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="alternative"></valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                    </elementSpec>
+                    
+                    <elementSpec ident="handShift" mode="change" module="transcr">
+                        <attList>
+                            <attDef ident="new" mode="replace" usage="req">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="#pbs"></valItem>
+                                    <valItem ident="#mws"></valItem>
+                                    <valItem ident="#library"></valItem>
+                                </valList>
+                            </attDef>
+                            <attDef ident="medium" mode="replace" usage="req">
+                                <valList mode="replace" type="closed">
+                                    <valItem ident="pen"></valItem>
+                                    <valItem ident="pencil"></valItem>
+                                </valList>
+                            </attDef>
+                        </attList>
+                    </elementSpec>                
+                    </specGrp>
+          
+          <specGrpRef target="#modules"></specGrpRef>
+          <moduleRef except="abbr analytic biblScope biblStruct              binaryObject cb choice cit distinct divGen editor email expan gb gloss              head headItem headLabel imprint l label lb listBibl lg measure              meeting mentioned monogr pb postBox postCode publisher              q quote said series soCalled sp street teiCorpus textLang time sic corr reg orig" key="core"></moduleRef>
+          <moduleRef key="header"></moduleRef>
+          <moduleRef key="textstructure"></moduleRef>
+          <moduleRef key="msdescription"></moduleRef>
+          <moduleRef key="namesdates"></moduleRef>
+          <specGrpRef target="#mainSpec"></specGrpRef>
+
+        </schemaSpec>
+      </div>
+    </body>
+  </text>
+</TEI>

--- a/data/odd/shelley-godwin-master.odd
+++ b/data/odd/shelley-godwin-master.odd
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="../derivatives/brown_odds.rnc" type="application/relax-ng-compact-syntax"?>
-<?xml-model href="../derivatives/brown_odds.isosch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!--<?xml-model href="../derivatives/brown_odds.rnc" type="application/relax-ng-compact-syntax"?>
+<?xml-model href="../derivatives/brown_odds.isosch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>-->
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:svg="http://www.w3.org/2000/svg"
   xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns="http://www.tei-c.org/ns/1.0"
   xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:ge="http://www.tei-c.org/ns/geneticEditions">
+  <!--2017-08-15 ebb: Updated ODD file for continued work on SGA file with Pgh-Frankenstein project. -->
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/data/odd/shelley-godwin-page.odd
+++ b/data/odd/shelley-godwin-page.odd
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="http://teijenkins.hcmc.uvic.ca/job/TEIP5-Pure-ODD/lastStableBuild/artifact/P5/release/xml/tei/custom/schema/relaxng/tei_all.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="http://teijenkins.hcmc.uvic.ca/job/TEIP5-Pure-ODD/lastStableBuild/artifact/P5/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!--<?xml-model href="http://teijenkins.hcmc.uvic.ca/job/TEIP5-Pure-ODD/lastStableBuild/artifact/P5/release/xml/tei/custom/schema/relaxng/tei_all.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://teijenkins.hcmc.uvic.ca/job/TEIP5-Pure-ODD/lastStableBuild/artifact/P5/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>-->
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
     xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+    <!--2017-08-15 ebb: Updated ODD file for continued work on SGA file with Pgh-Frankenstein project. -->
     <teiHeader>
         <fileDesc>
             <titleStmt>
                 <title>Encoding Guidelines</title>
-                <author>
-                    <persName xml:id="tmunoz">Trevor Mu&#241;oz</persName>
+                <author xml:id="tmunoz">
+                    Trevor Mu&#241;oz
                 </author>
             </titleStmt>
             <publicationStmt>
@@ -384,7 +388,11 @@
                     <classSpec ident="att.transcriptional" type="atts" mode="change">
                         <attList>
                             <attDef ident="status" mode="delete"/>
-                            <attDef ident="hand" mode="replace">
+                            
+                        </attList>
+                    </classSpec>
+                        <classSpec ident="att.written" type="atts" mode="change">
+                           <attList> <attDef ident="hand" mode="replace">
                                 <valList type="closed" mode="replace">
                                     <valItem ident="#pbs">
                                         <gloss>Percy Shelley's handwriting</gloss>
@@ -404,9 +412,8 @@
                                     </valItem>
                                     <valItem ident="http://viaf.org/viaf/95159449"/>
                                 </valList>
-                            </attDef>
-                        </attList>
-                    </classSpec>
+                            </attDef></attList>
+                        </classSpec>
 
                     <classSpec ident="att.global.linking" type="atts" mode="change">
                         <attList>

--- a/data/schemata/shelley_godwin_Pgh_odd.rng
+++ b/data/schemata/shelley_godwin_Pgh_odd.rng
@@ -1,0 +1,11682 @@
+<?xml version="1.0" encoding="utf-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:tei="http://www.tei-c.org/ns/1.0"
+         xmlns:teix="http://www.tei-c.org/ns/Examples"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+         ns="http://www.tei-c.org/ns/1.0"><!--
+Schema generated from ODD source 2017-08-16T00:47:32Z. .
+TEI Edition: Version 3.2.0. Last updated on
+	10th July 2017, revision 0fcf651
+TEI Edition Location: http://www.tei-c.org/Vault/P5/Version 3.2.0/
+  
+--><!--This code was updated by Elisa Beshero-Bondar, building on work copyrighted by Trevor Muñoz, Raffaele Viglianti, and Maryland Institute for Technology in the Humanities and licensed under a Creative Commons Attribution 3.0 Unported License.-->
+   <define name="sgamacro.paraContent">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+            <ref name="sgamodel.phrase"/>
+            <ref name="sgamodel.inter"/>
+            <ref name="sgamodel.global"/>
+        
+            <ref name="sgamodel.lLike"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.limitedContent">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.limitedPhrase"/>
+            <ref name="sgamodel.inter"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.phraseSeq">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+            <ref name="sgamodel.phrase"/>
+            <ref name="sgamodel.global"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.phraseSeq.limited">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.limitedPhrase"/>
+            <ref name="sgamodel.global"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.specialPara">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+            <ref name="sgamodel.phrase"/>
+            <ref name="sgamodel.inter"/>
+            <ref name="sgamodel.divPart"/>
+            <ref name="sgamodel.global"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="sgamacro.xtext">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="sgamodel.gLike"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="anyElement-xenoData">
+      <element>
+         <anyName>
+            <except>
+               <nsName ns="http://www.tei-c.org/ns/1.0"/>
+               <name ns="http://www.tei-c.org/ns/Examples">egXML</name>
+            </except>
+         </anyName>
+         <zeroOrMore>
+            <attribute>
+               <anyName/>
+            </attribute>
+         </zeroOrMore>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="anyElement-xenoData"/>
+            </choice>
+         </zeroOrMore>
+      </element>
+   </define>
+   <define name="sgaatt.ascribed.attributes">
+      <ref name="sgaatt.ascribed.attribute.who"/>
+   </define>
+   <define name="sgaatt.ascribed.attribute.who">
+      <optional>
+         <attribute name="who">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the person, or group of people, to whom the element content is ascribed.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.canonical.attributes">
+      <ref name="sgaatt.canonical.attribute.key"/>
+      <ref name="sgaatt.canonical.attribute.ref"/>
+   </define>
+   <define name="sgaatt.canonical.attribute.key">
+      <optional>
+         <attribute name="key">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides an externally-defined means of identifying the entity (or entities) being named, using a coded value of some kind.</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.canonical.attribute.ref">
+      <optional>
+         <attribute name="ref">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) provides an explicit means of locating a full definition or identity for the entity being named by means of one or more URIs.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attributes">
+      <ref name="sgaatt.ranging.attribute.atLeast"/>
+      <ref name="sgaatt.ranging.attribute.atMost"/>
+      <ref name="sgaatt.ranging.attribute.min"/>
+      <ref name="sgaatt.ranging.attribute.max"/>
+      <ref name="sgaatt.ranging.attribute.confidence"/>
+   </define>
+   <define name="sgaatt.ranging.attribute.atLeast">
+      <optional>
+         <attribute name="atLeast">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives a minimum estimated value for the approximate measurement.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.atMost">
+      <optional>
+         <attribute name="atMost">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives a maximum estimated value for the approximate measurement.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.min">
+      <optional>
+         <attribute name="min">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where the measurement summarizes more than one observation or a range, supplies the minimum value observed.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.max">
+      <optional>
+         <attribute name="max">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where the measurement summarizes more than one observation or a range, supplies the maximum value observed.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.ranging.attribute.confidence">
+      <optional>
+         <attribute name="confidence">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the degree of statistical confidence (between zero and one) that a value falls within the range specified by min and max, or the proportion of observed values that fall within that range.</a:documentation>
+            <data type="double"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attributes">
+      <ref name="sgaatt.ranging.attributes"/>
+      <ref name="sgaatt.dimensions.attribute.unit"/>
+      <ref name="sgaatt.dimensions.attribute.quantity"/>
+      <ref name="sgaatt.dimensions.attribute.extent"/>
+      <ref name="sgaatt.dimensions.attribute.precision"/>
+      <ref name="sgaatt.dimensions.attribute.scope"/>
+   </define>
+   <define name="sgaatt.dimensions.attribute.unit">
+      <optional>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">names the unit used for the measurement
+Suggested values include: 1] cm(centimetres) ; 2] mm(millimetres) ; 3] in(inches) ; 4] lines; 5] chars(characters) </a:documentation>
+            <choice>
+               <value>cm</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(centimetres) </a:documentation>
+               <value>mm</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(millimetres) </a:documentation>
+               <value>in</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(inches) </a:documentation>
+               <value>lines</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">lines of text</a:documentation>
+               <value>chars</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(characters) characters of text</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.quantity">
+      <optional>
+         <attribute name="quantity">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the length in the units specified</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.extent">
+      <optional>
+         <attribute name="extent">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the size of the object concerned using a project-specific vocabulary combining quantity and units in a single string of words.</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.precision">
+      <optional>
+         <attribute name="precision">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the precision of the values specified by the other attributes.</a:documentation>
+            <choice>
+               <value>high</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>medium</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>low</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>unknown</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.dimensions.attribute.scope">
+      <optional>
+         <attribute name="scope">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where the measurement summarizes more than one observation, specifies the applicability of this measurement.
+Sample values include: 1] all; 2] most; 3] range</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.written.attributes">
+      <ref name="sgaatt.written.attribute.hand"/>
+   </define>
+   <define name="sgaatt.written.attribute.hand">
+      <optional>
+         <attribute name="hand">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>#pbs</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Percy Shelley's handwriting) Text written in Percy Shelley's hand.</a:documentation>
+               <value>#mws</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Mary Shelley's handwriting) Text written in Mary Shelley's hand.</a:documentation>
+               <value>#comp</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(compositor's handwriting) Text written in an (unknown?) compositor's hand.</a:documentation>
+               <value>#library</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(librarian's handwriting) Text written in an (unknown?) librarian's hand.</a:documentation>
+               <value>http://viaf.org/viaf/95159449</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.damaged.attributes">
+      <ref name="sgaatt.dimensions.attributes"/>
+      <ref name="sgaatt.written.attributes"/>
+      <ref name="sgaatt.damaged.attribute.agent"/>
+      <ref name="sgaatt.damaged.attribute.degree"/>
+      <ref name="sgaatt.damaged.attribute.group"/>
+   </define>
+   <define name="sgaatt.damaged.attribute.agent">
+      <optional>
+         <attribute name="agent">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">categorizes the cause of the damage, if it can be identified.
+Sample values include: 1] rubbing; 2] mildew; 3] smoke</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.damaged.attribute.degree">
+      <optional>
+         <attribute name="degree">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a coded representation of the degree of damage, either as a number between 0 (undamaged) and 1 (very extensively damaged), or as one of the codes high, medium, low, or unknown. The damage element with the degree attribute should only be used where the text may be read with some confidence; text supplied from other sources should be tagged as supplied.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <choice>
+                  <value>high</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>medium</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>low</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unknown</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.damaged.attribute.group">
+      <optional>
+         <attribute name="group">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">assigns an arbitrary number to each stretch of damage regarded as forming part of the same physical phenomenon.</a:documentation>
+            <data type="nonNegativeInteger"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.breaking.attributes">
+      <ref name="sgaatt.breaking.attribute.break"/>
+   </define>
+   <define name="sgaatt.breaking.attribute.break">
+      <optional>
+         <attribute name="break">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether or not the element bearing this attribute should be considered to mark the end of an orthographic token in the same way as whitespace.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.cReferencing.attributes">
+      <ref name="sgaatt.cReferencing.attribute.cRef"/>
+   </define>
+   <define name="sgaatt.cReferencing.attribute.cRef">
+      <optional>
+         <attribute name="cRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(canonical reference) specifies the destination of the pointer by supplying a canonical reference expressed using the scheme defined in a refsDecl element in the TEI header</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attributes">
+      <ref name="sgaatt.datable.w3c.attribute.when"/>
+      <ref name="sgaatt.datable.w3c.attribute.notBefore"/>
+      <ref name="sgaatt.datable.w3c.attribute.notAfter"/>
+      <ref name="sgaatt.datable.w3c.attribute.from"/>
+      <ref name="sgaatt.datable.w3c.attribute.to"/>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.when">
+      <optional>
+         <attribute name="when">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of the date or time in a standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.notBefore">
+      <optional>
+         <attribute name="notBefore">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the earliest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.notAfter">
+      <optional>
+         <attribute name="notAfter">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the latest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.from">
+      <optional>
+         <attribute name="from">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the starting point of the period in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.w3c.attribute.to">
+      <optional>
+         <attribute name="to">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the ending point of the period in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable.w3c-att-datable-w3c-when-constraint-rule-1">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@when]">
+        <sch:report test="@notBefore|@notAfter|@from|@to" role="nonfatal">The @when attribute cannot be used with any other att.datable.w3c attributes.</sch:report>
+      </sch:rule>
+   </pattern>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable.w3c-att-datable-w3c-from-constraint-rule-2">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@from]">
+        <sch:report test="@notBefore" role="nonfatal">The @from and @notBefore attributes cannot be used together.</sch:report>
+      </sch:rule>
+   </pattern>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable.w3c-att-datable-w3c-to-constraint-rule-3">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@to]">
+        <sch:report test="@notAfter" role="nonfatal">The @to and @notAfter attributes cannot be used together.</sch:report>
+      </sch:rule>
+   </pattern>
+   <define name="sgaatt.datable.attributes">
+      <ref name="sgaatt.datable.w3c.attributes"/>
+      <ref name="sgaatt.datable.iso.attributes"/>
+      <ref name="sgaatt.datable.custom.attributes"/>
+      <ref name="sgaatt.datable.attribute.calendar"/>
+      <ref name="sgaatt.datable.attribute.period"/>
+   </define>
+   <define name="sgaatt.datable.attribute.calendar">
+      <optional>
+         <attribute name="calendar">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the system or calendar to which the date represented by the content of this element belongs.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.datable-calendar-calendar-constraint-rule-4">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@calendar]">
+            <sch:assert test="string-length(.) gt 0">
+@calendar indicates the system or calendar to which the date represented by the content of this element
+belongs, but this <sch:name/> element has no textual content.</sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.datable.attribute.period">
+      <optional>
+         <attribute name="period">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to some location defining a named period of time within which the datable item is understood to have occurred.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datcat.attributes">
+      <ref name="sgaatt.datcat.attribute.datcat"/>
+      <ref name="sgaatt.datcat.attribute.valueDatcat"/>
+   </define>
+   <define name="sgaatt.datcat.attribute.datcat">
+      <optional>
+         <attribute name="datcat" ns="http://www.isocat.org/ns/dcr">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a PID (persistent identifier) that aligns the given element with the appropriate Data Category (or categories) in ISOcat.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datcat.attribute.valueDatcat">
+      <optional>
+         <attribute name="valueDatcat" ns="http://www.isocat.org/ns/dcr">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a PID (persistent identifier) that aligns the content of the given element or the value of the given attribute with the appropriate simple Data Category (or categories) in ISOcat.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.declarable.attributes">
+      <ref name="sgaatt.declarable.attribute.default"/>
+   </define>
+   <define name="sgaatt.declarable.attribute.default">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="default"
+                    a:defaultValue="false">
+            <a:documentation>indicates whether or not this element is selected by default when its parent is selected.</a:documentation>
+            <choice>
+               <value>true</value>
+               <a:documentation>This element is selected if its parent is selected</a:documentation>
+               <value>false</value>
+               <a:documentation>This element can only be selected explicitly, unless it is the only one of its kind, in which case it is selected if its parent is selected.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.fragmentable.attributes">
+      <ref name="sgaatt.fragmentable.attribute.part"/>
+   </define>
+   <define name="sgaatt.fragmentable.attribute.part">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="part"
+                    a:defaultValue="N">
+            <a:documentation>specifies whether or not its parent element is fragmented in some way, typically by some other overlapping structure: for example a speech which is divided between two or more verse stanzas, a paragraph which is split across a page division, a verse line which is divided between two speakers.</a:documentation>
+            <choice>
+               <value>Y</value>
+               <a:documentation>(yes) the element is fragmented in some (unspecified) respect</a:documentation>
+               <value>N</value>
+               <a:documentation>(no) the element is not fragmented, or no claim is made as to its completeness</a:documentation>
+               <value>I</value>
+               <a:documentation>(initial) this is the initial part of a fragmented element</a:documentation>
+               <value>M</value>
+               <a:documentation>(medial) this is a medial part of a fragmented element</a:documentation>
+               <value>F</value>
+               <a:documentation>(final) this is the final part of a fragmented element</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.divLike.attributes">
+      <ref name="sgaatt.fragmentable.attributes"/>
+      <ref name="sgaatt.divLike.attribute.org"/>
+      <ref name="sgaatt.divLike.attribute.sample"/>
+   </define>
+   <define name="sgaatt.divLike.attribute.org">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="org"
+                    a:defaultValue="uniform">
+            <a:documentation>(organization) specifies how the content of the division is organized.</a:documentation>
+            <choice>
+               <value>composite</value>
+               <a:documentation>no claim is made about the sequence in which the immediate contents of this division are to be processed, or their inter-relationships.</a:documentation>
+               <value>uniform</value>
+               <a:documentation>the immediate contents of this element are regarded as forming a logical unit, to be processed in sequence.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.divLike.attribute.sample">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="sample"
+                    a:defaultValue="complete">
+            <a:documentation>indicates whether this division is a sample of the original source and if so, from which part.</a:documentation>
+            <choice>
+               <value>initial</value>
+               <a:documentation>division lacks material present at end in source.</a:documentation>
+               <value>medial</value>
+               <a:documentation>division lacks material at start and end.</a:documentation>
+               <value>final</value>
+               <a:documentation>division lacks material at start.</a:documentation>
+               <value>unknown</value>
+               <a:documentation>position of sampled material within original unknown.</a:documentation>
+               <value>complete</value>
+               <a:documentation>division is not a sample.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.docStatus.attributes">
+      <ref name="sgaatt.docStatus.attribute.status"/>
+   </define>
+   <define name="sgaatt.docStatus.attribute.status">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="status"
+                    a:defaultValue="draft">
+            <a:documentation>describes the status of a document either currently or, when associated with a dated element, at the time indicated.
+Sample values include: 1] approved; 2] candidate; 3] cleared; 4] deprecated; 5] draft; 6] embargoed; 7] expired; 8] frozen; 9] galley; 10] proposed; 11] published; 12] recommendation; 13] submitted; 14] unfinished; 15] withdrawn</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.responsibility.attributes">
+      <ref name="sgaatt.global.responsibility.attribute.cert"/>
+      <ref name="sgaatt.global.responsibility.attribute.resp"/>
+   </define>
+   <define name="sgaatt.global.responsibility.attribute.cert">
+      <optional>
+         <attribute name="cert">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(certainty) signifies the degree of certainty associated with the intervention or interpretation.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <choice>
+                  <value>high</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>medium</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>low</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unknown</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.responsibility.attribute.resp">
+      <optional>
+         <attribute name="resp">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsible party) indicates the agency responsible for the intervention or interpretation, for example an editor or transcriber.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.editLike.attributes">
+      <ref name="sgaatt.dimensions.attributes"/>
+      <ref name="sgaatt.editLike.attribute.evidence"/>
+      <ref name="sgaatt.editLike.attribute.instant"/>
+   </define>
+   <define name="sgaatt.editLike.attribute.evidence">
+      <optional>
+         <attribute name="evidence">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the nature of the evidence supporting the reliability or accuracy of the intervention or interpretation.
+Suggested values include: 1] internal; 2] external; 3] conjecture</a:documentation>
+            <list>
+               <oneOrMore>
+                  <choice>
+                     <value>internal</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">there is internal evidence to support the intervention.</a:documentation>
+                     <value>external</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">there is external evidence to support the intervention.</a:documentation>
+                     <value>conjecture</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the intervention or interpretation has been made by the editor, cataloguer, or scholar on the basis of their expertise.</a:documentation>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </choice>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.editLike.attribute.instant">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="instant"
+                    a:defaultValue="false">
+            <a:documentation>indicates whether this is an instant revision or not.</a:documentation>
+            <choice>
+               <data type="boolean"/>
+               <choice>
+                  <value>unknown</value>
+                  <a:documentation/>
+                  <value>inapplicable</value>
+                  <a:documentation/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.rendition.attributes">
+      <ref name="sgaatt.global.rendition.attribute.rend"/>
+      <ref name="sgaatt.global.rendition.attribute.style"/>
+      <ref name="sgaatt.global.rendition.attribute.rendition"/>
+   </define>
+   <define name="sgaatt.global.rendition.attribute.rend">
+      <optional>
+         <attribute name="rend">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rendition) indicates how the element in question was rendered or presented in the source text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.rendition.attribute.style">
+      <optional>
+         <attribute name="style">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an expression in some formal style definition language which defines the rendering or presentation used for this element in the source text</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.rendition.attribute.rendition">
+      <optional>
+         <attribute name="rendition">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a description of the rendering or presentation used for this element in the source text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.source.attributes">
+      <ref name="sgaatt.global.source.attribute.source"/>
+   </define>
+   <define name="sgaatt.global.source.attribute.source">
+      <optional>
+         <attribute name="source">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the source from which some aspect of this element is drawn.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attributes">
+      <ref name="sgaatt.global.rendition.attributes"/>
+      <ref name="sgaatt.global.linking.attributes"/>
+      <ref name="sgaatt.global.facs.attributes"/>
+      <ref name="sgaatt.global.responsibility.attributes"/>
+      <ref name="sgaatt.global.source.attributes"/>
+      <ref name="sgaatt.global.attribute.el-target"/>
+      <ref name="sgaatt.global.attribute.att-target"/>
+      <ref name="sgaatt.global.attribute.att-value"/>
+      <ref name="sgaatt.global.attribute.xmlid"/>
+      <ref name="sgaatt.global.attribute.n"/>
+      <ref name="sgaatt.global.attribute.xmllang"/>
+      <ref name="sgaatt.global.attribute.xmlbase"/>
+      <ref name="sgaatt.global.attribute.xmlspace"/>
+   </define>
+   <define name="sgaatt.global.attribute.el-target">
+      <optional>
+         <attribute name="el-target" ns="http://shelleygodwinarchive.org/ns/1.0">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A convenience attribute for indicating what text-centric element a document-centric element should be transformed to</a:documentation>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.att-target">
+      <optional>
+         <attribute name="att-target" ns="http://shelleygodwinarchive.org/ns/1.0">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A convenience attribute for indicating what attribute should be added in transforming from document- to text-centric markup. By convention the attribute is placed on the element specified in a preceding el-target attribute</a:documentation>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.att-value">
+      <optional>
+         <attribute name="att-value" ns="http://shelleygodwinarchive.org/ns/1.0">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If an attribute created during a document- to text-centric markup conversion should have a particular value, please indicate</a:documentation>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmlid">
+      <optional>
+         <attribute name="xml:id">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) provides a unique identifier for the element bearing the attribute.</a:documentation>
+            <data type="ID"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.n">
+      <optional>
+         <attribute name="n">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) gives a number (or other label) for an element, which is not necessarily unique within the document.</a:documentation>
+            <data type="string"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmllang">
+      <optional>
+         <attribute name="xml:lang">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language) indicates the language of the element content using a tag generated according to BCP 47.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmlbase">
+      <optional>
+         <attribute name="xml:base">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a base URI reference with which applications can resolve relative URI references into absolute URI references.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.attribute.xmlspace">
+      <optional>
+         <attribute name="xml:space">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">signals an intention about how white space should be managed by applications.</a:documentation>
+            <choice>
+               <value>default</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">signals that the application's default white-space processing modes are acceptable</a:documentation>
+               <value>preserve</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the intent that applications preserve all white space</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attributes">
+      <ref name="sgaatt.handFeatures.attribute.scribe"/>
+      <ref name="sgaatt.handFeatures.attribute.scribeRef"/>
+      <ref name="sgaatt.handFeatures.attribute.script"/>
+      <ref name="sgaatt.handFeatures.attribute.scriptRef"/>
+      <ref name="sgaatt.handFeatures.attribute.medium"/>
+      <ref name="sgaatt.handFeatures.attribute.scope"/>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scribe">
+      <optional>
+         <attribute name="scribe">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives a name or other identifier for the scribe believed to be responsible for this hand.</a:documentation>
+            <data type="Name"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scribeRef">
+      <optional>
+         <attribute name="scribeRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a full description of the scribe concerned, typically supplied by a person element elsewhere in the description.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.script">
+      <optional>
+         <attribute name="script">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the particular script or writing style used by this hand, for example secretary, copperplate, Chancery, Italian, etc.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="Name"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scriptRef">
+      <optional>
+         <attribute name="scriptRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a full description of the script or writing style used by this hand, typically supplied by a scriptNote element elsewhere in the description.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.medium">
+      <optional>
+         <attribute name="medium">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the tint or type of ink, e.g. brown, or other writing medium, e.g. pencil</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.handFeatures.attribute.scope">
+      <optional>
+         <attribute name="scope">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies how widely this hand is used in the manuscript.</a:documentation>
+            <choice>
+               <value>sole</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">only this hand is used throughout the manuscript</a:documentation>
+               <value>major</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">this hand is used through most of the manuscript</a:documentation>
+               <value>minor</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">this hand is used occasionally in the manuscript</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.internetMedia.attributes">
+      <ref name="sgaatt.internetMedia.attribute.mimeType"/>
+   </define>
+   <define name="sgaatt.internetMedia.attribute.mimeType">
+      <optional>
+         <attribute name="mimeType">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.media.attributes">
+      <ref name="sgaatt.internetMedia.attributes"/>
+      <ref name="sgaatt.media.attribute.width"/>
+      <ref name="sgaatt.media.attribute.height"/>
+      <ref name="sgaatt.media.attribute.scale"/>
+   </define>
+   <define name="sgaatt.media.attribute.width">
+      <optional>
+         <attribute name="width">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates the display width</a:documentation>
+            <data type="token">
+               <param name="pattern">[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|gd|rem|vw|vh|vm)</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.media.attribute.height">
+      <optional>
+         <attribute name="height">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates the display height</a:documentation>
+            <data type="token">
+               <param name="pattern">[\-+]?\d+(\.\d+)?(%|cm|mm|in|pt|pc|px|em|ex|gd|rem|vw|vh|vm)</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.media.attribute.scale">
+      <optional>
+         <attribute name="scale">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the media are displayed, indicates a scale factor to be applied when generating the desired display size</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.resourced.attributes">
+      <ref name="sgaatt.resourced.attribute.url"/>
+   </define>
+   <define name="sgaatt.resourced.attribute.url">
+      <attribute name="url">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(uniform resource locator) specifies the URL from which the media concerned may be obtained.</a:documentation>
+         <data type="anyURI"/>
+      </attribute>
+   </define>
+   <define name="sgaatt.measurement.attributes">
+      <ref name="sgaatt.measurement.attribute.unit"/>
+      <ref name="sgaatt.measurement.attribute.quantity"/>
+      <ref name="sgaatt.measurement.attribute.commodity"/>
+   </define>
+   <define name="sgaatt.measurement.attribute.unit">
+      <optional>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the units used for the measurement, usually using the standard symbol for the desired units.
+Suggested values include: 1] m(metre) ; 2] kg(kilogram) ; 3] s(second) ; 4] Hz(hertz) ; 5] Pa(pascal) ; 6] Ω(ohm) ; 7] L(litre) ; 8] t(tonne) ; 9] ha(hectare) ; 10] Å(ångström) ; 11] mL(millilitre) ; 12] cm(centimetre) ; 13] dB(decibel) ; 14] kbit(kilobit) ; 15] Kibit(kibibit) ; 16] kB(kilobyte) ; 17] KiB(kibibyte) ; 18] MB(megabyte) ; 19] MiB(mebibyte) </a:documentation>
+            <choice>
+               <value>m</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(metre) SI base unit of length</a:documentation>
+               <value>kg</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kilogram) SI base unit of mass</a:documentation>
+               <value>s</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(second) SI base unit of time</a:documentation>
+               <value>Hz</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(hertz) SI unit of frequency</a:documentation>
+               <value>Pa</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pascal) SI unit of pressure or stress</a:documentation>
+               <value>Ω</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ohm) SI unit of electric resistance</a:documentation>
+               <value>L</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(litre) 1 dm³</a:documentation>
+               <value>t</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(tonne) 10³ kg</a:documentation>
+               <value>ha</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(hectare) 1 hm²</a:documentation>
+               <value>Å</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ångström) 10⁻¹⁰ m</a:documentation>
+               <value>mL</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(millilitre) </a:documentation>
+               <value>cm</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(centimetre) </a:documentation>
+               <value>dB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(decibel) see remarks, below</a:documentation>
+               <value>kbit</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kilobit) 10³ or 1000 bits</a:documentation>
+               <value>Kibit</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kibibit) 2¹⁰ or 1024 bits</a:documentation>
+               <value>kB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kilobyte) 10³ or 1000 bytes</a:documentation>
+               <value>KiB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(kibibyte) 2¹⁰ or 1024 bytes</a:documentation>
+               <value>MB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(megabyte) 10⁶ or 1 000 000 bytes</a:documentation>
+               <value>MiB</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(mebibyte) 2²⁰ or 1 048 576 bytes</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.measurement.attribute.quantity">
+      <optional>
+         <attribute name="quantity">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of the specified units that comprise the measurement</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.measurement.attribute.commodity">
+      <optional>
+         <attribute name="commodity">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the substance that is being measured</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.naming.attributes">
+      <ref name="sgaatt.canonical.attributes"/>
+      <ref name="sgaatt.naming.attribute.role"/>
+      <ref name="sgaatt.naming.attribute.nymRef"/>
+   </define>
+   <define name="sgaatt.naming.attribute.role">
+      <optional>
+         <attribute name="role">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">may be used to specify further information about the entity referenced by this name in the form of a set of whitespace-separated values, for example the occupation of a person, or the status of a place.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.naming.attribute.nymRef">
+      <optional>
+         <attribute name="nymRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference to the canonical name) provides a means of locating the canonical form (nym) of the names associated with the object named by the element bearing it.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.placement.attributes">
+      <ref name="sgaatt.placement.attribute.place"/>
+   </define>
+   <define name="sgaatt.placement.attribute.place">
+      <optional>
+         <attribute name="place">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies where this item is placed.
+Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6] overleaf; 7] above; 8] end; 9] inline; 10] inspace</a:documentation>
+            <list>
+               <oneOrMore>
+                  <choice>
+                     <value>below</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">below the line</a:documentation>
+                     <value>bottom</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">at the foot of the page</a:documentation>
+                     <value>margin</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in the margin (left, right, or both)</a:documentation>
+                     <value>top</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">at the top of the page</a:documentation>
+                     <value>opposite</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">on the opposite, i.e. facing, page</a:documentation>
+                     <value>overleaf</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">on the other side of the leaf</a:documentation>
+                     <value>above</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">above the line</a:documentation>
+                     <value>end</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">at the end of e.g. chapter or volume.</a:documentation>
+                     <value>inline</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">within the body of the text.</a:documentation>
+                     <value>inspace</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in a predefined space, for example left by an earlier scribe.</a:documentation>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </choice>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.typed.attributes">
+      <ref name="sgaatt.typed.attribute.type"/>
+      <ref name="sgaatt.typed.attribute.subtype"/>
+   </define>
+   <define name="sgaatt.typed.attribute.type">
+      <optional>
+         <attribute name="type">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.typed.attribute.subtype">
+      <optional>
+         <attribute name="subtype">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a sub-categorization of the element, if needed</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.typed-subtypeTyped-constraint-rule-5">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@subtype]">
+        <sch:assert test="@type">The <sch:name/> element should not be categorized in detail with @subtype unless also categorized in general with @type</sch:assert>
+      </sch:rule>
+   </pattern>
+   <define name="sgaatt.pointing.attributes">
+      <ref name="sgaatt.pointing.attribute.targetLang"/>
+      <ref name="sgaatt.pointing.attribute.target"/>
+      <ref name="sgaatt.pointing.attribute.evaluate"/>
+   </define>
+   <define name="sgaatt.pointing.attribute.targetLang">
+      <optional>
+         <attribute name="targetLang">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the language of the content to be found at the destination referenced by target, using a language tag generated according to BCP 47.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.pointing-targetLang-targetLang-constraint-rule-6">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[not(self::tei:schemaSpec)][@targetLang]">
+            <sch:assert test="@target">@targetLang should only be used on <sch:name/> if @target is specified.</sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.pointing.attribute.target">
+      <optional>
+         <attribute name="target">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the destination of the reference by supplying one or more URI References</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.pointing.attribute.evaluate">
+      <optional>
+         <attribute name="evaluate">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the intended meaning when the target of a pointer is itself a pointer.</a:documentation>
+            <choice>
+               <value>all</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">if the element pointed to is itself a pointer, then the target of that pointer will be taken, and so on, until an element is found which is not a pointer.</a:documentation>
+               <value>one</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">if the element pointed to is itself a pointer, then its target (whether a pointer or not) is taken as the target of this pointer.</a:documentation>
+               <value>none</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">no further evaluation of targets is carried out beyond that needed to find the element specified in the pointer's target.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.pointing.group.attributes">
+      <ref name="sgaatt.pointing.attributes"/>
+      <ref name="sgaatt.typed.attributes"/>
+      <ref name="sgaatt.pointing.group.attribute.domains"/>
+      <ref name="sgaatt.pointing.group.attribute.targFunc"/>
+   </define>
+   <define name="sgaatt.pointing.group.attribute.domains">
+      <optional>
+         <attribute name="domains">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">optionally specifies the identifiers of the elements within which all elements indicated by the contents of this element lie.</a:documentation>
+            <list>
+               <data type="anyURI"/>
+               <data type="anyURI"/>
+               <zeroOrMore>
+                  <data type="anyURI"/>
+               </zeroOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.pointing.group.attribute.targFunc">
+      <optional>
+         <attribute name="targFunc">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(target function) describes the function of each of the values of the target attribute of the enclosed link, join, or alt tags.</a:documentation>
+            <list>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+               <zeroOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </zeroOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.segLike.attributes">
+      <ref name="sgaatt.datcat.attributes"/>
+      <ref name="sgaatt.fragmentable.attributes"/>
+      <ref name="sgaatt.segLike.attribute.function"/>
+   </define>
+   <define name="sgaatt.segLike.attribute.function">
+      <optional>
+         <attribute name="function">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the function of the segment.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.sortable.attributes">
+      <ref name="sgaatt.sortable.attribute.sortKey"/>
+   </define>
+   <define name="sgaatt.sortable.attribute.sortKey">
+      <optional>
+         <attribute name="sortKey">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the sort key for this element in an index, list or group which contains it.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.edition.attributes">
+      <ref name="sgaatt.edition.attribute.ed"/>
+      <ref name="sgaatt.edition.attribute.edRef"/>
+   </define>
+   <define name="sgaatt.edition.attribute.ed">
+      <optional>
+         <attribute name="ed">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition) supplies a sigil or other arbitrary identifier for the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.edition.attribute.edRef">
+      <optional>
+         <attribute name="edRef">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition reference) provides a pointer to the source edition in which the associated feature (for example, a page, column, or line break) occurs at this point in the text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.spanning.attributes">
+      <ref name="sgaatt.spanning.attribute.spanTo"/>
+   </define>
+   <define name="sgaatt.spanning.attribute.spanTo">
+      <optional>
+         <attribute name="spanTo">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the end of a span initiated by the element bearing this attribute.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.spanning-spanTo-spanTo-2-constraint-rule-7">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@spanTo]">
+            <sch:assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]">
+The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow the current element <sch:name/>
+                  </sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.styleDef.attributes">
+      <ref name="sgaatt.styleDef.attribute.scheme"/>
+      <ref name="sgaatt.styleDef.attribute.schemeVersion"/>
+   </define>
+   <define name="sgaatt.styleDef.attribute.scheme">
+      <optional>
+         <attribute name="scheme">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the language used to describe the rendition.</a:documentation>
+            <choice>
+               <value>css</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Cascading Stylesheet Language</a:documentation>
+               <value>xslfo</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Extensible Stylesheet Language Formatting Objects</a:documentation>
+               <value>free</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Informal free text description</a:documentation>
+               <value>other</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A user-defined rendition description language</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.styleDef.attribute.schemeVersion">
+      <optional>
+         <attribute name="schemeVersion">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a version number for the style language provided in scheme.</a:documentation>
+            <data type="token">
+               <param name="pattern">[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+            id="shelley_godwin_odd-att.styleDef-schemeVersion-schemeVersionRequiresScheme-constraint-rule-8">
+      <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="tei:*[@schemeVersion]">
+            <sch:assert test="@scheme and not(@scheme = 'free')">
+              @schemeVersion can only be used if @scheme is specified.
+            </sch:assert>
+          </sch:rule>
+   </pattern>
+   <define name="sgaatt.timed.attributes">
+      <ref name="sgaatt.timed.attribute.start"/>
+      <ref name="sgaatt.timed.attribute.end"/>
+   </define>
+   <define name="sgaatt.timed.attribute.start">
+      <optional>
+         <attribute name="start">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location within a temporal alignment at which this element begins.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.timed.attribute.end">
+      <optional>
+         <attribute name="end">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location within a temporal alignment at which this element ends.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.transcriptional.attributes">
+      <ref name="sgaatt.editLike.attributes"/>
+      <ref name="sgaatt.written.attributes"/>
+      <ref name="sgaatt.transcriptional.attribute.cause"/>
+      <ref name="sgaatt.transcriptional.attribute.seq"/>
+   </define>
+   <define name="sgaatt.transcriptional.attribute.cause">
+      <optional>
+         <attribute name="cause">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">documents the presumed cause for the intervention.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.transcriptional.attribute.seq">
+      <optional>
+         <attribute name="seq">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sequence) assigns a sequence number related to the order in which the encoded features carrying this attribute are believed to have occurred.</a:documentation>
+            <data type="nonNegativeInteger"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.translatable.attributes">
+      <ref name="sgaatt.translatable.attribute.versionDate"/>
+   </define>
+   <define name="sgaatt.translatable.attribute.versionDate">
+      <optional>
+         <attribute name="versionDate">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the date on which the source text was extracted and sent to the translator</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.citing.attributes">
+      <ref name="sgaatt.citing.attribute.unit"/>
+      <ref name="sgaatt.citing.attribute.from"/>
+      <ref name="sgaatt.citing.attribute.to"/>
+   </define>
+   <define name="sgaatt.citing.attribute.unit">
+      <optional>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the unit of information conveyed by the element, e.g. columns, pages, volume, entry.
+Suggested values include: 1] volume; 2] issue; 3] page; 4] line; 5] chapter; 6] part; 7] column; 8] entry</a:documentation>
+            <choice>
+               <value>volume</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a volume number.</a:documentation>
+               <value>issue</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains an issue number, or volume and issue numbers.</a:documentation>
+               <value>page</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a page number or page range.</a:documentation>
+               <value>line</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a line number or line range.</a:documentation>
+               <value>chapter</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element contains a chapter indication (number and/or title)</a:documentation>
+               <value>part</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a part of a book or collection.</a:documentation>
+               <value>column</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies an entry number or label in a list of entries.</a:documentation>
+               <value>entry</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the element identifies a column.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.citing.attribute.from">
+      <optional>
+         <attribute name="from">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the starting point of the range of units indicated by the unit attribute.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.citing.attribute.to">
+      <optional>
+         <attribute name="to">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the end-point of the range of units indicated by the unit attribute.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamodel.nameLike.agent">
+      <choice>
+         <ref name="sganame"/>
+         <ref name="sgaorgName"/>
+         <ref name="sgapersName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike.agent_alternation">
+      <choice>
+         <ref name="sganame"/>
+         <ref name="sgaorgName"/>
+         <ref name="sgapersName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequence">
+      <ref name="sganame"/>
+      <ref name="sgaorgName"/>
+      <ref name="sgapersName"/>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequenceOptional">
+      <optional>
+         <ref name="sganame"/>
+      </optional>
+      <optional>
+         <ref name="sgaorgName"/>
+      </optional>
+      <optional>
+         <ref name="sgapersName"/>
+      </optional>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sganame"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaorgName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgapersName"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.nameLike.agent_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sganame"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaorgName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgapersName"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.segLike">
+      <choice>
+         <ref name="sgaseg"/>
+         <ref name="sgac"/>
+      </choice>
+   </define>
+   <define name="sgamodel.hiLike">
+      <choice>
+         <ref name="sgahi"/>
+      </choice>
+   </define>
+   <define name="sgamodel.hiLike_alternation">
+      <choice>
+         <ref name="sgahi"/>
+      </choice>
+   </define>
+   <define name="sgamodel.hiLike_sequence">
+      <ref name="sgahi"/>
+   </define>
+   <define name="sgamodel.hiLike_sequenceOptional">
+      <optional>
+         <ref name="sgahi"/>
+      </optional>
+   </define>
+   <define name="sgamodel.hiLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgahi"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.hiLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgahi"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.emphLike">
+      <choice>
+         <ref name="sgaforeign"/>
+         <ref name="sgaemph"/>
+         <ref name="sgaterm"/>
+         <ref name="sgatitle"/>
+      </choice>
+   </define>
+   <define name="sgamodel.emphLike_alternation">
+      <choice>
+         <ref name="sgaforeign"/>
+         <ref name="sgaemph"/>
+         <ref name="sgaterm"/>
+         <ref name="sgatitle"/>
+      </choice>
+   </define>
+   <define name="sgamodel.emphLike_sequence">
+      <ref name="sgaforeign"/>
+      <ref name="sgaemph"/>
+      <ref name="sgaterm"/>
+      <ref name="sgatitle"/>
+   </define>
+   <define name="sgamodel.emphLike_sequenceOptional">
+      <optional>
+         <ref name="sgaforeign"/>
+      </optional>
+      <optional>
+         <ref name="sgaemph"/>
+      </optional>
+      <optional>
+         <ref name="sgaterm"/>
+      </optional>
+      <optional>
+         <ref name="sgatitle"/>
+      </optional>
+   </define>
+   <define name="sgamodel.emphLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaforeign"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaemph"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaterm"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgatitle"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.emphLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaforeign"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaemph"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaterm"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgatitle"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.highlighted">
+      <choice>
+         <ref name="sgamodel.hiLike"/>
+         <ref name="sgamodel.emphLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.dateLike">
+      <choice>
+         <ref name="sgadate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.dateLike_alternation">
+      <choice>
+         <ref name="sgadate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.dateLike_sequence">
+      <ref name="sgadate"/>
+   </define>
+   <define name="sgamodel.dateLike_sequenceOptional">
+      <optional>
+         <ref name="sgadate"/>
+      </optional>
+   </define>
+   <define name="sgamodel.dateLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgadate"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.dateLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgadate"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.dimLike">
+      <choice>
+         <ref name="sgaheight"/>
+         <ref name="sgadepth"/>
+         <ref name="sgawidth"/>
+      </choice>
+   </define>
+   <define name="sgamodel.measureLike">
+      <choice>
+         <ref name="sganum"/>
+         <ref name="sgameasureGrp"/>
+         <ref name="sgadim"/>
+         <ref name="sgaheight"/>
+         <ref name="sgadepth"/>
+         <ref name="sgawidth"/>
+         <ref name="sgageo"/>
+      </choice>
+   </define>
+   <define name="sgamodel.measureLike_alternation">
+      <choice>
+         <ref name="sganum"/>
+         <ref name="sgameasureGrp"/>
+         <ref name="sgadim"/>
+         <ref name="sgaheight"/>
+         <ref name="sgadepth"/>
+         <ref name="sgawidth"/>
+         <ref name="sgageo"/>
+      </choice>
+   </define>
+   <define name="sgamodel.measureLike_sequence">
+      <ref name="sganum"/>
+      <ref name="sgameasureGrp"/>
+      <ref name="sgadim"/>
+      <ref name="sgaheight"/>
+      <ref name="sgadepth"/>
+      <ref name="sgawidth"/>
+      <ref name="sgageo"/>
+   </define>
+   <define name="sgamodel.measureLike_sequenceOptional">
+      <optional>
+         <ref name="sganum"/>
+      </optional>
+      <optional>
+         <ref name="sgameasureGrp"/>
+      </optional>
+      <optional>
+         <ref name="sgadim"/>
+      </optional>
+      <optional>
+         <ref name="sgaheight"/>
+      </optional>
+      <optional>
+         <ref name="sgadepth"/>
+      </optional>
+      <optional>
+         <ref name="sgawidth"/>
+      </optional>
+      <optional>
+         <ref name="sgageo"/>
+      </optional>
+   </define>
+   <define name="sgamodel.measureLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sganum"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgameasureGrp"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadim"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaheight"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadepth"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgawidth"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgageo"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.measureLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sganum"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgameasureGrp"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadim"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaheight"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadepth"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgawidth"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgageo"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.egLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.egLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.egLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.egLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.egLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.egLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.graphicLike">
+      <choice>
+         <ref name="sgamedia"/>
+         <ref name="sgagraphic"/>
+      </choice>
+   </define>
+   <define name="sgamodel.offsetLike">
+      <choice>
+         <ref name="sgaoffset"/>
+         <ref name="sgageogFeat"/>
+      </choice>
+   </define>
+   <define name="sgamodel.offsetLike_alternation">
+      <choice>
+         <ref name="sgaoffset"/>
+         <ref name="sgageogFeat"/>
+      </choice>
+   </define>
+   <define name="sgamodel.offsetLike_sequence">
+      <ref name="sgaoffset"/>
+      <ref name="sgageogFeat"/>
+   </define>
+   <define name="sgamodel.offsetLike_sequenceOptional">
+      <optional>
+         <ref name="sgaoffset"/>
+      </optional>
+      <optional>
+         <ref name="sgageogFeat"/>
+      </optional>
+   </define>
+   <define name="sgamodel.offsetLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaoffset"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgageogFeat"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.offsetLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaoffset"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgageogFeat"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.pPart.msdesc">
+      <choice>
+         <ref name="sgacatchwords"/>
+         <ref name="sgadimensions"/>
+         <ref name="sgaheraldry"/>
+         <ref name="sgalocus"/>
+         <ref name="sgalocusGrp"/>
+         <ref name="sgamaterial"/>
+         <ref name="sgaobjectType"/>
+         <ref name="sgaorigDate"/>
+         <ref name="sgaorigPlace"/>
+         <ref name="sgasecFol"/>
+         <ref name="sgasignatures"/>
+         <ref name="sgastamp"/>
+         <ref name="sgawatermark"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.editorial">
+      <choice>
+         <ref name="sgasubst"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.editorial_alternation">
+      <choice>
+         <ref name="sgasubst"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequence">
+      <ref name="sgasubst"/>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequenceOptional">
+      <optional>
+         <ref name="sgasubst"/>
+      </optional>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgasubst"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.pPart.editorial_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgasubst"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.pPart.transcriptional">
+      <choice>
+         <ref name="sgaadd"/>
+         <ref name="sgadel"/>
+         <ref name="sgaunclear"/>
+         <ref name="sgadamage"/>
+         <ref name="sgahandShift"/>
+         <ref name="sgarestore"/>
+         <ref name="sgasecl"/>
+         <ref name="sgamod"/>
+         <ref name="sgaretrace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_alternation">
+      <choice>
+         <ref name="sgaadd"/>
+         <ref name="sgadel"/>
+         <ref name="sgaunclear"/>
+         <ref name="sgadamage"/>
+         <ref name="sgahandShift"/>
+         <ref name="sgarestore"/>
+         <ref name="sgasecl"/>
+         <ref name="sgamod"/>
+         <ref name="sgaretrace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequence">
+      <ref name="sgaadd"/>
+      <ref name="sgadel"/>
+      <ref name="sgaunclear"/>
+      <ref name="sgadamage"/>
+      <ref name="sgahandShift"/>
+      <ref name="sgarestore"/>
+      <ref name="sgasecl"/>
+      <ref name="sgamod"/>
+      <ref name="sgaretrace"/>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequenceOptional">
+      <optional>
+         <ref name="sgaadd"/>
+      </optional>
+      <optional>
+         <ref name="sgadel"/>
+      </optional>
+      <optional>
+         <ref name="sgaunclear"/>
+      </optional>
+      <optional>
+         <ref name="sgadamage"/>
+      </optional>
+      <optional>
+         <ref name="sgahandShift"/>
+      </optional>
+      <optional>
+         <ref name="sgarestore"/>
+      </optional>
+      <optional>
+         <ref name="sgasecl"/>
+      </optional>
+      <optional>
+         <ref name="sgamod"/>
+      </optional>
+      <optional>
+         <ref name="sgaretrace"/>
+      </optional>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaadd"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadel"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaunclear"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadamage"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgahandShift"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgarestore"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgasecl"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamod"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaretrace"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.pPart.transcriptional_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaadd"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadel"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaunclear"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadamage"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgahandShift"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgarestore"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgasecl"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamod"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaretrace"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.pPart.edit">
+      <choice>
+         <ref name="sgamodel.pPart.editorial"/>
+         <ref name="sgamodel.pPart.transcriptional"/>
+      </choice>
+   </define>
+   <define name="sgamodel.linePart">
+      <choice>
+         <ref name="sgamodel.hiLike"/>
+         <ref name="sgaadd"/>
+         <ref name="sgadel"/>
+         <ref name="sgaunclear"/>
+         <ref name="sgazone"/>
+         <ref name="sgadamage"/>
+         <ref name="sgahandShift"/>
+         <ref name="sgarestore"/>
+         <ref name="sgaline"/>
+         <ref name="sgamod"/>
+         <ref name="sgaretrace"/>
+         <ref name="sgaseg"/>
+         <ref name="sgac"/>
+      </choice>
+   </define>
+   <define name="sgamodel.ptrLike">
+      <choice>
+         <ref name="sgaptr"/>
+         <ref name="sgaref"/>
+      </choice>
+   </define>
+   <define name="sgamodel.lPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.global.meta">
+      <choice>
+         <ref name="sgaindex"/>
+         <ref name="sgasubstJoin"/>
+         <ref name="sgalistTranspose"/>
+         <ref name="sgalink"/>
+         <ref name="sgalinkGrp"/>
+         <ref name="sgajoin"/>
+         <ref name="sgajoinGrp"/>
+         <ref name="sgaalt"/>
+      </choice>
+   </define>
+   <define name="sgamodel.milestoneLike">
+      <choice>
+         <ref name="sgamilestone"/>
+         <ref name="sgaanchor"/>
+      </choice>
+   </define>
+   <define name="sgamodel.gLike">
+      <choice>
+         <ref name="sgag"/>
+      </choice>
+   </define>
+   <define name="sgamodel.oddDecl">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.oddDecl_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.oddDecl_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.oddDecl_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.oddDecl_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.oddDecl_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.phrase.xml">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.specDescLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.biblLike">
+      <choice>
+         <ref name="sgabibl"/>
+         <ref name="sgabiblFull"/>
+         <ref name="sgamsDesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.biblLike_alternation">
+      <choice>
+         <ref name="sgabibl"/>
+         <ref name="sgabiblFull"/>
+         <ref name="sgamsDesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.biblLike_sequence">
+      <ref name="sgabibl"/>
+      <ref name="sgabiblFull"/>
+      <ref name="sgamsDesc"/>
+   </define>
+   <define name="sgamodel.biblLike_sequenceOptional">
+      <optional>
+         <ref name="sgabibl"/>
+      </optional>
+      <optional>
+         <ref name="sgabiblFull"/>
+      </optional>
+      <optional>
+         <ref name="sgamsDesc"/>
+      </optional>
+   </define>
+   <define name="sgamodel.biblLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgabibl"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgabiblFull"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamsDesc"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.biblLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgabibl"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgabiblFull"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamsDesc"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.headLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.headLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.headLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.headLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.headLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.headLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.labelLike">
+      <choice>
+         <ref name="sgadesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.labelLike_alternation">
+      <choice>
+         <ref name="sgadesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.labelLike_sequence">
+      <ref name="sgadesc"/>
+   </define>
+   <define name="sgamodel.labelLike_sequenceOptional">
+      <optional>
+         <ref name="sgadesc"/>
+      </optional>
+   </define>
+   <define name="sgamodel.labelLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgadesc"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.labelLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgadesc"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.listLike">
+      <choice>
+         <ref name="sgalist"/>
+         <ref name="sgalistOrg"/>
+         <ref name="sgalistEvent"/>
+         <ref name="sgalistPerson"/>
+         <ref name="sgalistPlace"/>
+         <ref name="sgalistRelation"/>
+         <ref name="sgalistNym"/>
+      </choice>
+   </define>
+   <define name="sgamodel.listLike_alternation">
+      <choice>
+         <ref name="sgalist"/>
+         <ref name="sgalistOrg"/>
+         <ref name="sgalistEvent"/>
+         <ref name="sgalistPerson"/>
+         <ref name="sgalistPlace"/>
+         <ref name="sgalistRelation"/>
+         <ref name="sgalistNym"/>
+      </choice>
+   </define>
+   <define name="sgamodel.listLike_sequence">
+      <ref name="sgalist"/>
+      <ref name="sgalistOrg"/>
+      <ref name="sgalistEvent"/>
+      <ref name="sgalistPerson"/>
+      <ref name="sgalistPlace"/>
+      <ref name="sgalistRelation"/>
+      <ref name="sgalistNym"/>
+   </define>
+   <define name="sgamodel.listLike_sequenceOptional">
+      <optional>
+         <ref name="sgalist"/>
+      </optional>
+      <optional>
+         <ref name="sgalistOrg"/>
+      </optional>
+      <optional>
+         <ref name="sgalistEvent"/>
+      </optional>
+      <optional>
+         <ref name="sgalistPerson"/>
+      </optional>
+      <optional>
+         <ref name="sgalistPlace"/>
+      </optional>
+      <optional>
+         <ref name="sgalistRelation"/>
+      </optional>
+      <optional>
+         <ref name="sgalistNym"/>
+      </optional>
+   </define>
+   <define name="sgamodel.listLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgalist"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistOrg"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistEvent"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistPerson"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistPlace"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistRelation"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalistNym"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.listLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgalist"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistOrg"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistEvent"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistPerson"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistPlace"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistRelation"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalistNym"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.noteLike">
+      <choice>
+         <ref name="sganote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.lLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.lLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.lLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.lLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.lLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.lLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.pLike">
+      <choice>
+         <ref name="sgap"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pLike_alternation">
+      <choice>
+         <ref name="sgap"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pLike_sequence">
+      <ref name="sgap"/>
+   </define>
+   <define name="sgamodel.pLike_sequenceOptional">
+      <optional>
+         <ref name="sgap"/>
+      </optional>
+   </define>
+   <define name="sgamodel.pLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgap"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.pLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgap"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.stageLike">
+      <choice>
+         <ref name="sgastage"/>
+      </choice>
+   </define>
+   <define name="sgamodel.stageLike_alternation">
+      <choice>
+         <ref name="sgastage"/>
+      </choice>
+   </define>
+   <define name="sgamodel.stageLike_sequence">
+      <ref name="sgastage"/>
+   </define>
+   <define name="sgamodel.stageLike_sequenceOptional">
+      <optional>
+         <ref name="sgastage"/>
+      </optional>
+   </define>
+   <define name="sgamodel.stageLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgastage"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.stageLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgastage"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.entryPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.eventLike">
+      <choice>
+         <ref name="sgaevent"/>
+         <ref name="sgalistEvent"/>
+      </choice>
+   </define>
+   <define name="sgamodel.global.edit">
+      <choice>
+         <ref name="sgagap"/>
+         <ref name="sgaaddSpan"/>
+         <ref name="sgadamageSpan"/>
+         <ref name="sgadelSpan"/>
+         <ref name="sgaspace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divPart">
+      <choice>
+         <ref name="sgamodel.lLike"/>
+         <ref name="sgamodel.pLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.persStateLike">
+      <choice>
+         <ref name="sgapersName"/>
+         <ref name="sgaaffiliation"/>
+         <ref name="sgaage"/>
+         <ref name="sgaeducation"/>
+         <ref name="sgafaith"/>
+         <ref name="sgafloruit"/>
+         <ref name="sgalangKnowledge"/>
+         <ref name="sganationality"/>
+         <ref name="sgaoccupation"/>
+         <ref name="sgapersona"/>
+         <ref name="sgaresidence"/>
+         <ref name="sgasex"/>
+         <ref name="sgasocecStatus"/>
+         <ref name="sgastate"/>
+         <ref name="sgatrait"/>
+      </choice>
+   </define>
+   <define name="sgamodel.personLike">
+      <choice>
+         <ref name="sgaorg"/>
+         <ref name="sgaperson"/>
+         <ref name="sgapersonGrp"/>
+      </choice>
+   </define>
+   <define name="sgamodel.personPart">
+      <choice>
+         <ref name="sgamodel.biblLike"/>
+         <ref name="sgamodel.eventLike"/>
+         <ref name="sgamodel.persStateLike"/>
+         <ref name="sganame"/>
+         <ref name="sgaidno"/>
+         <ref name="sgabirth"/>
+         <ref name="sgadeath"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeNamePart">
+      <choice>
+         <ref name="sgaplaceName"/>
+         <ref name="sgabloc"/>
+         <ref name="sgacountry"/>
+         <ref name="sgaregion"/>
+         <ref name="sgasettlement"/>
+         <ref name="sgadistrict"/>
+         <ref name="sgageogName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeNamePart_alternation">
+      <choice>
+         <ref name="sgaplaceName"/>
+         <ref name="sgabloc"/>
+         <ref name="sgacountry"/>
+         <ref name="sgaregion"/>
+         <ref name="sgasettlement"/>
+         <ref name="sgadistrict"/>
+         <ref name="sgageogName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeNamePart_sequence">
+      <ref name="sgaplaceName"/>
+      <ref name="sgabloc"/>
+      <ref name="sgacountry"/>
+      <ref name="sgaregion"/>
+      <ref name="sgasettlement"/>
+      <ref name="sgadistrict"/>
+      <ref name="sgageogName"/>
+   </define>
+   <define name="sgamodel.placeNamePart_sequenceOptional">
+      <optional>
+         <ref name="sgaplaceName"/>
+      </optional>
+      <optional>
+         <ref name="sgabloc"/>
+      </optional>
+      <optional>
+         <ref name="sgacountry"/>
+      </optional>
+      <optional>
+         <ref name="sgaregion"/>
+      </optional>
+      <optional>
+         <ref name="sgasettlement"/>
+      </optional>
+      <optional>
+         <ref name="sgadistrict"/>
+      </optional>
+      <optional>
+         <ref name="sgageogName"/>
+      </optional>
+   </define>
+   <define name="sgamodel.placeNamePart_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaplaceName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgabloc"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgacountry"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaregion"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgasettlement"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgadistrict"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgageogName"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.placeNamePart_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaplaceName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgabloc"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgacountry"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaregion"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgasettlement"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgadistrict"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgageogName"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.placeStateLike">
+      <choice>
+         <ref name="sgamodel.placeNamePart"/>
+         <ref name="sgaclimate"/>
+         <ref name="sgalocation"/>
+         <ref name="sgapopulation"/>
+         <ref name="sgastate"/>
+         <ref name="sgaterrain"/>
+         <ref name="sgatrait"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeStateLike_alternation">
+      <choice>
+         <ref name="sgamodel.placeNamePart_alternation"/>
+         <ref name="sgaclimate"/>
+         <ref name="sgalocation"/>
+         <ref name="sgapopulation"/>
+         <ref name="sgastate"/>
+         <ref name="sgaterrain"/>
+         <ref name="sgatrait"/>
+      </choice>
+   </define>
+   <define name="sgamodel.placeStateLike_sequence">
+      <ref name="sgamodel.placeNamePart_sequence"/>
+      <ref name="sgaclimate"/>
+      <ref name="sgalocation"/>
+      <ref name="sgapopulation"/>
+      <ref name="sgastate"/>
+      <ref name="sgaterrain"/>
+      <ref name="sgatrait"/>
+   </define>
+   <define name="sgamodel.placeStateLike_sequenceOptional">
+      <optional>
+         <ref name="sgamodel.placeNamePart_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgaclimate"/>
+      </optional>
+      <optional>
+         <ref name="sgalocation"/>
+      </optional>
+      <optional>
+         <ref name="sgapopulation"/>
+      </optional>
+      <optional>
+         <ref name="sgastate"/>
+      </optional>
+      <optional>
+         <ref name="sgaterrain"/>
+      </optional>
+      <optional>
+         <ref name="sgatrait"/>
+      </optional>
+   </define>
+   <define name="sgamodel.placeStateLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgamodel.placeNamePart_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaclimate"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgalocation"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgapopulation"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgastate"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaterrain"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgatrait"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.placeStateLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgamodel.placeNamePart_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaclimate"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgalocation"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgapopulation"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgastate"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaterrain"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgatrait"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.orgPart">
+      <choice>
+         <ref name="sgamodel.eventLike"/>
+         <ref name="sgalistOrg"/>
+         <ref name="sgalistPerson"/>
+         <ref name="sgalistPlace"/>
+      </choice>
+   </define>
+   <define name="sgamodel.publicationStmtPart.agency">
+      <choice>
+         <ref name="sgadistributor"/>
+         <ref name="sgaauthority"/>
+      </choice>
+   </define>
+   <define name="sgamodel.publicationStmtPart.detail">
+      <choice>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgaaddress"/>
+         <ref name="sgadate"/>
+         <ref name="sgapubPlace"/>
+         <ref name="sgaidno"/>
+         <ref name="sgaavailability"/>
+      </choice>
+   </define>
+   <define name="sgamodel.availabilityPart">
+      <choice>
+         <ref name="sgalicence"/>
+      </choice>
+   </define>
+   <define name="sgamodel.certLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.descLike">
+      <choice>
+         <ref name="sgadesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.glossLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.quoteLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.quoteLike_alternation">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.quoteLike_sequence">
+      <empty/>
+   </define>
+   <define name="sgamodel.quoteLike_sequenceOptional">
+      <empty/>
+   </define>
+   <define name="sgamodel.quoteLike_sequenceOptionalRepeatable">
+      <empty/>
+   </define>
+   <define name="sgamodel.quoteLike_sequenceRepeatable">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.qLike">
+      <choice>
+         <ref name="sgamodel.quoteLike"/>
+         <ref name="sgafloatingText"/>
+      </choice>
+   </define>
+   <define name="sgamodel.qLike_alternation">
+      <choice>
+         <ref name="sgamodel.quoteLike_alternation"/>
+         <ref name="sgafloatingText"/>
+      </choice>
+   </define>
+   <define name="sgamodel.qLike_sequence">
+      <ref name="sgamodel.quoteLike_sequence"/>
+      <ref name="sgafloatingText"/>
+   </define>
+   <define name="sgamodel.qLike_sequenceOptional">
+      <optional>
+         <ref name="sgamodel.quoteLike_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgafloatingText"/>
+      </optional>
+   </define>
+   <define name="sgamodel.qLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgamodel.quoteLike_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgafloatingText"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.qLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgamodel.quoteLike_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgafloatingText"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.respLike">
+      <choice>
+         <ref name="sgaauthor"/>
+         <ref name="sgarespStmt"/>
+         <ref name="sgasponsor"/>
+         <ref name="sgafunder"/>
+         <ref name="sgaprincipal"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divWrapper">
+      <choice>
+         <ref name="sgabyline"/>
+         <ref name="sgadateline"/>
+         <ref name="sgaargument"/>
+         <ref name="sgaepigraph"/>
+         <ref name="sgasalute"/>
+         <ref name="sgadocAuthor"/>
+         <ref name="sgadocDate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divTopPart">
+      <choice>
+         <ref name="sgamodel.headLike"/>
+         <ref name="sgaopener"/>
+         <ref name="sgasigned"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divTop">
+      <choice>
+         <ref name="sgamodel.divWrapper"/>
+         <ref name="sgamodel.divTopPart"/>
+      </choice>
+   </define>
+   <define name="sgamodel.frontPart.drama">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.pLike.front">
+      <choice>
+         <ref name="sgabyline"/>
+         <ref name="sgaargument"/>
+         <ref name="sgaepigraph"/>
+         <ref name="sgadocTitle"/>
+         <ref name="sgatitlePart"/>
+         <ref name="sgadocAuthor"/>
+         <ref name="sgadocEdition"/>
+         <ref name="sgadocImprint"/>
+         <ref name="sgadocDate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divBottomPart">
+      <choice>
+         <ref name="sgatrailer"/>
+         <ref name="sgacloser"/>
+         <ref name="sgasigned"/>
+         <ref name="sgapostscript"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divBottom">
+      <choice>
+         <ref name="sgamodel.divWrapper"/>
+         <ref name="sgamodel.divBottomPart"/>
+      </choice>
+   </define>
+   <define name="sgamodel.titlepagePart">
+      <choice>
+         <ref name="sgagraphic"/>
+         <ref name="sgabyline"/>
+         <ref name="sgaargument"/>
+         <ref name="sgaepigraph"/>
+         <ref name="sgadocTitle"/>
+         <ref name="sgatitlePart"/>
+         <ref name="sgadocAuthor"/>
+         <ref name="sgaimprimatur"/>
+         <ref name="sgadocEdition"/>
+         <ref name="sgadocImprint"/>
+         <ref name="sgadocDate"/>
+      </choice>
+   </define>
+   <define name="sgamodel.msQuoteLike">
+      <choice>
+         <ref name="sgatitle"/>
+         <ref name="sgacolophon"/>
+         <ref name="sgaexplicit"/>
+         <ref name="sgafinalRubric"/>
+         <ref name="sgaincipit"/>
+         <ref name="sgarubric"/>
+      </choice>
+   </define>
+   <define name="sgamodel.msItemPart">
+      <choice>
+         <ref name="sgamodel.biblLike"/>
+         <ref name="sgamodel.quoteLike"/>
+         <ref name="sgamodel.respLike"/>
+         <ref name="sgamodel.msQuoteLike"/>
+         <ref name="sgaidno"/>
+         <ref name="sgafiliation"/>
+         <ref name="sgamsItem"/>
+         <ref name="sgamsItemStruct"/>
+         <ref name="sgadecoNote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.imprintPart">
+      <choice>
+         <ref name="sgapubPlace"/>
+         <ref name="sgadistributor"/>
+      </choice>
+   </define>
+   <define name="sgamodel.catDescPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.addressLike">
+      <choice>
+         <ref name="sgaaddress"/>
+         <ref name="sgaaffiliation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.addressLike_alternation">
+      <choice>
+         <ref name="sgaaddress"/>
+         <ref name="sgaaffiliation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.addressLike_sequence">
+      <ref name="sgaaddress"/>
+      <ref name="sgaaffiliation"/>
+   </define>
+   <define name="sgamodel.addressLike_sequenceOptional">
+      <optional>
+         <ref name="sgaaddress"/>
+      </optional>
+      <optional>
+         <ref name="sgaaffiliation"/>
+      </optional>
+   </define>
+   <define name="sgamodel.addressLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgaaddress"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaaffiliation"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.addressLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgaaddress"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaaffiliation"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.nameLike">
+      <choice>
+         <ref name="sgamodel.nameLike.agent"/>
+         <ref name="sgamodel.offsetLike"/>
+         <ref name="sgamodel.placeStateLike"/>
+         <ref name="sgars"/>
+         <ref name="sgaidno"/>
+         <ref name="sgamodel.persNamePart"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike_alternation">
+      <choice>
+         <ref name="sgamodel.nameLike.agent_alternation"/>
+         <ref name="sgamodel.offsetLike_alternation"/>
+         <ref name="sgamodel.placeStateLike_alternation"/>
+         <ref name="sgars"/>
+         <ref name="sgaidno"/>
+         <ref name="sgamodel.persNamePart_alternation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.nameLike_sequence">
+      <ref name="sgamodel.nameLike.agent_sequence"/>
+      <ref name="sgamodel.offsetLike_sequence"/>
+      <ref name="sgamodel.placeStateLike_sequence"/>
+      <ref name="sgars"/>
+      <ref name="sgaidno"/>
+      <ref name="sgamodel.persNamePart_sequence"/>
+   </define>
+   <define name="sgamodel.nameLike_sequenceOptional">
+      <optional>
+         <ref name="sgamodel.nameLike.agent_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgamodel.offsetLike_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgamodel.placeStateLike_sequenceOptional"/>
+      </optional>
+      <optional>
+         <ref name="sgars"/>
+      </optional>
+      <optional>
+         <ref name="sgaidno"/>
+      </optional>
+      <optional>
+         <ref name="sgamodel.persNamePart_sequenceOptional"/>
+      </optional>
+   </define>
+   <define name="sgamodel.nameLike_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgamodel.nameLike.agent_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamodel.offsetLike_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamodel.placeStateLike_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgars"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaidno"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgamodel.persNamePart_sequenceOptionalRepeatable"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.nameLike_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgamodel.nameLike.agent_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamodel.offsetLike_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamodel.placeStateLike_sequenceRepeatable"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgars"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaidno"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgamodel.persNamePart_sequenceRepeatable"/>
+      </oneOrMore>
+   </define>
+   <define name="sgamodel.global">
+      <choice>
+         <ref name="sgamodel.global.meta"/>
+         <ref name="sgamodel.milestoneLike"/>
+         <ref name="sgamodel.noteLike"/>
+         <ref name="sgamodel.global.edit"/>
+         <ref name="sgametamark"/>
+         <ref name="sgafigure"/>
+      </choice>
+   </define>
+   <define name="sgamodel.biblPart">
+      <choice>
+         <ref name="sgamodel.respLike"/>
+         <ref name="sgamodel.imprintPart"/>
+         <ref name="sgacitedRange"/>
+         <ref name="sgabibl"/>
+         <ref name="sgarelatedItem"/>
+         <ref name="sgaedition"/>
+         <ref name="sgaextent"/>
+         <ref name="sgaavailability"/>
+         <ref name="sgamsIdentifier"/>
+         <ref name="sgalistRelation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.frontPart">
+      <choice>
+         <ref name="sgamodel.frontPart.drama"/>
+         <ref name="sgatitlePage"/>
+      </choice>
+   </define>
+   <define name="sgamodel.addrPart">
+      <choice>
+         <ref name="sgamodel.nameLike"/>
+         <ref name="sgaaddrLine"/>
+      </choice>
+   </define>
+   <define name="sgamodel.pPart.data">
+      <choice>
+         <ref name="sgamodel.dateLike"/>
+         <ref name="sgamodel.measureLike"/>
+         <ref name="sgamodel.addressLike"/>
+         <ref name="sgamodel.nameLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.inter">
+      <choice>
+         <ref name="sgamodel.egLike"/>
+         <ref name="sgamodel.oddDecl"/>
+         <ref name="sgamodel.biblLike"/>
+         <ref name="sgamodel.labelLike"/>
+         <ref name="sgamodel.listLike"/>
+         <ref name="sgamodel.stageLike"/>
+         <ref name="sgamodel.qLike"/>
+      </choice>
+   </define>
+   <define name="sgamodel.common">
+      <choice>
+         <ref name="sgamodel.divPart"/>
+         <ref name="sgamodel.inter"/>
+      </choice>
+   </define>
+   <define name="sgamodel.phrase">
+      <choice>
+         <ref name="sgamodel.segLike"/>
+         <ref name="sgamodel.highlighted"/>
+         <ref name="sgamodel.graphicLike"/>
+         <ref name="sgamodel.pPart.msdesc"/>
+         <ref name="sgamodel.pPart.edit"/>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgamodel.lPart"/>
+         <ref name="sgamodel.phrase.xml"/>
+         <ref name="sgamodel.specDescLike"/>
+         <ref name="sgamodel.pPart.data"/>
+      </choice>
+   </define>
+   <define name="sgamodel.limitedPhrase">
+      <choice>
+         <ref name="sgamodel.hiLike"/>
+         <ref name="sgamodel.emphLike"/>
+         <ref name="sgamodel.pPart.msdesc"/>
+         <ref name="sgamodel.pPart.editorial"/>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgamodel.phrase.xml"/>
+         <ref name="sgamodel.pPart.data"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divLike">
+      <choice>
+         <ref name="sgadiv"/>
+      </choice>
+   </define>
+   <define name="sgamodel.divGenLike">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.div1Like">
+      <choice>
+         <ref name="sgadiv1"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div2Like">
+      <choice>
+         <ref name="sgadiv2"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div3Like">
+      <choice>
+         <ref name="sgadiv3"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div4Like">
+      <choice>
+         <ref name="sgadiv4"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div5Like">
+      <choice>
+         <ref name="sgadiv5"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div6Like">
+      <choice>
+         <ref name="sgadiv6"/>
+      </choice>
+   </define>
+   <define name="sgamodel.div7Like">
+      <choice>
+         <ref name="sgadiv7"/>
+      </choice>
+   </define>
+   <define name="sgamodel.applicationLike">
+      <choice>
+         <ref name="sgaapplication"/>
+      </choice>
+   </define>
+   <define name="sgamodel.teiHeaderPart">
+      <choice>
+         <ref name="sgaencodingDesc"/>
+         <ref name="sgaprofileDesc"/>
+         <ref name="sgaxenoData"/>
+      </choice>
+   </define>
+   <define name="sgamodel.sourceDescPart">
+      <notAllowed/>
+   </define>
+   <define name="sgamodel.encodingDescPart">
+      <choice>
+         <ref name="sgacharDecl"/>
+         <ref name="sgaschemaRef"/>
+         <ref name="sgaprojectDesc"/>
+         <ref name="sgasamplingDecl"/>
+         <ref name="sgaeditorialDecl"/>
+         <ref name="sgatagsDecl"/>
+         <ref name="sgastyleDefDecl"/>
+         <ref name="sgarefsDecl"/>
+         <ref name="sgalistPrefixDef"/>
+         <ref name="sgaclassDecl"/>
+         <ref name="sgageoDecl"/>
+         <ref name="sgaappInfo"/>
+      </choice>
+   </define>
+   <define name="sgamodel.editorialDeclPart">
+      <choice>
+         <ref name="sgacorrection"/>
+         <ref name="sganormalization"/>
+         <ref name="sgaquotation"/>
+         <ref name="sgahyphenation"/>
+         <ref name="sgasegmentation"/>
+         <ref name="sgastdVals"/>
+         <ref name="sgainterpretation"/>
+         <ref name="sgapunctuation"/>
+      </choice>
+   </define>
+   <define name="sgamodel.profileDescPart">
+      <choice>
+         <ref name="sgahandNotes"/>
+         <ref name="sgalistTranspose"/>
+         <ref name="sgaabstract"/>
+         <ref name="sgacreation"/>
+         <ref name="sgalangUsage"/>
+         <ref name="sgatextClass"/>
+         <ref name="sgacalendarDesc"/>
+         <ref name="sgacorrespDesc"/>
+      </choice>
+   </define>
+   <define name="sgamodel.correspActionPart">
+      <choice>
+         <ref name="sgamodel.dateLike"/>
+         <ref name="sgamodel.addressLike"/>
+         <ref name="sgamodel.nameLike"/>
+         <ref name="sganote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.correspContextPart">
+      <choice>
+         <ref name="sgamodel.ptrLike"/>
+         <ref name="sgamodel.pLike"/>
+         <ref name="sganote"/>
+      </choice>
+   </define>
+   <define name="sgamodel.correspDescPart">
+      <choice>
+         <ref name="sganote"/>
+         <ref name="sgacorrespAction"/>
+         <ref name="sgacorrespContext"/>
+      </choice>
+   </define>
+   <define name="sgamodel.resourceLike">
+      <choice>
+         <ref name="sgafacsimile"/>
+         <ref name="sgasourceDoc"/>
+         <ref name="sgatext"/>
+      </choice>
+   </define>
+   <define name="sgaatt.personal.attributes">
+      <ref name="sgaatt.naming.attributes"/>
+      <ref name="sgaatt.personal.attribute.full"/>
+      <ref name="sgaatt.personal.attribute.sort"/>
+   </define>
+   <define name="sgaatt.personal.attribute.full">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="full"
+                    a:defaultValue="yes">
+            <a:documentation>indicates whether the name component is given in full, as an abbreviation or simply as an initial.</a:documentation>
+            <choice>
+               <value>yes</value>
+               <a:documentation>the name component is spelled out in full.</a:documentation>
+               <value>abb</value>
+               <a:documentation>(abbreviated) the name component is given in an abbreviated form.</a:documentation>
+               <value>init</value>
+               <a:documentation>(initial letter) the name component is indicated only by one initial.</a:documentation>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.personal.attribute.sort">
+      <optional>
+         <attribute name="sort">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sort order of the name component in relation to others within the name.</a:documentation>
+            <data type="nonNegativeInteger"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamodel.placeLike">
+      <choice>
+         <ref name="sgaplace"/>
+      </choice>
+   </define>
+   <define name="sgaatt.milestoneUnit.attributes">
+      <ref name="sgaatt.milestoneUnit.attribute.unit"/>
+   </define>
+   <define name="sgaatt.milestoneUnit.attribute.unit">
+      <attribute name="unit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides a conventional name for the kind of section changing at this milestone.
+Suggested values include: 1] page; 2] column; 3] line; 4] book; 5] poem; 6] canto; 7] speaker; 8] stanza; 9] act; 10] scene; 11] section; 12] absent; 13] unnumbered</a:documentation>
+         <choice>
+            <value>page</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">physical page breaks (synonymous with the pb element).</a:documentation>
+            <value>column</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">column breaks.</a:documentation>
+            <value>line</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">line breaks (synonymous with the lb element).</a:documentation>
+            <value>book</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">any units termed book, liber, etc.</a:documentation>
+            <value>poem</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">individual poems in a collection.</a:documentation>
+            <value>canto</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">cantos or other major sections of a poem.</a:documentation>
+            <value>speaker</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">changes of speaker or narrator.</a:documentation>
+            <value>stanza</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">stanzas within a poem, book, or canto.</a:documentation>
+            <value>act</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">acts within a play.</a:documentation>
+            <value>scene</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">scenes within a play or act.</a:documentation>
+            <value>section</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">sections of any kind.</a:documentation>
+            <value>absent</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">passages not present in the reference edition.</a:documentation>
+            <value>unnumbered</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">passages present in the text, but not to be included as part of the reference.</a:documentation>
+            <data type="token">
+               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+            </data>
+         </choice>
+      </attribute>
+   </define>
+   <define name="sgap">
+      <element name="p">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(paragraph) marks paragraphs in prose. [3.1. Paragraphs 7.2.5. Speech Contents]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-p-abstractModel-p-constraint-report-4">
+            <rule context="tei:p">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="not(ancestor::floatingText) and (ancestor::tei:p or ancestor::tei:ab)          and not(parent::tei:exemplum                |parent::tei:item                |parent::tei:note                |parent::tei:q                |parent::tei:quote                |parent::tei:remarks                |parent::tei:said                |parent::tei:sp                |parent::tei:stage                |parent::tei:cell                |parent::tei:figure                )">
+        Abstract model violation: Paragraphs may not contain other paragraphs or ab elements.
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-p-abstractModel-structure-l-constraint-report-5">
+            <rule context="tei:p">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="ancestor::tei:l[not(.//tei:note//tei:p[. = current()])]">
+        Abstract model violation: Lines may not contain higher-level structural elements such as div, p, or ab.
+      </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.fragmentable.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaforeign">
+      <element name="foreign">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a word or phrase as belonging to some language other than that of the surrounding text. [3.3.2.1. Foreign Words or Expressions]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaemph">
+      <element name="emph">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(emphasized) marks words or phrases which are stressed or emphasized for linguistic or rhetorical effect. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahi">
+      <element name="hi">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(highlighted) marks a word or phrase as graphically distinct from the surrounding text, for reasons concerning which no claim is made. [3.3.2.2. Emphatic Words and Phrases 3.3.2. Emphasis, Foreign Words, and Unusual Language]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.written.attributes"/>
+         <attribute name="rend">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>hyphenated</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>underline</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>double-underline</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>bold</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>caps</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>italic</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>sup</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>sub</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadesc">
+      <element name="desc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description) contains a brief description of the object documented by its parent element, typically a documentation element or an entity. [22.4.1. Description of Components]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.translatable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaterm">
+      <element name="term">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single-word, multi-word, or symbolic designation which is regarded as a technical term. [3.3.4. Terms, Glosses, Equivalents, and Descriptions]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.cReferencing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagap">
+      <element name="gap">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates a point where material has been omitted in a transcription, whether for editorial reasons described in the TEI header, as part of sampling practice, or because the material is illegible, invisible, or inaudible. [3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.timed.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <optional>
+            <attribute name="reason">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the reason for omission
+Suggested values include: 1] cancelled; 2] deleted; 3] editorial; 4] illegible; 5] inaudible; 6] irrelevant; 7] sampling</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <choice>
+                        <value>cancelled</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>deleted</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>editorial</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">for features omitted from transcription due to editorial policy</a:documentation>
+                        <value>illegible</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>inaudible</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>irrelevant</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>sampling</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <data type="token">
+                           <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                        </data>
+                     </choice>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="hand">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in the case of text omitted from the transcription because of deliberate deletion by an identifiable hand, indicates the hand which made the deletion.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="agent">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in the case of text omitted because of damage, categorizes the cause of the damage, if it can be identified.
+Sample values include: 1] rubbing; 2] mildew; 3] smoke</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadd">
+      <element name="add">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(addition) contains letters, words, or phrases inserted in the source text by an author, scribe, or a previous annotator or corrector. [3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="place">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>superlinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>intralinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>sublinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>interlinear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>alternative</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadel">
+      <element name="del">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deletion) contains a letter, word, or passage deleted, marked as deleted, or otherwise indicated as superfluous or spurious in the copy text by an author, scribe, or a previous annotator or corrector. [3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.transcriptional.attribute.cause"/>
+         <ref name="sgaatt.transcriptional.attribute.seq"/>
+         <ref name="sgaatt.editLike.attribute.evidence"/>
+         <ref name="sgaatt.editLike.attribute.instant"/>
+         <ref name="sgaatt.dimensions.attribute.unit"/>
+         <ref name="sgaatt.dimensions.attribute.quantity"/>
+         <ref name="sgaatt.dimensions.attribute.extent"/>
+         <ref name="sgaatt.dimensions.attribute.precision"/>
+         <ref name="sgaatt.dimensions.attribute.scope"/>
+         <ref name="sgaatt.ranging.attribute.atLeast"/>
+         <ref name="sgaatt.ranging.attribute.atMost"/>
+         <ref name="sgaatt.ranging.attribute.min"/>
+         <ref name="sgaatt.ranging.attribute.max"/>
+         <ref name="sgaatt.ranging.attribute.confidence"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>strikethrough</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>overwritten</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>smear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>erased</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>vertical_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unmarked</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaunclear">
+      <element name="unclear">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word, phrase, or passage which cannot be transcribed with certainty because it is illegible or inaudible in the source. [11.3.3.1. Damage, Illegibility, and Supplied Text 3.4.3. Additions, Deletions, and Omissions]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <optional>
+            <attribute name="reason">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates why the material is hard to transcribe.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="hand">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the difficulty in transcription arises from action (partial deletion, etc.) assignable to an identifiable hand, signifies the hand responsible for the action.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="agent">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Where the difficulty in transcription arises from damage, categorizes the cause of the damage, if it can be identified.
+Sample values include: 1] rubbing; 2] mildew; 3] smoke</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganame">
+      <element name="name">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name, proper noun) contains a proper noun or noun phrase. [3.5.1. Referring Strings]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgars">
+      <element name="rs">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(referencing string) contains a general purpose name or referring string. [13.2.1. Personal Names 3.5.1. Referring Strings]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddress">
+      <element name="address">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a postal address, for example of a publisher, an organization, or an individual. [3.5.2. Addresses 2.2.4. Publication, Distribution, Licensing, etc. 3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <oneOrMore>
+               <group>
+        
+                  <ref name="sgamodel.addrPart"/>
+        
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </oneOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddrLine">
+      <element name="addrLine">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(address line) contains one line of a postal address. [3.5.2. Addresses 2.2.4. Publication, Distribution, Licensing, etc. 3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganum">
+      <element name="num">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) contains a number, written in any form. [3.5.3. Numbers and
+Measures]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.ranging.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the type of numeric value.
+Suggested values include: 1] cardinal; 2] ordinal; 3] fraction; 4] percentage</a:documentation>
+               <choice>
+                  <value>cardinal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">absolute number, e.g. 21, 21.5</a:documentation>
+                  <value>ordinal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">ordinal number, e.g. 21st</a:documentation>
+                  <value>fraction</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">fraction, e.g. one half or three-quarters</a:documentation>
+                  <value>percentage</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a percentage</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="value">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of the number in standard form.</a:documentation>
+               <choice>
+                  <data type="double"/>
+                  <data type="token">
+                     <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+                  </data>
+                  <data type="decimal"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgameasureGrp">
+      <element name="measureGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure group) contains a group of dimensional specifications which relate to the same object, for example the height and width of a manuscript page. [10.3.4. Dimensions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.measureLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.measurement.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadate">
+      <element name="date">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a date in any format. [3.5.4. Dates and Times 2.2.4. Publication, Distribution, Licensing, etc. 2.6. The Revision Description 3.11.2.4. Imprint, Size of a Document, and Reprint Information 15.2.3. The Setting Description 13.3.6. Dates and Times]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaptr">
+      <element name="ptr">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pointer) defines a pointer to another location. [3.6. Simple Links and Cross-References 16.1. Links]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-ptr-ptrAtts-constraint-report-6">
+            <rule context="tei:ptr">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@target and @cRef">Only one of the
+attributes @target and @cRef may be supplied on <name/>.</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.internetMedia.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.cReferencing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaref">
+      <element name="ref">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) defines a reference to another location, possibly modified by additional text or comment. [3.6. Simple Links and Cross-References 16.1. Links]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-ref-refAtts-constraint-report-7">
+            <rule context="tei:ref">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@target and @cRef">Only one of the
+	attributes @target' and @cRef' may be supplied on <name/>
+               </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.internetMedia.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.cReferencing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalist">
+      <element name="list">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any sequence of items organized as a list. [3.7. Lists]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+          
+                  <ref name="sgamodel.divTop"/>
+          
+          
+                  <ref name="sgamodel.global"/>
+          
+               </choice>
+            </zeroOrMore>
+      
+            <choice>
+               <oneOrMore>
+                  <group>
+                     <ref name="sgaitem"/>
+          
+                     <zeroOrMore>
+                        <ref name="sgamodel.global"/>
+                     </zeroOrMore>
+          
+                  </group>
+               </oneOrMore>
+               <group>
+          
+            
+          
+          
+            
+          
+                  <oneOrMore>
+                     <group>
+            
+            
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+            
+                        <ref name="sgaitem"/>
+            
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+            
+                     </group>
+                  </oneOrMore>
+               </group>
+            </choice>
+      
+            <zeroOrMore>
+               <group>
+          
+                  <ref name="sgamodel.divBottom"/>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+          
+               </group>
+            </zeroOrMore>
+      
+         </group>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-list-gloss-list-must-have-labels-constraint-rule-9">
+            <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="tei:list[@type='gloss']">
+	              <sch:assert test="tei:label">The content of a "gloss" list should include a sequence of one or more pairs of a label element followed by an item element</sch:assert>
+            </sch:rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the nature of the items in the list.
+Suggested values include: 1] gloss; 2] index; 3] instructions; 4] litany; 5] syllogism</a:documentation>
+               <choice>
+                  <value>gloss</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item glosses some term or concept, which is given by a label element preceding the list item.</a:documentation>
+                  <value>index</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is an entry in an index such as the alphabetical topical index at the back of a print volume.</a:documentation>
+                  <value>instructions</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is a step in a sequence of instructions, as in a recipe.</a:documentation>
+                  <value>litany</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is one of a sequence of petitions, supplications or invocations, typically in a religious ritual.</a:documentation>
+                  <value>syllogism</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">each list item is part of an argument consisting of two or more propositions and a final conclusion derived from them.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaitem">
+      <element name="item">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains one component of a list. [3.7. Lists 2.6. The Revision Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganote">
+      <element name="note">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a note or annotation. [3.8.1. Notes and Simple Annotation 2.2.6. The Notes Statement 3.11.2.8. Notes and Statement of Language 9.3.5.4. Notes within Entries]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="anchored"
+                       a:defaultValue="true">
+               <a:documentation>indicates whether the copy text shows the exact place of reference for the note.</a:documentation>
+               <data type="boolean"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="targetEnd">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the end of the span to which the note is attached, if the note is not embedded in the text at that point.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaindex">
+      <element name="index">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(index entry) marks a location to be indexed for whatever purpose. [3.8.2. Index Entries]</a:documentation>
+         <zeroOrMore>
+            <group>
+               <ref name="sgaterm"/>
+        
+               <optional>
+                  <ref name="sgaindex"/>
+               </optional>
+        
+            </group>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <optional>
+            <attribute name="indexName">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a single word which follows the rules defining a legal XML name (see ), supplying a name to specify which index (of several) the index entry belongs to.</a:documentation>
+               <data type="Name"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamedia">
+      <element name="media">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of any form of external media such as an audio or video clip etc. [3.9. Graphics and Other Non-textual Components]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.descLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.media.attribute.width"/>
+         <ref name="sgaatt.media.attribute.height"/>
+         <ref name="sgaatt.media.attribute.scale"/>
+         <ref name="sgaatt.resourced.attributes"/>
+         <ref name="sgaatt.timed.attributes"/>
+         <attribute name="mimeType">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MIME media type) specifies the applicable multimedia internet mail extension (MIME) media type</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagraphic">
+      <element name="graphic">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of a graphic or illustration, either forming part of a text, or providing an image of it. [3.9. Graphics and Other Non-textual Components 11.1. Digital Facsimiles]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.descLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.media.attributes"/>
+         <ref name="sgaatt.resourced.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamilestone">
+      <element name="milestone">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">marks a boundary point separating any kind of section of a text, typically but not necessarily indicating a point at which some part of a standard reference system changes, where the change is not represented by a structural element. [3.10.3. Milestone
+Elements]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.edition.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <ref name="sgaatt.breaking.attributes"/>
+         <attribute name="unit">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>tei:div</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:p</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:lg</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:l</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:date</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:speaker</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:q</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:stage</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:seg</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:note</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:head</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:div[@type='scene']</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>tei:div[@type='act']</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaauthor">
+      <element name="author">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in a bibliographic reference, contains the name(s) of an author, personal or corporate, of a work; for example in the same form as that provided by a recognized bibliographic name authority. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarespStmt">
+      <element name="respStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(statement of responsibility) supplies a statement of responsibility for the intellectual content of a text, edition, recording, or series, where the specialized elements for authors, editors, etc. do not suffice or do not apply. May also be used to encode information about individuals or organizations which have played a role in the production or distribution of a bibliographic work. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.2. The Edition Statement 2.2.5. The Series Statement]</a:documentation>
+         <group>
+            <choice>
+               <group>
+          
+                  <oneOrMore>
+                     <ref name="sgaresp"/>
+                  </oneOrMore>
+          
+          
+                  <oneOrMore>
+                     <ref name="sgamodel.nameLike.agent"/>
+                  </oneOrMore>
+          
+               </group>
+               <group>
+          
+                  <oneOrMore>
+                     <ref name="sgamodel.nameLike.agent"/>
+                  </oneOrMore>
+          
+          
+                  <oneOrMore>
+                     <ref name="sgaresp"/>
+                  </oneOrMore>
+          
+               </group>
+            </choice>
+            <zeroOrMore>
+               <ref name="sganote"/>
+            </zeroOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaresp">
+      <element name="resp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsibility) contains a phrase describing the nature of a person's intellectual responsibility, or an organization's role in the production or distribution of a work. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.2. The Edition Statement 2.2.5. The Series Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitle">
+      <element name="title">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a title for any kind of work. [3.11.2.2. Titles, Authors, and Editors 2.2.1. The Title Statement 2.2.5. The Series Statement]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the title according to some convenient typology.
+Sample values include: 1] main; 2] sub(subordinate) ; 3] alt(alternate) ; 4] short; 5] desc(descriptive) </a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="level">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the bibliographic level for a title, that is, whether it identifies an article, book, journal, series, or unpublished material.</a:documentation>
+               <choice>
+                  <value>a</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(analytic) the title applies to an analytic item, such as an article, poem, or other work published as part of a larger item.</a:documentation>
+                  <value>m</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(monographic) the title applies to a monograph such as a book or other item considered to be a distinct publication, including single volumes of multi-volume works</a:documentation>
+                  <value>j</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(journal) the title applies to any serial or periodical publication such as a journal, magazine, or newspaper</a:documentation>
+                  <value>s</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series) the title applies to a series of otherwise distinct publications such as a collection</a:documentation>
+                  <value>u</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unpublished) the title applies to any unpublished material (including theses and dissertations unless published by a commercial press)</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacitedRange">
+      <element name="citedRange">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cited range) defines the range of cited content, often represented by pages or other units [3.11.2.5. Scopes and Ranges in Bibliographic Citations]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.citing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapubPlace">
+      <element name="pubPlace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication place) contains the name of the place where a bibliographic item was published. [3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabibl">
+      <element name="bibl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(bibliographic citation) contains a loosely-structured bibliographic citation of which the sub-components may or may not be explicitly tagged. [3.11.1. Methods of Encoding Bibliographic References and Lists of References 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.highlighted"/>
+               <ref name="sgamodel.pPart.data"/>
+               <ref name="sgamodel.pPart.edit"/>
+               <ref name="sgamodel.segLike"/>
+               <ref name="sgamodel.ptrLike"/>
+               <ref name="sgamodel.biblPart"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarelatedItem">
+      <element name="relatedItem">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains or references some other bibliographic item which is related to the present one in some specified manner, for example as a constituent or alternative version of it. [3.11.2.7. Related Items]</a:documentation>
+         <optional>
+            <choice>
+               <ref name="sgamodel.biblLike"/>
+               <ref name="sgamodel.ptrLike"/>
+            </choice>
+         </optional>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relatedItem-targetorcontent1-constraint-report-8">
+            <rule context="tei:relatedItem">
+               <sch:report xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@target and count( child::* ) &gt; 0">
+If the @target attribute on <sch:name/> is used, the
+relatedItem element must be empty</sch:report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relatedItem-targetorcontent1-constraint-assert-7">
+            <rule context="tei:relatedItem">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@target or child::*">A relatedItem element should have either a 'target' attribute
+        or a child element to indicate the related bibliographic item</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the related bibliographic element by means of an absolute or relative URI reference</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastage">
+      <element name="stage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(stage direction) contains any kind of stage direction within a dramatic text or fragment. [3.12.2. Core Tags for Drama 3.12. Passages of Verse or Drama 7.2.4. Stage Directions]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.ascribed.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the kind of stage direction.
+Suggested values include: 1] setting; 2] entrance; 3] exit; 4] business; 5] novelistic; 6] delivery; 7] modifier; 8] location; 9] mixed</a:documentation>
+               <list>
+                  <zeroOrMore>
+                     <choice>
+                        <value>setting</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a setting.</a:documentation>
+                        <value>entrance</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes an entrance.</a:documentation>
+                        <value>exit</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes an exit.</a:documentation>
+                        <value>business</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes stage business.</a:documentation>
+                        <value>novelistic</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">is a narrative, motivating stage direction.</a:documentation>
+                        <value>delivery</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes how a character speaks.</a:documentation>
+                        <value>modifier</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives some detail about a character.</a:documentation>
+                        <value>location</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a location.</a:documentation>
+                        <value>mixed</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">more than one of the above</a:documentation>
+                        <data type="token">
+                           <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                        </data>
+                     </choice>
+                  </zeroOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.global.facs.attributes">
+      <ref name="sgaatt.global.facs.attribute.facs"/>
+   </define>
+   <define name="sgaatt.global.facs.attribute.facs">
+      <optional>
+         <attribute name="facs">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(facsimile) points to all or part of an image which corresponds with the content of the element.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attributes">
+      <ref name="sgaatt.coordinated.attribute.start"/>
+      <ref name="sgaatt.coordinated.attribute.ulx"/>
+      <ref name="sgaatt.coordinated.attribute.uly"/>
+      <ref name="sgaatt.coordinated.attribute.lrx"/>
+      <ref name="sgaatt.coordinated.attribute.lry"/>
+      <ref name="sgaatt.coordinated.attribute.points"/>
+   </define>
+   <define name="sgaatt.coordinated.attribute.start">
+      <optional>
+         <attribute name="start">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the element within a transcription of the text containing at least the start of the writing represented by this zone or surface.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.ulx">
+      <optional>
+         <attribute name="ulx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.uly">
+      <optional>
+         <attribute name="uly">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.lrx">
+      <optional>
+         <attribute name="lrx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.lry">
+      <optional>
+         <attribute name="lry">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.coordinated.attribute.points">
+      <optional>
+         <attribute name="points">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a two dimensional area within the bounding box specified by the other attributes by means of a series of pairs of numbers, each of which gives the x,y coordinates of a point on a line enclosing the area.</a:documentation>
+            <list>
+               <data type="token">
+                  <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+               </data>
+               <data type="token">
+                  <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+               </data>
+               <data type="token">
+                  <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+               </data>
+               <zeroOrMore>
+                  <data type="token">
+                     <param name="pattern">(\-?[0-9]+\.?[0-9]*,\-?[0-9]+\.?[0-9]*)</param>
+                  </data>
+               </zeroOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgafacsimile">
+      <element name="facsimile">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a representation of some written source in the form of a set of images rather than as transcribed or encoded text. [11.1. Digital Facsimiles]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgafront"/>
+            </optional>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.graphicLike"/>
+                  <ref name="sgasurface"/>
+                  <ref name="sgasurfaceGrp"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <optional>
+               <ref name="sgaback"/>
+            </optional>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasourceDoc">
+      <element name="sourceDoc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a transcription or other representation of a single source document potentially forming part of a dossier génétique or collection of sources. [11.1. Digital Facsimiles 11.2.2. Embedded Transcription]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.global"/>
+               <ref name="sgamodel.graphicLike"/>
+               <ref name="sgasurface"/>
+               <ref name="sgasurfaceGrp"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurface">
+      <element name="surface">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines a written surface as a two-dimensional coordinate space, optionally grouping one or more graphic representations of that space, zones of interest within that space, and transcriptions of the writing within them. [11.1. Digital Facsimiles 11.2.2. Embedded Transcription]</a:documentation>
+         <group>
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.graphicLike"/>
+               </choice>
+            </zeroOrMore>
+            <zeroOrMore>
+               <group>
+                  <choice>
+                     <ref name="sgazone"/>
+                     <ref name="sgaline"/>
+                  </choice>
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+               </group>
+            </zeroOrMore>
+         </group>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="tei"
+             uri="http://www.tei-c.org/ns/1.0"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.rend"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.coordinated.attribute.start"/>
+         <ref name="sgaatt.coordinated.attribute.points"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <attribute name="xml:id">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) provides a unique identifier for the element bearing the attribute.</a:documentation>
+            <data type="ID"/>
+         </attribute>
+         <optional>
+            <attribute name="n">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) gives a number (or other label) for an element, which is not necessarily unique within the document.</a:documentation>
+               <data type="string"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="partOf">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(corresponds) Syntactic sugar attribute—should refer to the id of the sourceDoc element with which this surface should be associated</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <attribute name="ulx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <attribute name="uly">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the upper left corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <attribute name="lrx">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the x coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <attribute name="lry">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the y coordinate value for the lower right corner of a rectangular space.</a:documentation>
+            <choice>
+               <data type="double"/>
+               <data type="token">
+                  <param name="pattern">(\-?[\d]+/\-?[\d]+)</param>
+               </data>
+               <data type="decimal"/>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute name="shelfmark" ns="http://mith.umd.edu/sc/ns1#">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="folio" ns="http://mith.umd.edu/sc/ns1#">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurfaceGrp">
+      <element name="surfaceGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines any kind of useful grouping of written surfaces, for example the recto and verso of a single leaf, which the encoder wishes to treat as a single unit. [11.1. Digital Facsimiles]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.global"/>
+               <ref name="sgasurface"/>
+               <ref name="sgasurfaceGrp"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgazone">
+      <element name="zone">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines any two-dimensional area within a surface element. [11.1. Digital Facsimiles 11.2.2. Embedded Transcription]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.graphicLike"/>
+               <ref name="sgamodel.milestoneLike"/>
+               <ref name="sgamodel.noteLike"/>
+               <ref name="sgamodel.global.edit"/>
+               <ref name="sgametamark"/>
+               <ref name="sgamodel.linePart"/>
+               <ref name="sgaalt"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.coordinated.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.written.attributes"/>
+         <attribute name="type">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>top</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Material that can appear at the top of a manuscript page—like headings or notes</a:documentation>
+               <value>left_margin</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Zone for marginal additions, deletions, and other modifications. More than one zone with this type may appear in a document if marginal zones are distinct interventions.</a:documentation>
+               <value>main</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The main block of text on a page</a:documentation>
+               <value>pagination</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">For segments of a page where page numbers have been added in one or more original hands; distinct from later additions by librarians/collectors</a:documentation>
+               <value>library</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A zone of writing which appears to have been added by librarians/collectors at a later date—often page numbers</a:documentation>
+               <value>sketch</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A zone identifying a sketch or doodle</a:documentation>
+               <value>calculation</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A zone identifying a written calculation</a:documentation>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="rotate"
+                       a:defaultValue="0">
+               <a:documentation>indicates the amount by which this zone has been rotated clockwise, with respect to the normal orientation of the parent surface element as implied by the dimensions given in the msDesc element or by the coordinates of the surface itself. The orientation is expressed in arc degrees.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddSpan">
+      <element name="addSpan">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(added span of text) marks the beginning of a longer sequence of text added by an author, scribe, annotator or corrector (see also add). [11.3.1.4. Additions and Deletions]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-addSpan-spanTo-constraint-assert-8">
+            <rule context="tei:addSpan">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@spanTo">The @spanTo attribute of <sch:name/> is required.</sch:assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-addSpan-spanTo_fr-constraint-assert-9">
+            <rule context="tei:addSpan">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="@spanTo">L'attribut spanTo est requis.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadamage">
+      <element name="damage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an area of damage to the text witness. [11.3.3.1. Damage, Illegibility, and Supplied Text]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.damaged.attributes"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>inkblot</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>tear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>cut</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadamageSpan">
+      <element name="damageSpan">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(damaged span of text) marks the beginning of a longer sequence of text which is damaged in some way but still legible. [11.3.3.1. Damage, Illegibility, and Supplied Text]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-damageSpan-spanTo-constraint-assert-10">
+            <rule context="tei:damageSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">
+The @spanTo attribute of <name/> is required.</assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-damageSpan-spanTo_fr-constraint-assert-11">
+            <rule context="tei:damageSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">L'attribut spanTo est requis.</assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.damaged.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadelSpan">
+      <element name="delSpan">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deleted span of text) marks the beginning of a longer sequence of text deleted, marked as deleted, or otherwise signaled as superfluous or spurious by an author, scribe, annotator, or corrector. [11.3.1.4. Additions and Deletions]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-delSpan-spanTo-constraint-assert-12">
+            <rule context="tei:delSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">The @spanTo attribute of <name/> is required.</assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-delSpan-spanTo_fr-constraint-assert-13">
+            <rule context="tei:delSpan">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@spanTo">L'attribut spanTo est requis.</assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandNotes">
+      <element name="handNotes">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains one or more handNote elements documenting the different hands identified within the source texts. [11.3.2.1. Document Hands]</a:documentation>
+         <oneOrMore>
+            <ref name="sgahandNote"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandShift">
+      <element name="handShift">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">marks the beginning of a sequence of text written in a new hand, or the beginning of a scribal stint. [11.3.2.1. Document Hands]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attribute.scribe"/>
+         <ref name="sgaatt.handFeatures.attribute.scribeRef"/>
+         <ref name="sgaatt.handFeatures.attribute.script"/>
+         <ref name="sgaatt.handFeatures.attribute.scriptRef"/>
+         <ref name="sgaatt.handFeatures.attribute.scope"/>
+         <attribute name="medium">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>pen</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>pencil</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <attribute name="new">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            <choice>
+               <value>#pbs</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>#mws</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <value>#library</value>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+            </choice>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarestore">
+      <element name="restore">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates restoration of text to an earlier state by cancellation of an editorial or authorial marking or instruction. [11.3.1.6. Cancellation of Deletions and Other Markings]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>stetdots</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>smear_strikethrough</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>underline</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaspace">
+      <element name="space">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of a significant space in the text. [11.5.1. Space]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.rend"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <optional>
+            <attribute name="resp">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsible party) (responsible party) indicates the individual responsible for identifying and measuring the space</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="dim">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(dimension) indicates whether the space is horizontal or vertical.</a:documentation>
+               <choice>
+                  <value>horizontal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the space is horizontal.</a:documentation>
+                  <value>vertical</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the space is vertical.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasubst">
+      <element name="subst">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution) groups one or more deletions with one or more additions when the combination is to be regarded as a single intervention in the text. [11.3.1.5. Substitutions]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgaadd"/>
+               <ref name="sgadel"/>
+               <ref name="sgamodel.milestoneLike"/>
+            </choice>
+         </oneOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-subst-substContents1-constraint-assert-14">
+            <rule context="tei:subst">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="child::tei:add and child::tei:del">
+                  <name/> must have at least one child add and at least one child del</assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.transcriptional.attribute.seq"/>
+         <ref name="sgaatt.editLike.attribute.evidence"/>
+         <ref name="sgaatt.editLike.attribute.instant"/>
+         <ref name="sgaatt.dimensions.attribute.unit"/>
+         <ref name="sgaatt.dimensions.attribute.quantity"/>
+         <ref name="sgaatt.dimensions.attribute.extent"/>
+         <ref name="sgaatt.dimensions.attribute.precision"/>
+         <ref name="sgaatt.dimensions.attribute.scope"/>
+         <ref name="sgaatt.ranging.attribute.atLeast"/>
+         <ref name="sgaatt.ranging.attribute.atMost"/>
+         <ref name="sgaatt.ranging.attribute.min"/>
+         <ref name="sgaatt.ranging.attribute.max"/>
+         <ref name="sgaatt.ranging.attribute.confidence"/>
+         <optional>
+            <attribute name="cause">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>clarify</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>fix</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="hand">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>#pbs</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>#mws</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>#library</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasubstJoin">
+      <element name="substJoin">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution join) identifies a series of possibly fragmented additions, deletions or other revisions on a manuscript that combine to make up a single intervention in the text [11.3.1.5. Substitutions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasecl">
+      <element name="secl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(secluded text) Secluded. Marks text present in the source which the editor believes to be genuine but out of its original place (which is unknown). [11.3.1.7. Text Omitted from or Supplied in the Transcription]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <optional>
+            <attribute name="reason">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">one or more words indicating why this text has been secluded, e.g. interpolated etc.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaline">
+      <element name="line">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the transcription of a topographic line in the source document [11.2.2. Embedded Transcription]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.global"/>
+               <ref name="sgamodel.segLike"/>
+               <ref name="sgamodel.hiLike"/>
+               <ref name="sgazone"/>
+               <ref name="sgaline"/>
+               <ref name="sgadel"/>
+               <ref name="sgaadd"/>
+               <ref name="sgaunclear"/>
+               <ref name="sgadamage"/>
+               <ref name="sgahandShift"/>
+               <ref name="sgamod"/>
+               <ref name="sgaretrace"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.coordinated.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <choice>
+                     <value>right</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>center</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>left</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+                  <data type="string">
+                     <param name="pattern">indent\d</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistTranspose">
+      <element name="listTranspose">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a list of transpositions, each of which is indicated at some point in a document typically by means of metamarks. [11.3.4.5. Transpositions]</a:documentation>
+         <oneOrMore>
+            <ref name="sgatranspose"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgametamark">
+      <element name="metamark">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains or describes any kind of graphic or written signal within a document the function of which is to determine how it should be read rather than forming part of the actual content of the document. [11.3.4.2. Metamarks]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.attribute.xmlspace"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <optional>
+            <attribute name="rend">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+Suggested values include: 1] line; 2] short_line; 3] wavey_short_line; 4] left_bracket_short_line; 5] short_vertical_line; 6] top_left_bracket; 7] caret; 8] left_caret; 9] cross; 10] star</a:documentation>
+               <choice>
+                  <value>line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A line, often used to separate content.</a:documentation>
+                  <value>short_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A short line, similar to an underline, but often used to separate content, not for emphasis (in which case hi[@rend="underline"] is used</a:documentation>
+                  <value>wavey_short_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A wavey short line, similar to an underline, but often used to separate content, not for emphasis (in which case hi[@rend="underline"] is used</a:documentation>
+                  <value>left_bracket_short_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A line wrapping some text starting from the top left corner, then curving to underline the text. Often used to separate content.</a:documentation>
+                  <value>short_vertical_line</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A short vertical line, often used inline to separate words or to indicate insertion.</a:documentation>
+                  <value>top_left_bracket</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A corner bracket located in the top left of a word.</a:documentation>
+                  <value>caret</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A caret pointing upwards. This is often encoded literally in SGA for convenience. This value provides an alternative way of encoding it.</a:documentation>
+                  <value>left_caret</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A caret pointing left.</a:documentation>
+                  <value>cross</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A cross, often used for displacement. This is often encoded literally in SGA for convenience. This value provides an alternative way of encoding it.</a:documentation>
+                  <value>star</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A star or asterisk, often used for displacement. This is often encoded literally in SGA for convenience. This value provides an alternative way of encoding it.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="function">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>count</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>insert</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>separate</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>paragraph</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>displacement</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>transpose</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>sequence</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>alternate</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>unclear</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>math_operation</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Perform a mathematical operation (e.g. a sum). Usually rendered a as line</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies one or more elements to which the metamark applies.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamod">
+      <element name="mod">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">represents any kind of modification identified within a single document. [11.3.4.1. Generic Modification]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.inter"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-mod-modContents-constraint-rule-10">
+            <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="tei:mod">
+                                    <sch:report test="not(@spanTo) and not(tei:restore) and not(count(node()) gt 1)">The mod element is
+                                        intended to group a series of related changes to the
+                                        manuscript. Thus, mod must have more than one child
+                                        element. If only a single addition or deletion is being
+                                        encoded, mod is not required.</sch:report>
+                                </sch:rule>
+         </pattern>
+         <ref name="sgaatt.global.attribute.el-target"/>
+         <ref name="sgaatt.global.attribute.att-target"/>
+         <ref name="sgaatt.global.attribute.att-value"/>
+         <ref name="sgaatt.global.attribute.xmlid"/>
+         <ref name="sgaatt.global.attribute.n"/>
+         <ref name="sgaatt.global.attribute.xmllang"/>
+         <ref name="sgaatt.global.attribute.xmlbase"/>
+         <ref name="sgaatt.global.rendition.attribute.rend"/>
+         <ref name="sgaatt.global.rendition.attribute.style"/>
+         <ref name="sgaatt.global.rendition.attribute.rendition"/>
+         <ref name="sgaatt.global.linking.attribute.corresp"/>
+         <ref name="sgaatt.global.linking.attribute.next"/>
+         <ref name="sgaatt.global.linking.attribute.prev"/>
+         <ref name="sgaatt.global.facs.attribute.facs"/>
+         <ref name="sgaatt.global.responsibility.attribute.cert"/>
+         <ref name="sgaatt.global.responsibility.attribute.resp"/>
+         <ref name="sgaatt.global.source.attribute.source"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <optional>
+            <attribute name="xml:space">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>preserve</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>additions</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>deletions</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaretrace">
+      <element name="retrace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a sequence of writing which has been retraced, for example by over-inking, to clarify or fix it. [11.3.4.3. Fixation and Clarification]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.spanning.attributes"/>
+         <ref name="sgaatt.transcriptional.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatranspose">
+      <element name="transpose">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a single textual transposition as an ordered list of at least two pointers specifying the order in which the elements indicated should be re-combined. [11.3.4.5. Transpositions]</a:documentation>
+         <group>
+            <ref name="sgaptr"/>
+      
+            <oneOrMore>
+               <ref name="sgaptr"/>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgag">
+      <element name="g">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character or glyph) represents a glyph, or a non-standard character. [5. Characters, Glyphs, and Writing Modes]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="ref">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to a description of the character or glyph intended.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgachar">
+      <element name="char">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character) provides descriptive information about a character. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgacharName"/>
+            </optional>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.descLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgacharProp"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamapping"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgafigure"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.graphicLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.noteLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacharName">
+      <element name="charName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character name) contains the name of a character, expressed following Unicode conventions. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacharProp">
+      <element name="charProp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character property) provides a name and value for some property of the parent character or glyph. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+            <choice>
+               <ref name="sgaunicodeName"/>
+               <ref name="sgalocalName"/>
+            </choice>
+            <ref name="sgavalue"/>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacharDecl">
+      <element name="charDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character declarations) provides information about nonstandard characters and glyphs. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgadesc"/>
+            </optional>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgachar"/>
+                  <ref name="sgaglyph"/>
+               </choice>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaglyph">
+      <element name="glyph">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character glyph) provides descriptive information about a character glyph. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgaglyphName"/>
+            </optional>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.descLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgacharProp"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamapping"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgafigure"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.graphicLike"/>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.noteLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaglyphName">
+      <element name="glyphName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character glyph name) contains the name of a glyph, expressed following Unicode conventions for character names. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocalName">
+      <element name="localName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(locally-defined property name) contains a locally defined name for some property. [5.2.1. Character Properties]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamapping">
+      <element name="mapping">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character mapping) contains one or more characters which are related to the parent character or glyph in some respect, as specified by the type attribute. [5.2. Markup Constructs for Representation of Characters and Glyphs]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaunicodeName">
+      <element name="unicodeName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unicode property name) contains the name of a registered Unicode normative or informative property. [5.2.1. Character Properties]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="version">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the version number of the Unicode Standard in which this property name is defined.</a:documentation>
+               <data type="token">
+                  <param name="pattern">[\d]+(\.[\d]+){0,2}</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgavalue">
+      <element name="value">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single value for some property, attribute, or other analysis. [5.2.1. Character Properties]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.global.linking.attributes">
+      <ref name="sgaatt.global.linking.attribute.corresp"/>
+      <ref name="sgaatt.global.linking.attribute.next"/>
+      <ref name="sgaatt.global.linking.attribute.prev"/>
+   </define>
+   <define name="sgaatt.global.linking.attribute.corresp">
+      <optional>
+         <attribute name="corresp">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(corresponds) points to elements that correspond to the current element in some way.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.linking.attribute.next">
+      <optional>
+         <attribute name="next">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to the next element of a virtual aggregate of which the current element is part.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.global.linking.attribute.prev">
+      <optional>
+         <attribute name="prev">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(previous) points to the previous element of a virtual aggregate of which the current element is part.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgalink">
+      <element name="link">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines an association or hypertextual link among elements or passages, of some type not more precisely specifiable by other elements. [16.1. Links]</a:documentation>
+         <empty/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-link-linkTargets3-constraint-assert-15">
+            <rule context="tei:link">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="contains(normalize-space(@target),' ')">You must supply at least two values for @target or  on <sch:name/>
+               </sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalinkGrp">
+      <element name="linkGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(link group) defines a collection of associations or hypertextual links. [16.1. Links]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgalink"/>
+               <ref name="sgaptr"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.group.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaanchor">
+      <element name="anchor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anchor point) attaches an identifier to a point within a text, whether or not it corresponds with a textual element. [8.4.2. Synchronization and Overlap 16.5. Correspondence and Alignment]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaseg">
+      <element name="seg">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(arbitrary segment) represents any segmentation of text below the chunk level. [16.3. Blocks, Segments, and Anchors 6.2. Components of the Verse Line 7.2.5. Speech Contents]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.segLike.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.written.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               <choice>
+                  <value>alternative</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgajoin">
+      <element name="join">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a possibly fragmented segment of text, by pointing at the possibly discontiguous elements which compose it. [16.7. Aggregation]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.descLike"/>
+               <ref name="sgamodel.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-join-joinTargets3-constraint-assert-16">
+            <rule context="tei:join">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="contains(@target,' ')">
+You must supply at least two values for @target on <name/>
+               </assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="result">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the name of an element which this aggregation may be understood to represent.</a:documentation>
+               <data type="Name"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="scope"
+                       a:defaultValue="root">
+               <a:documentation>indicates whether the targets to be joined include the entire element indicated (the entire subtree including its root), or just the children of the target (the branches of the subtree).</a:documentation>
+               <choice>
+                  <value>root</value>
+                  <a:documentation>the rooted subtrees indicated by the target attribute are joined, each subtree become a child of the virtual element created by the join</a:documentation>
+                  <value>branches</value>
+                  <a:documentation>the children of the subtrees indicated by the target attribute become the children of the virtual element (i.e. the roots of the subtrees are discarded)</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgajoinGrp">
+      <element name="joinGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(join group) groups a collection of join elements and possibly pointers. [16.7. Aggregation]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.glossLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgajoin"/>
+                  <ref name="sgaptr"/>
+               </choice>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.group.attributes"/>
+         <optional>
+            <attribute name="result">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the default value for the result on each join included within the group.</a:documentation>
+               <data type="Name"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaalt">
+      <element name="alt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternation) identifies an alternation or a set of choices among elements or passages. [16.8. Alternation]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attribute.targetLang"/>
+         <ref name="sgaatt.pointing.attribute.evaluate"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the destination of the reference by supplying one or more URI References</a:documentation>
+               <list>
+                  <data type="anyURI"/>
+                  <data type="anyURI"/>
+                  <zeroOrMore>
+                     <data type="anyURI"/>
+                  </zeroOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="mode">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">states whether the alternations gathered in this collection are exclusive or inclusive.</a:documentation>
+               <choice>
+                  <value>excl</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(exclusive) indicates that the alternation is exclusive, i.e. that at most one of the alternatives occurs.</a:documentation>
+                  <value>incl</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(inclusive) indicates that the alternation is not exclusive, i.e. that one or more of the alternatives occur.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="weights">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If mode is excl, each weight states the probability that the corresponding alternative occurs. If mode is incl each weight states the probability that the corresponding alternative occurs given that at least one of the other alternatives occurs.</a:documentation>
+               <list>
+                  <data type="double"/>
+                  <data type="double"/>
+                  <zeroOrMore>
+                     <data type="double"/>
+                  </zeroOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafigure">
+      <element name="figure">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups elements representing or containing graphic information such as an illustration, formula, or figure. [14.4. Specific Elements for Graphic Images]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.headLike"/>
+               <ref name="sgamodel.common"/>
+               <ref name="sgafigDesc"/>
+               <ref name="sgamodel.graphicLike"/>
+               <ref name="sgamodel.global"/>
+               <ref name="sgamodel.divBottom"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.placement.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafigDesc">
+      <element name="figDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of figure) contains a brief prose description of the appearance or content of a graphic figure, for use when documenting an image without displaying it. [14.4. Specific Elements for Graphic Images]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.patternReplacement.attributes">
+      <ref name="sgaatt.patternReplacement.attribute.matchPattern"/>
+      <ref name="sgaatt.patternReplacement.attribute.replacementPattern"/>
+   </define>
+   <define name="sgaatt.patternReplacement.attribute.matchPattern">
+      <attribute name="matchPattern">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a regular expression against which the values of other attributes can be matched.</a:documentation>
+         <data type="token"/>
+      </attribute>
+   </define>
+   <define name="sgaatt.patternReplacement.attribute.replacementPattern">
+      <attribute name="replacementPattern">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a replacement pattern, that is, the skeleton of a relative or absolute URI containing references to groups in the matchPattern which, once subpattern substitution has been performed, complete the URI.</a:documentation>
+         <text/>
+      </attribute>
+   </define>
+   <define name="sgateiHeader">
+      <element name="teiHeader">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI header) supplies descriptive and declarative metadata associated with a digital resource or set of resources. [2.1.1. The TEI Header and Its Components 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+            <ref name="sgafileDesc"/>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.teiHeaderPart"/>
+            </zeroOrMore>
+      
+      
+            <optional>
+               <ref name="sgarevisionDesc"/>
+            </optional>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafileDesc">
+      <element name="fileDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file description) contains a full bibliographic description of an electronic file. [2.2. The File Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <group>
+            <group>
+               <ref name="sgatitleStmt"/>
+        
+               <optional>
+                  <ref name="sgaeditionStmt"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgaextent"/>
+               </optional>
+        
+               <ref name="sgapublicationStmt"/>
+        
+               <optional>
+                  <ref name="sgaseriesStmt"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sganotesStmt"/>
+               </optional>
+        
+            </group>
+      
+            <oneOrMore>
+               <ref name="sgasourceDesc"/>
+            </oneOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitleStmt">
+      <element name="titleStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title statement) groups information about the title of a work and those responsible for its content. [2.2.1. The Title Statement 2.2. The File Description]</a:documentation>
+         <group>
+      
+            <oneOrMore>
+               <ref name="sgatitle"/>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.respLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasponsor">
+      <element name="sponsor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the name of a sponsoring organization or institution. [2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafunder">
+      <element name="funder">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(funding body) specifies the name of an individual, institution, or organization responsible for the funding of a project or text. [2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprincipal">
+      <element name="principal">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(principal researcher) supplies the name of the principal researcher responsible for the creation of an electronic text. [2.2.1. The Title Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaeditionStmt">
+      <element name="editionStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition statement) groups information relating to one edition of a text. [2.2.2. The Edition Statement 2.2. The File Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+               <ref name="sgaedition"/>
+        
+               <zeroOrMore>
+                  <ref name="sgamodel.respLike"/>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaedition">
+      <element name="edition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the particularities of one edition of a text. [2.2.2. The Edition Statement]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaextent">
+      <element name="extent">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the approximate size of a text stored on some carrier medium or of some other object, digital or non-digital, specified in any convenient units. [2.2.3. Type and Extent of File 2.2. The File Description 3.11.2.4. Imprint, Size of a Document, and Reprint Information 10.7.1. Object Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapublicationStmt">
+      <element name="publicationStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication statement) groups information concerning the publication or distribution of an electronic or other text. [2.2.4. Publication, Distribution, Licensing, etc. 2.2. The File Description]</a:documentation>
+         <choice>
+      
+	           <oneOrMore>
+               <group>
+	  
+	                 <ref name="sgamodel.publicationStmtPart.agency"/>
+	  
+	  
+	                 <zeroOrMore>
+                     <ref name="sgamodel.publicationStmtPart.detail"/>
+                  </zeroOrMore>
+	  
+	              </group>
+            </oneOrMore>
+      
+      
+	           <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadistributor">
+      <element name="distributor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the name of a person or other agency responsible for the distribution of a text. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaauthority">
+      <element name="authority">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(release authority) supplies the name of a person or other agency responsible for making a work available, other than a publisher or distributor. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaidno">
+      <element name="idno">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) supplies any form of identifier used to identify some object, such as a bibliographic item, a person, a title, an organization, etc. in a standardized way. [2.2.4. Publication, Distribution, Licensing, etc. 2.2.5. The Series Statement 3.11.2.4. Imprint, Size of a Document, and Reprint Information]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgaidno"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">categorizes the identifier, for example as an ISBN, Social Security number, etc.
+Suggested values include: 1] ISBN; 2] ISSN; 3] DOI; 4] URI; 5] VIAF; 6] ESTC; 7] OCLC</a:documentation>
+               <choice>
+                  <value>ISBN</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">International Standard Book Number: a 13- or (if assigned prior to 2007) 10-digit identifying number assigned by the publishing industry to a published book or similar item, registered with the International ISBN Agency.</a:documentation>
+                  <value>ISSN</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">International Standard Serial Number: an eight-digit number to uniquely identify a serial publication.</a:documentation>
+                  <value>DOI</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Digital Object Identifier: a unique string of letters and numbers assigned to an electronic document.</a:documentation>
+                  <value>URI</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Uniform Resource Identifier: a string of characters to uniquely identify a resource which usually contains indication of the means of accessing that resource, the name of its host, and its filepath.</a:documentation>
+                  <value>VIAF</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A data number in the Virtual Internet Authority File assigned to link different names in catalogs around the world for the same entity.</a:documentation>
+                  <value>ESTC</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">English Short-Title Catalogue number: an identifying number assigned to a document in English printed in the British Isles or North America before 1801.</a:documentation>
+                  <value>OCLC</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">union catalog number in WorldCat representing a resource held by one or more of the member libraries in the global cooperative Online Computer Library Center.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaavailability">
+      <element name="availability">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies information about the availability of a text, for example any restrictions on its use or distribution, its copyright status, any licence applying to it, etc. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.availabilityPart"/>
+               <ref name="sgamodel.pLike"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="status"
+                       a:defaultValue="unknown">
+               <a:documentation>supplies a code identifying the current availability of the text.</a:documentation>
+               <choice>
+                  <value>free</value>
+                  <a:documentation>the text is freely available.</a:documentation>
+                  <value>unknown</value>
+                  <a:documentation>the status of the text is unknown.</a:documentation>
+                  <value>restricted</value>
+                  <a:documentation>the text is not freely available.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalicence">
+      <element name="licence">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a licence or other legal agreement applicable to the text. [2.2.4. Publication, Distribution, Licensing, etc.]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaseriesStmt">
+      <element name="seriesStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series statement) groups information about the series, if any, to which a publication belongs. [2.2.5. The Series Statement 2.2. The File Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <oneOrMore>
+                  <ref name="sgatitle"/>
+               </oneOrMore>
+        
+        
+               <zeroOrMore>
+                  <choice>
+            
+                     <ref name="sgarespStmt"/>
+                  </choice>
+               </zeroOrMore>
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgaidno"/>
+            
+                  </choice>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganotesStmt">
+      <element name="notesStmt">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(notes statement) collects together any notes providing information about a text additional to that recorded in other parts of the bibliographic description. [2.2.6. The Notes Statement 2.2. The File Description]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.noteLike"/>
+               <ref name="sgarelatedItem"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasourceDesc">
+      <element name="sourceDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source description) describes the source from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as "born digital" for a text which has no previous existence. [2.2.7. The Source Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgamodel.sourceDescPart"/>
+                  <ref name="sgamodel.listLike"/>
+               </choice>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabiblFull">
+      <element name="biblFull">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(fully-structured bibliographic citation) contains a fully-structured bibliographic citation, in which all components of the TEI file description are present. [3.11.1. Methods of Encoding Bibliographic References and Lists of References 2.2. The File Description 2.2.7. The Source Description 15.3.2. Declarable Elements]</a:documentation>
+         <choice>
+            <group>
+               <group>
+                  <ref name="sgatitleStmt"/>
+                  <optional>
+                     <ref name="sgaeditionStmt"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaextent"/>
+                  </optional>
+                  <ref name="sgapublicationStmt"/>
+                  <optional>
+                     <ref name="sgaseriesStmt"/>
+                  </optional>
+                  <optional>
+                     <ref name="sganotesStmt"/>
+                  </optional>
+               </group>
+               <zeroOrMore>
+                  <ref name="sgasourceDesc"/>
+               </zeroOrMore>
+            </group>
+            <group>
+               <ref name="sgafileDesc"/>
+               <ref name="sgaprofileDesc"/>
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaencodingDesc">
+      <element name="encodingDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(encoding description) documents the relationship between an electronic text and the source or sources from which it was derived. [2.3. The Encoding Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.encodingDescPart"/>
+               <ref name="sgamodel.pLike"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaschemaRef">
+      <element name="schemaRef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(schema reference) describes or points to a related customization or schema file [2.3.9. The Schema Specification]</a:documentation>
+         <optional>
+            <ref name="sgamodel.descLike"/>
+         </optional>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.resourced.attributes"/>
+         <optional>
+            <attribute name="key">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">the identifier used for the customization or schema</a:documentation>
+               <data type="NCName"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprojectDesc">
+      <element name="projectDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(project description) describes in detail the aim or purpose for which an electronic file was encoded, together with any other relevant information concerning the process by which it was assembled or collected. [2.3.1. The Project Description 2.3. The Encoding Description 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasamplingDecl">
+      <element name="samplingDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sampling declaration) contains a prose description of the rationale and methods used in sampling texts in the creation of a corpus or collection. [2.3.2. The Sampling Declaration 2.3. The Encoding Description 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaeditorialDecl">
+      <element name="editorialDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(editorial practice declaration) provides details of editorial principles and practices applied during the encoding of a text. [2.3.3. The Editorial Practices Declaration 2.3. The Encoding Description 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgamodel.editorialDeclPart"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrection">
+      <element name="correction">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correction principles) states how and under what circumstances corrections have been made in the text. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="status"
+                       a:defaultValue="unknown">
+               <a:documentation>indicates the degree of correction applied to the text.</a:documentation>
+               <choice>
+                  <value>high</value>
+                  <a:documentation>the text has been thoroughly checked and proofread.</a:documentation>
+                  <value>medium</value>
+                  <a:documentation>the text has been checked at least once.</a:documentation>
+                  <value>low</value>
+                  <a:documentation>the text has not been checked.</a:documentation>
+                  <value>unknown</value>
+                  <a:documentation>the correction status of the text is unknown.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="method"
+                       a:defaultValue="silent">
+               <a:documentation>indicates the method adopted to indicate corrections within the text.</a:documentation>
+               <choice>
+                  <value>silent</value>
+                  <a:documentation>corrections have been made silently</a:documentation>
+                  <value>markup</value>
+                  <a:documentation>corrections have been represented using markup</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganormalization">
+      <element name="normalization">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the extent of normalization or regularization of the original source carried out in converting it to electronic form. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="method"
+                       a:defaultValue="silent">
+               <a:documentation>indicates the method adopted to indicate normalizations within the text.</a:documentation>
+               <choice>
+                  <value>silent</value>
+                  <a:documentation>normalization made silently</a:documentation>
+                  <value>markup</value>
+                  <a:documentation>normalization represented using markup</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaquotation">
+      <element name="quotation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies editorial practice adopted with respect to quotation marks in the original. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-quotation-quotationContents-constraint-report-10">
+            <rule context="tei:quotation">
+               <report xmlns:xi="http://www.w3.org/2001/XInclude"
+                       xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="not(@marks) and not (tei:p)">
+On <name/>, either the @marks attribute should be used, or a paragraph of description provided</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute name="marks">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(quotation marks) indicates whether or not quotation marks have been retained as content within the text.</a:documentation>
+               <choice>
+                  <value>none</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">no quotation marks have been retained</a:documentation>
+                  <value>some</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">some quotation marks have been retained</a:documentation>
+                  <value>all</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">all quotation marks have been retained</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahyphenation">
+      <element name="hyphenation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">summarizes the way in which hyphenation in a source text has been treated in an encoded version of it. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="eol"
+                       a:defaultValue="some">
+               <a:documentation>(end-of-line) indicates whether or not end-of-line hyphenation has been retained in a text.</a:documentation>
+               <choice>
+                  <value>all</value>
+                  <a:documentation>all end-of-line hyphenation has been retained, even though the lineation of the original may not have been.</a:documentation>
+                  <value>some</value>
+                  <a:documentation>end-of-line hyphenation has been retained in some cases.</a:documentation>
+                  <value>hard</value>
+                  <a:documentation>all soft end-of-line hyphenation has been removed: any remaining end-of-line hyphenation should be retained.</a:documentation>
+                  <value>none</value>
+                  <a:documentation>all end-of-line hyphenation has been removed: any remaining hyphenation occurred within the line.</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasegmentation">
+      <element name="segmentation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the principles according to which the text has been segmented, for example into sentences, tone-units, graphemic strata, etc. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastdVals">
+      <element name="stdVals">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(standard values) specifies the format used when standardized date or number values are supplied. [2.3.3. The Editorial Practices Declaration 15.3.2. Declarable Elements]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgainterpretation">
+      <element name="interpretation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the scope of any analytic or interpretive information added to the text in addition to the transcription. [2.3.3. The Editorial Practices Declaration]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapunctuation">
+      <element name="punctuation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies editorial practice adopted with respect to punctuation marks in the original. [2.3.3. The Editorial Practices Declaration 3.2. Treatment of Punctuation]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="marks">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether or not punctation marks have been retained as content within the text.</a:documentation>
+               <choice>
+                  <value>none</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">no punctuation marks have been retained</a:documentation>
+                  <value>some</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">some punctuation marks have been retained</a:documentation>
+                  <value>all</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">all punctuation marks have been retained</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="placement">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether punctation marks have been captured inside or outside of an adjacent element.</a:documentation>
+               <choice>
+                  <value>internal</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">punctuation marks are captured inside adjacent elements</a:documentation>
+                  <value>external</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">punctuation marks are captured outside adjacent elements</a:documentation>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatagsDecl">
+      <element name="tagsDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(tagging declaration) provides detailed information about the tagging applied to a document. [2.3.4. The Tagging Declaration 2.3. The Encoding Description]</a:documentation>
+         <group>      
+            <zeroOrMore>
+               <ref name="sgarendition"/>
+            </zeroOrMore>
+            <zeroOrMore>
+               <ref name="sganamespace"/>
+            </zeroOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="partial">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether the element types listed exhaustively include all those found within text, or represent only a subset.</a:documentation>
+               <data type="boolean"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatagUsage">
+      <element name="tagUsage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">documents the usage of a specific element within a specified document. [2.3.4. The Tagging Declaration]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="gi">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(generic identifier) specifies the name (generic identifier) of the element indicated by the tag, within the namespace indicated by the parent namespace element.</a:documentation>
+            <data type="Name"/>
+         </attribute>
+         <optional>
+            <attribute name="occurs">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of occurrences of this element within the text.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="withId">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(with unique identifier) specifies the number of occurrences of this element within the text which bear a distinct value for the global xml:id attribute.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganamespace">
+      <element name="namespace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the formal name of the namespace to which the elements documented by its children belong. [2.3.4. The Tagging Declaration]</a:documentation>
+         <oneOrMore>
+            <ref name="sgatagUsage"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="name">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the full formal name of the namespace concerned.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarendition">
+      <element name="rendition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies information about the rendition or appearance of one or more elements in the source text. [2.3.4. The Tagging Declaration]</a:documentation>
+         <ref name="sgamacro.limitedContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.styleDef.attributes"/>
+         <optional>
+            <attribute name="scope">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">where CSS is used, provides a way of defining pseudo-elements, that is, styling rules applicable to specific sub-portions of an element.
+Sample values include: 1] first-line; 2] first-letter; 3] before; 4] after</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="selector">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a selector or series of selectors specifying the elements to which the contained style description applies, expressed in the language specified in the scheme attribute.</a:documentation>
+               <data type="string"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastyleDefDecl">
+      <element name="styleDefDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(style definition language declaration) specifies the name of the formal language in which style or renditional information is supplied elsewhere in the document. The specific version of the scheme may also be supplied. [2.3.5. The Default Style Definition Language Declaration]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.styleDef.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarefsDecl">
+      <element name="refsDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(references declaration) specifies how canonical references are constructed for this text. [2.3.6.3. Milestone Method 2.3. The Encoding Description 2.3.6. The Reference System Declaration]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgacRefPattern"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgarefState"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacRefPattern">
+      <element name="cRefPattern">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(canonical reference pattern) specifies an expression and replacement pattern for transforming a canonical reference into a URI. [2.3.6.3. Milestone Method 2.3.6. The Reference System Declaration 2.3.6.2. Search-and-Replace Method]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.patternReplacement.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprefixDef">
+      <element name="prefixDef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(prefix definition) defines a prefixing scheme used in data.pointer values, showing how abbreviated URIs using the scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.pLike"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.patternReplacement.attributes"/>
+         <attribute name="ident">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a name which functions as the prefix for an abbreviated pointing scheme such as a private URI scheme. The prefix constitutes the text preceding the first colon.</a:documentation>
+            <data type="token">
+               <param name="pattern">[a-z][a-z0-9\+\.\-]*</param>
+            </data>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistPrefixDef">
+      <element name="listPrefixDef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of prefix definitions) contains a list of definitions of prefixing schemes used in data.pointer values, showing how abbreviated URIs using each scheme may be expanded into full URIs. [16.2.3. Using Abbreviated Pointers]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgaprefixDef"/>
+               <ref name="sgalistPrefixDef"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarefState">
+      <element name="refState">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference state) specifies one component of a canonical reference defined by the milestone method. [2.3.6.3. Milestone Method 2.3.6. The Reference System Declaration]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.milestoneUnit.attributes"/>
+         <ref name="sgaatt.edition.attributes"/>
+         <optional>
+            <attribute name="length">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the fixed length of the reference component.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="delim">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(delimiter) supplies a delimiting string following the reference component.</a:documentation>
+               <data type="string"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaclassDecl">
+      <element name="classDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(classification declarations) contains one or more taxonomies defining any classificatory codes used elsewhere in the text. [2.3.7. The Classification Declaration 2.3. The Encoding Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgataxonomy"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgataxonomy">
+      <element name="taxonomy">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines a typology either implicitly, by means of a bibliographic citation, or explicitly by a structured taxonomy. [2.3.7. The Classification Declaration]</a:documentation>
+         <choice>
+      
+      
+      
+      
+      
+      
+      
+      
+            <choice>
+	              <oneOrMore>
+                  <choice>
+                     <ref name="sgacategory"/>
+                     <ref name="sgataxonomy"/>
+	                 </choice>
+               </oneOrMore>
+	              <group>
+	                 <oneOrMore>
+                     <choice>
+                        <ref name="sgamodel.glossLike"/>
+                        <ref name="sgamodel.descLike"/>
+	                    </choice>
+                  </oneOrMore>
+	                 <zeroOrMore>
+                     <choice>
+                        <ref name="sgacategory"/>
+                        <ref name="sgataxonomy"/>
+	                    </choice>
+                  </zeroOrMore>
+	              </group>
+            </choice>
+            <group>
+               <ref name="sgamodel.biblLike"/>
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgacategory"/>
+                     <ref name="sgataxonomy"/>
+                  </choice>
+               </zeroOrMore>
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacategory">
+      <element name="category">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an individual descriptive category, possibly nested within a superordinate category, within a user-defined taxonomy. [2.3.7. The Classification Declaration]</a:documentation>
+         <group>
+            <choice>
+        
+               <oneOrMore>
+                  <ref name="sgacatDesc"/>
+               </oneOrMore>
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.descLike"/>
+                     <ref name="sgamodel.glossLike"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </choice>
+      
+            <zeroOrMore>
+               <ref name="sgacategory"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacatDesc">
+      <element name="catDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(category description) describes some category within a taxonomy or text typology, either in the form of a brief prose description or in terms of the situational parameters used by the TEI formal textDesc. [2.3.7. The Classification Declaration]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.limitedPhrase"/>
+               <ref name="sgamodel.catDescPart"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageoDecl">
+      <element name="geoDecl">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographic coordinates declaration) documents the notation and the datum used for geographic coordinates expressed as content of the geo element elsewhere within the document. [2.3.8. The Geographic Coordinates Declaration]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="datum"
+                       a:defaultValue="WGS84">
+               <a:documentation>supplies a commonly used code name for the datum employed.
+Suggested values include: 1] WGS84(World Geodetic System) ; 2] MGRS(Military Grid Reference System) ; 3] OSGB36(ordnance survey great britain) ; 4] ED50(European Datum coordinate system) </a:documentation>
+               <choice>
+                  <value>WGS84</value>
+                  <a:documentation>(World Geodetic System) a pair of numbers to be interpreted as latitude followed by longitude according to the World Geodetic System.</a:documentation>
+                  <value>MGRS</value>
+                  <a:documentation>(Military Grid Reference System) the values supplied are geospatial entity object codes, based on</a:documentation>
+                  <value>OSGB36</value>
+                  <a:documentation>(ordnance survey great britain) the value supplied is to be interpreted as a British National Grid Reference.</a:documentation>
+                  <value>ED50</value>
+                  <a:documentation>(European Datum coordinate system) the value supplied is to be interpreted as latitude followed by longitude according to the European Datum coordinate system.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaappInfo">
+      <element name="appInfo">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(application information) records information about an application which has edited the TEI file. [2.3.10. The Application Information Element]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.applicationLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaapplication">
+      <element name="application">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about an application which has acted upon the document. [2.3.10. The Application Information Element]</a:documentation>
+         <group>
+      
+            <oneOrMore>
+               <ref name="sgamodel.labelLike"/>
+            </oneOrMore>
+      
+            <choice>
+        
+               <zeroOrMore>
+                  <ref name="sgamodel.ptrLike"/>
+               </zeroOrMore>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </zeroOrMore>
+        
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <attribute name="ident">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies an identifier for the application, independent of its version number or display name.</a:documentation>
+            <data type="Name"/>
+         </attribute>
+         <attribute name="version">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a version number for the application, independent of its identifier or display name.</a:documentation>
+            <data type="token">
+               <param name="pattern">[\d]+[a-z]*[\d]*(\.[\d]+[a-z]*[\d]*){0,3}</param>
+            </data>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprofileDesc">
+      <element name="profileDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text-profile description) provides a detailed description of non-bibliographic aspects of a text, specifically the languages and sublanguages used, the situation in which it was produced, the participants and their setting. [2.4. The Profile Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <zeroOrMore>
+            <ref name="sgamodel.profileDescPart"/>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandNote">
+      <element name="handNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(note on hand) describes a particular style or hand distinguished within a manuscript. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaabstract">
+      <element name="abstract">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a summary or formal abstract prefixed to an existing source document by the encoder. [2.4.4. Abstracts]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgamodel.listLike"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacreation">
+      <element name="creation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the creation of a text. [2.4.1. Creation 2.4. The Profile Description]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.limitedPhrase"/>
+               <ref name="sgalistChange"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalangUsage">
+      <element name="langUsage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language usage) describes the languages, sublanguages, registers, dialects, etc. represented within a text. [2.4.2. Language Usage 2.4. The Profile Description 15.3.2. Declarable Elements]</a:documentation>
+         <choice>
+        
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+         
+          
+            <oneOrMore>
+               <ref name="sgalanguage"/>
+            </oneOrMore>
+        
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalanguage">
+      <element name="language">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes a single language or sublanguage used within a text. [2.4.2. Language Usage]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="ident">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(identifier) Supplies a language code constructed as defined in BCP 47 which is used to identify the language documented by this element, and which is referenced by the global xml:lang attribute.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute name="usage">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the approximate percentage (by volume) of the text which uses this language.</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatextClass">
+      <element name="textClass">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text classification) groups information which describes the nature or topic of a text in terms of a standard classification scheme, thesaurus, etc. [2.4.3. The Text Classification]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgaclassCode"/>
+               <ref name="sgacatRef"/>
+               <ref name="sgakeywords"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgakeywords">
+      <element name="keywords">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a list of keywords or phrases identifying the topic or nature of a text. [2.4.3. The Text Classification]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgaterm"/>
+            </oneOrMore>
+      
+            <ref name="sgalist"/>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the controlled vocabulary within which the set of keywords concerned is defined, for example by a taxonomy element, or by some other resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaclassCode">
+      <element name="classCode">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(classification code) contains the classification code used for this text in some standard classification system. [2.4.3. The Text Classification]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <attribute name="scheme">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the classification system in use, as defined by, e.g. a taxonomy element, or some other resource.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacatRef">
+      <element name="catRef">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(category reference) specifies one or more defined categories within some taxonomy or text typology. [2.4.3. The Text Classification]</a:documentation>
+         <empty/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the classification scheme within which the set of categories concerned is defined, for example by a taxonomy element, or by some other resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacalendarDesc">
+      <element name="calendarDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(calendar description) contains a description of the calendar system used in any dating expression found in the text. [2.4. The Profile Description 2.4.5. Calendar Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgacalendar"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacalendar">
+      <element name="calendar">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a calendar or dating system used in a dating formula in the text. [2.4.5. Calendar Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.pLike"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrespDesc">
+      <element name="correspDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence
+    description) contains a description of the actions related to one act of correspondence. [2.4.6. Correspondence Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.correspDescPart"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrespAction">
+      <element name="correspAction">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence action) contains a structured description of the place, the name of a person/organization and the date related to the sending/receiving of a message or any other action related to the correspondence. [2.4.6. Correspondence Description]</a:documentation>
+         <choice>
+            <oneOrMore>
+               <ref name="sgamodel.correspActionPart"/>
+            </oneOrMore>
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the nature of the action.
+Suggested values include: 1] sent; 2] received; 3] transmitted; 4] redirected; 5] forwarded</a:documentation>
+               <choice>
+                  <value>sent</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the sending or dispatch of a message.</a:documentation>
+                  <value>received</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the receipt of a message.</a:documentation>
+                  <value>transmitted</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the transmission of a message, i.e. between the dispatch and the next receipt, redirect or forwarding.</a:documentation>
+                  <value>redirected</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the redirection of an unread message.</a:documentation>
+                  <value>forwarded</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">information concerning the forwarding of a message.</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacorrespContext">
+      <element name="correspContext">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correspondence context) provides references to preceding or following correspondence related to this piece of correspondence. [2.4.6. Correspondence Description]</a:documentation>
+         <oneOrMore>
+            <ref name="sgamodel.correspContextPart"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaxenoData">
+      <element name="xenoData">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(non-TEI metadata) provides a container element into which metadata in non-TEI formats may be placed. [2.5. Non-TEI Metadata]</a:documentation>
+         <choice>
+            <text/>
+            <ref name="anyElement-xenoData"/>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarevisionDesc">
+      <element name="revisionDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(revision description) summarizes the revision history for a file. [2.6. The Revision Description 2.1.1. The TEI Header and Its Components]</a:documentation>
+         <choice>
+            <ref name="sgalist"/>
+            <ref name="sgalistChange"/>
+      
+            <oneOrMore>
+               <ref name="sgachange"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgachange">
+      <element name="change">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">documents a change or set of changes made during the production of a source document, or during the revision of an electronic file. [2.6. The Revision Description 2.4.1. Creation 11.7. Identifying Changes and Revisions]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.ascribed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="target">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to one or more elements that belong to this change.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgascriptNote">
+      <element name="scriptNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a particular script distinguished within the description of a manuscript or similar resource. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistChange">
+      <element name="listChange">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups a number of change descriptions associated with either the creation of a source text or the revision of an encoded text. [2.6. The Revision Description 11.7. Identifying Changes and Revisions]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgalistChange"/>
+               <ref name="sgachange"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="ordered"
+                       a:defaultValue="true">
+               <a:documentation>indicates whether the ordering of its child change elements is to be considered significant or not</a:documentation>
+               <data type="boolean"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaTEI">
+      <element name="TEI">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI document) contains a single TEI-conformant document, combining a single TEI header with one or more members of the model.resourceLike class. Multiple TEI elements may be combined to form a teiCorpus element. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+            <ref name="sgateiHeader"/>
+            <oneOrMore>
+               <ref name="sgamodel.resourceLike"/>
+            </oneOrMore>
+         </group>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="tei"
+             uri="http://www.tei-c.org/ns/1.0"/>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="xs"
+             uri="http://www.w3.org/2001/XMLSchema"/>
+         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+             prefix="rng"
+             uri="http://relaxng.org/ns/structure/1.0"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="version">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the major version number of the TEI Guidelines against which this document is valid.</a:documentation>
+               <data type="token">
+                  <param name="pattern">[\d]+(\.[\d]+){0,2}</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatext">
+      <element name="text">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single text of any kind, whether unitary or composite, for example a poem or drama, a collection of essays, a novel, a dictionary, or a corpus sample. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgafront"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+            <choice>
+               <ref name="sgabody"/>
+               <ref name="sgagroup"/>
+            </choice>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgaback"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabody">
+      <element name="body">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text body) contains the whole body of a single unitary text, excluding any front or back matter. [4. Default Text Structure]</a:documentation>
+         <group>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+      
+      
+            <optional>
+               <group>
+          
+                  <ref name="sgamodel.divTop"/>
+          
+          
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.global"/>
+                        <ref name="sgamodel.divTop"/>
+                     </choice>
+                  </zeroOrMore>
+          
+               </group>
+            </optional>
+      
+      
+      
+            <optional>
+               <group>
+          
+                  <ref name="sgamodel.divGenLike"/>
+          
+          
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.global"/>
+                        <ref name="sgamodel.divGenLike"/>
+                     </choice>
+                  </zeroOrMore>
+          
+               </group>
+            </optional>
+      
+      
+        
+            <choice>
+          
+          
+               <oneOrMore>
+                  <group>
+              
+                     <ref name="sgamodel.divLike"/>
+              
+              
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.global"/>
+                           <ref name="sgamodel.divGenLike"/>
+                        </choice>
+                     </zeroOrMore>
+              
+                  </group>
+               </oneOrMore>
+          
+          
+          
+               <oneOrMore>
+                  <group>
+              
+                     <ref name="sgamodel.div1Like"/>
+              
+              
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.global"/>
+                           <ref name="sgamodel.divGenLike"/>
+                        </choice>
+                     </zeroOrMore>
+              
+                  </group>
+               </oneOrMore>
+          
+          
+               <group>
+                  <oneOrMore>
+                     <group>
+              
+                        <ref name="sgamodel.common"/>
+              
+              
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+              
+                     </group>
+                  </oneOrMore>
+            
+                  <optional>
+                     <choice>
+                
+                
+                        <oneOrMore>
+                           <group>
+                    
+                              <ref name="sgamodel.divLike"/>
+                    
+                    
+                              <zeroOrMore>
+                                 <choice>
+                                    <ref name="sgamodel.global"/>
+                                    <ref name="sgamodel.divGenLike"/>
+                                 </choice>
+                              </zeroOrMore>
+                    
+                           </group>
+                        </oneOrMore>
+                
+                
+                
+                        <oneOrMore>
+                           <group>
+                    
+                              <ref name="sgamodel.div1Like"/>
+                    
+                    
+                              <zeroOrMore>
+                                 <choice>
+                                    <ref name="sgamodel.global"/>
+                                    <ref name="sgamodel.divGenLike"/>
+                                 </choice>
+                              </zeroOrMore>
+                    
+                           </group>
+                        </oneOrMore>
+                
+                     </choice>
+                  </optional>
+            
+               </group>
+            </choice>
+        
+      
+      
+      
+            <zeroOrMore>
+               <group>
+          
+                  <ref name="sgamodel.divBottom"/>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+          
+               </group>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagroup">
+      <element name="group">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the body of a composite text, grouping together a sequence of distinct texts (or groups of such texts) which are regarded as a unit for some purpose, for example the collected works of an author, a sequence of prose essays, etc. [4. Default Text Structure 4.3.1. Grouped Texts 15.1. Varieties of Composite Text]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <group>
+               <choice>
+                  <ref name="sgatext"/>
+                  <ref name="sgagroup"/>
+               </choice>
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgatext"/>
+                     <ref name="sgagroup"/>
+                     <ref name="sgamodel.global"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.divBottom"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafloatingText">
+      <element name="floatingText">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a single text of any kind, whether unitary or composite, which interrupts the text containing it at any point and after which the surrounding text resumes. [4.3.2. Floating Texts]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgafront"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+            <choice>
+               <ref name="sgabody"/>
+               <ref name="sgagroup"/>
+            </choice>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <ref name="sgaback"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv">
+      <element name="div">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text division) contains a subdivision of the front, body, or back of a text. [4.1. Divisions of the Body]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+          
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+          
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.divLike"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+              
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+              
+                        </group>
+                     </oneOrMore>
+          
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.divLike"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-div-abstractModel-structure-l-constraint-report-11">
+            <rule context="tei:div">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="ancestor::tei:l">
+        Abstract model violation: Lines may not contain higher-level structural elements such as div.
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-div-abstractModel-structure-p-constraint-report-12">
+            <rule context="tei:div">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="ancestor::tei:p or ancestor::tei:ab and not(ancestor::tei:floatingText)">
+        Abstract model violation: p and ab may not contain higher-level structural elements such as div.
+      </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv1">
+      <element name="div1">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-1 text division) contains a first-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div2Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div2Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv2">
+      <element name="div2">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-2 text division) contains a second-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div3Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div3Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv3">
+      <element name="div3">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-3 text division) contains a third-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div4Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div4Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv4">
+      <element name="div4">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-4 text division) contains a fourth-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div5Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div5Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv5">
+      <element name="div5">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-5 text division) contains a fifth-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div6Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div6Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv6">
+      <element name="div6">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-6 text division) contains a sixth-level subdivision of the front, body, or back of a text. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+                     <oneOrMore>
+                        <group>
+                           <choice>
+                              <ref name="sgamodel.div7Like"/>
+                              <ref name="sgamodel.divGenLike"/>
+                           </choice>
+            
+                           <zeroOrMore>
+                              <ref name="sgamodel.global"/>
+                           </zeroOrMore>
+            
+                        </group>
+                     </oneOrMore>
+                     <group>
+                        <oneOrMore>
+                           <group>
+              
+                              <ref name="sgamodel.common"/>
+              
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </oneOrMore>
+                        <zeroOrMore>
+                           <group>
+                              <choice>
+                                 <ref name="sgamodel.div7Like"/>
+                                 <ref name="sgamodel.divGenLike"/>
+                              </choice>
+              
+                              <zeroOrMore>
+                                 <ref name="sgamodel.global"/>
+                              </zeroOrMore>
+              
+                           </group>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadiv7">
+      <element name="div7">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(level-7 text division) contains the smallest possible subdivision of the front, body or back of a text, larger than a paragraph. [4.1.2. Numbered Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.divTop"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <oneOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.common"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </oneOrMore>
+                  <zeroOrMore>
+                     <group>
+          
+                        <ref name="sgamodel.divBottom"/>
+          
+          
+                        <zeroOrMore>
+                           <ref name="sgamodel.global"/>
+                        </zeroOrMore>
+          
+                     </group>
+                  </zeroOrMore>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.divLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatrailer">
+      <element name="trailer">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a closing title or footer appearing at the end of a division of a text. [4.2.4. Content of Textual Divisions 4.2. Elements Common to All Divisions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+	              <text/>
+	
+	              <ref name="sgamodel.gLike"/>
+	              <ref name="sgamodel.phrase"/>
+	              <ref name="sgamodel.inter"/>
+	              <ref name="sgamodel.lLike"/>
+	              <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabyline">
+      <element name="byline">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the primary statement of responsibility given for a work on its title page or at the head or end of the work. [4.2.2. Openers and Closers 4.5. Front Matter]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgadocAuthor"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadateline">
+      <element name="dateline">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a brief description of the place, date, time, etc. of production of a letter, newspaper story, or other work, prefixed or suffixed to it as a kind of heading or trailer. [4.2.2. Openers and Closers]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+               <ref name="sgadocDate"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaargument">
+      <element name="argument">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a formal list or prose description of the topics addressed by a subdivision of a text. [4.2. Elements Common to All Divisions 4.6. Title Pages]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.headLike"/>
+               </choice>
+            </zeroOrMore>
+      
+            <oneOrMore>
+               <group>
+        
+                  <ref name="sgamodel.common"/>
+        
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </oneOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaepigraph">
+      <element name="epigraph">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a quotation, anonymous or attributed, appearing at the start or end of a section or on a title page. [4.2.3. Arguments, Epigraphs, and Postscripts 4.2. Elements Common to All Divisions 4.6. Title Pages]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgamodel.common"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaopener">
+      <element name="opener">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups together dateline, byline, salutation, and similar phrases appearing as a preliminary group at the start of a division, especially of a letter. [4.2. Elements Common to All Divisions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+        
+               <ref name="sgaargument"/>
+               <ref name="sgabyline"/>
+               <ref name="sgadateline"/>
+               <ref name="sgaepigraph"/>
+               <ref name="sgasalute"/>
+               <ref name="sgasigned"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacloser">
+      <element name="closer">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups together salutations, datelines, and similar phrases appearing as a final group at the end of a division, especially of a letter. [4.2.2. Openers and Closers 4.2. Elements Common to All Divisions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgasigned"/>
+               <ref name="sgadateline"/>
+               <ref name="sgasalute"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasalute">
+      <element name="salute">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(salutation) contains a salutation or greeting prefixed to a foreword, dedicatory epistle, or other division of a text, or the salutation in the closing of a letter, preface, etc. [4.2.2. Openers and Closers]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasigned">
+      <element name="signed">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(signature) contains the closing salutation, etc., appended to a foreword, dedicatory epistle, or other division of a text. [4.2.2. Openers and Closers]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapostscript">
+      <element name="postscript">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a postscript, e.g. to a letter. [4.2. Elements Common to All Divisions]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.divTopPart"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <ref name="sgamodel.common"/>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.global"/>
+                  <ref name="sgamodel.common"/>
+               </choice>
+            </zeroOrMore>
+      
+            <zeroOrMore>
+               <group>
+        
+                  <ref name="sgamodel.divBottomPart"/>
+        
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </zeroOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.written.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitlePage">
+      <element name="titlePage">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title page) contains the title page of a text, appearing within the front or back matter. [4.6. Title Pages]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+      
+            <ref name="sgamodel.titlepagePart"/>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.titlepagePart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">classifies the title page according to any convenient typology.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocTitle">
+      <element name="docTitle">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document title) contains the title of a document, including all its constituents, as given on a title page. [4.6. Title Pages]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.global"/>
+            </zeroOrMore>
+      
+            <oneOrMore>
+               <group>
+                  <ref name="sgatitlePart"/>
+        
+                  <zeroOrMore>
+                     <ref name="sgamodel.global"/>
+                  </zeroOrMore>
+        
+               </group>
+            </oneOrMore>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatitlePart">
+      <element name="titlePart">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a subsection or division of the title of a work, as indicated on a title page. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="type"
+                       a:defaultValue="main">
+               <a:documentation>specifies the role of this subdivision of the title.
+Suggested values include: 1] main; 2] sub(subordinate) ; 3] alt(alternate) ; 4] short; 5] desc(descriptive) </a:documentation>
+               <choice>
+                  <value>main</value>
+                  <a:documentation>main title of the work</a:documentation>
+                  <value>sub</value>
+                  <a:documentation>(subordinate) subtitle of the work</a:documentation>
+                  <value>alt</value>
+                  <a:documentation>(alternate) alternative title of the work</a:documentation>
+                  <value>short</value>
+                  <a:documentation>abbreviated form of title</a:documentation>
+                  <value>desc</value>
+                  <a:documentation>(descriptive) descriptive paraphrase of the work</a:documentation>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocAuthor">
+      <element name="docAuthor">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document author) contains the name of the author of the document, as given on the title page (often but not always contained in a byline). [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaimprimatur">
+      <element name="imprimatur">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a formal statement authorizing the publication of a work, sometimes required to appear on a title page or its verso. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocEdition">
+      <element name="docEdition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document edition) contains an edition statement as presented on a title page of a document. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.paraContent"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocImprint">
+      <element name="docImprint">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document imprint) contains the imprint statement (place and date of publication, publisher name), as given (usually) at the foot of a title page. [4.6. Title Pages]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgapubPlace"/>
+               <ref name="sgadocDate"/>
+        
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadocDate">
+      <element name="docDate">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(document date) contains the date of a document, as given on a title page or in a dateline. [4.6. Title Pages]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="when">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the value of the date in standard form, i.e. YYYY-MM-DD.</a:documentation>
+               <choice>
+                  <data type="date"/>
+                  <data type="gYear"/>
+                  <data type="gMonth"/>
+                  <data type="gDay"/>
+                  <data type="gYearMonth"/>
+                  <data type="gMonthDay"/>
+                  <data type="time"/>
+                  <data type="dateTime"/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafront">
+      <element name="front">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(front matter) contains any prefatory matter (headers, abstracts, title page, prefaces, dedications, etc.) found at the start of a document, before the main body. [4.6. Title Pages 4. Default Text Structure]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.frontPart"/>
+                  <ref name="sgamodel.pLike"/>
+                  <ref name="sgamodel.pLike.front"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+            <optional>
+               <group>
+                  <choice>
+          
+                     <group>
+                        <ref name="sgamodel.div1Like"/>
+                        <zeroOrMore>
+                           <choice>
+                              <ref name="sgamodel.div1Like"/>
+                              <ref name="sgamodel.frontPart"/>
+                              <ref name="sgamodel.global"/>
+                           </choice>
+                        </zeroOrMore>
+                     </group>
+          
+                     <group>
+                        <ref name="sgamodel.divLike"/>
+                        <zeroOrMore>
+                           <choice>
+                              <ref name="sgamodel.divLike"/>
+                              <ref name="sgamodel.frontPart"/>
+                              <ref name="sgamodel.global"/>
+                           </choice>
+                        </zeroOrMore>
+                     </group>
+                  </choice>
+        
+                  <optional>
+                     <group>
+                        <ref name="sgamodel.divBottom"/>
+                        <zeroOrMore>
+                           <choice>
+                              <ref name="sgamodel.divBottom"/>
+                              <ref name="sgamodel.global"/>
+                           </choice>
+                        </zeroOrMore>
+                     </group>
+                  </optional>
+               </group>
+            </optional>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaback">
+      <element name="back">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(back matter) contains any appendixes, etc. following the main part of a text. [4.7. Back Matter 4. Default Text Structure]</a:documentation>
+         <group>
+
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.frontPart"/>
+                  <ref name="sgamodel.pLike.front"/>
+                  <ref name="sgamodel.pLike"/>
+                  <ref name="sgamodel.listLike"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+
+
+
+            <optional>
+               <choice>
+                  <group>
+
+                     <ref name="sgamodel.div1Like"/>
+
+
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.frontPart"/>
+                           <ref name="sgamodel.div1Like"/>
+                           <ref name="sgamodel.global"/>
+                        </choice>
+                     </zeroOrMore>
+
+                  </group>
+                  <group>
+
+                     <ref name="sgamodel.divLike"/>
+
+
+                     <zeroOrMore>
+                        <choice>
+                           <ref name="sgamodel.frontPart"/>
+                           <ref name="sgamodel.divLike"/>
+                           <ref name="sgamodel.global"/>
+                        </choice>
+                     </zeroOrMore>
+
+                  </group>
+               </choice>
+            </optional>
+
+
+
+            <optional>
+               <group>
+
+                  <ref name="sgamodel.divBottomPart"/>
+
+
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.divBottomPart"/>
+                        <ref name="sgamodel.global"/>
+                     </choice>
+                  </zeroOrMore>
+
+               </group>
+            </optional>
+
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.msExcerpt.attributes">
+      <ref name="sgaatt.msExcerpt.attribute.defective"/>
+   </define>
+   <define name="sgaatt.msExcerpt.attribute.defective">
+      <optional>
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="defective"
+                    a:defaultValue="false">
+            <a:documentation>indicates whether the passage being quoted is defective, i.e. incomplete through loss or damage.</a:documentation>
+            <choice>
+               <data type="boolean"/>
+               <choice>
+                  <value>unknown</value>
+                  <a:documentation/>
+                  <value>inapplicable</value>
+                  <a:documentation/>
+               </choice>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.msClass.attributes">
+      <ref name="sgaatt.msClass.attribute.class"/>
+   </define>
+   <define name="sgaatt.msClass.attribute.class">
+      <optional>
+         <attribute name="class">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the text types or classifications applicable to this item by pointing to other elements or resources defining the classification concerned. </a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamsDesc">
+      <element name="msDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript description) contains a description of a single identifiable manuscript or other text-bearing object. [10.1. Overview]</a:documentation>
+         <group>
+            <ref name="sgamsIdentifier"/>
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+            <choice>
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+               <group>
+                  <optional>
+                     <ref name="sgamsContents"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaphysDesc"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgahistory"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaadditional"/>
+                  </optional>
+                  <choice>
+                     <zeroOrMore>
+                        <ref name="sgamsPart"/>
+                     </zeroOrMore>
+                     <zeroOrMore>
+                        <ref name="sgamsFrag"/>
+                     </zeroOrMore>
+                  </choice>
+               </group>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.docStatus.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacatchwords">
+      <element name="catchwords">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the system used to ensure correct ordering of the quires making up a codex or incunable, typically by means of annotations at the foot of the page. [10.3.7. Catchwords, Signatures, Secundo Folio]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-catchwords-catchword_in_msDesc-constraint-assert-17">
+            <rule context="tei:catchwords">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="ancestor::tei:msDesc"
+                           role="nonfatal">WARNING: deprecated use of element — The <sch:name/> element will not be allowed outside of msDesc as of 2018-10-01.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadimensions">
+      <element name="dimensions">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a dimensional specification. [10.3.4. Dimensions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="sgadim"/>
+               <ref name="sgamodel.dimLike"/>
+            </choice>
+         </zeroOrMore>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-dimensions-duplicateDim-constraint-report-13">
+            <rule context="tei:dimensions">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="count(tei:width)&gt; 1">
+The element <name/> may appear once only
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-dimensions-duplicateDim-constraint-report-14">
+            <rule context="tei:dimensions">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="count(tei:height)&gt; 1">
+The element <name/> may appear once only
+      </report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-dimensions-duplicateDim-constraint-report-15">
+            <rule context="tei:dimensions">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="count(tei:depth)&gt; 1">
+The element <name/> may appear once only
+      </report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates which aspect of the object is being measured.
+Sample values include: 1] leaves; 2] ruled; 3] pricked; 4] written; 5] miniatures; 6] binding; 7] box</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadim">
+      <element name="dim">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any single measurement forming part of a dimensional specification of some sort. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaheight">
+      <element name="height">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a measurement measured along the axis at right angles to the bottom of the written surface, i.e. parallel to the spine for a codex or book. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadepth">
+      <element name="depth">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a measurement measured across the spine of a book or codex, or (for other text-bearing objects) perpendicular to the measurement given by the width element. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgawidth">
+      <element name="width">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a measurement measured along the axis parallel to the bottom of the written surface, i.e. perpendicular to the spine of a book or codex. [10.3.4. Dimensions]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.dimensions.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaheraldry">
+      <element name="heraldry">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a heraldic formula or phrase, typically found as part of a blazon, coat of arms, etc.  [10.3.8. Heraldry]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocus">
+      <element name="locus">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines a location within a manuscript or manuscript part, usually as a (possibly discontinuous) sequence of folio references. [10.3.5. References to Locations within a Manuscript]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgahi"/>
+               <ref name="sgalocus"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.pointing.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the foliation scheme in terms of which the location is being specified by pointing to some foliation element defining it, or to some other equivalent resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="from">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the starting point of the location in a normalized form, typically a page number.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="to">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the end-point of the location in a normalized form, typically as a page number.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocusGrp">
+      <element name="locusGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups a number of locations which together form a distinct but discontinuous item within a manuscript or manuscript part, according to a specific foliation. [10.3.5. References to Locations within a Manuscript]</a:documentation>
+         <oneOrMore>
+            <ref name="sgalocus"/>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the foliation scheme in terms of which all the locations contained by the group are specified by pointing to some foliation element defining it, or to some other equivalent resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamaterial">
+      <element name="material">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing the material of which the object being described is composed. [10.3.2. Material and Object Type]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaobjectType">
+      <element name="objectType">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing the type of object being referred to. [10.3.2. Material and Object Type]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorigDate">
+      <element name="origDate">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(origin date) contains any form of date, used to identify the date of origin for a manuscript or manuscript part. [10.3.1. Origination]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgamodel.phrase"/>
+               <ref name="sgamodel.global"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorigPlace">
+      <element name="origPlace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(origin place) contains any form of place name, used to identify the place of origin for a manuscript or manuscript part. [10.3.1. Origination]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasecFol">
+      <element name="secFol">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(second folio) marks the word or words taken from a fixed point in a codex (typically the beginning of the second leaf) in order to provide a unique identifier for it.  [10.3.7. Catchwords, Signatures, Secundo Folio]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-secFol-secFol_in_msDesc-constraint-assert-18">
+            <rule context="tei:secFol">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="ancestor::tei:msDesc"
+                           role="nonfatal">WARNING: deprecated use of element — The <sch:name/> element will not be allowed outside of msDesc as of 2018-10-01.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasignatures">
+      <element name="signatures">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains discussion of the leaf or quire signatures found within a codex. [10.3.7. Catchwords, Signatures, Secundo Folio]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-signatures-signatures_in_msDesc-constraint-assert-19">
+            <rule context="tei:signatures">
+               <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                           xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                           xmlns="http://www.tei-c.org/ns/1.0"
+                           test="ancestor::tei:msDesc"
+                           role="nonfatal">WARNING: deprecated use of element — The <sch:name/> element will not be allowed outside of msDesc as of 2018-10-01.</sch:assert>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastamp">
+      <element name="stamp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing a stamp or similar device. [10.3.3. Watermarks and Stamps]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgawatermark">
+      <element name="watermark">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a word or phrase describing a watermark or similar device. [10.3.3. Watermarks and Stamps]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsIdentifier">
+      <element name="msIdentifier">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript identifier) contains the information required to identify the manuscript being described. [10.4. The Manuscript Identifier]</a:documentation>
+         <group>
+            <group>
+               <optional>
+                  <ref name="sgaplaceName"/>
+               </optional>
+               <optional>
+                  <ref name="sgabloc"/>
+               </optional>
+               <optional>
+                  <ref name="sgacountry"/>
+               </optional>
+               <optional>
+                  <ref name="sgaregion"/>
+               </optional>
+               <optional>
+                  <ref name="sgasettlement"/>
+               </optional>
+               <optional>
+                  <ref name="sgadistrict"/>
+               </optional>
+               <optional>
+                  <ref name="sgageogName"/>
+               </optional>
+        
+               <optional>
+                  <ref name="sgainstitution"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgarepository"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgacollection"/>
+               </zeroOrMore>
+        
+        
+               <optional>
+                  <ref name="sgaidno"/>
+               </optional>
+        
+            </group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamsName"/>
+                  <ref name="sgaaltIdentifier"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-msIdentifier-msId_minimal-constraint-report-16">
+            <rule context="tei:msIdentifier">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="not(parent::tei:msPart) and       (local-name(*[1])='idno' or       local-name(*[1])='altIdentifier' or       normalize-space(.)='')">An msIdentifier must contain either a repository or location of some type, or a manuscript name</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgainstitution">
+      <element name="institution">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of an organization such as a university or library, with which a manuscript is identified, generally its holding institution. [10.4. The Manuscript Identifier]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarepository">
+      <element name="repository">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a repository within which manuscripts are stored, possibly forming part of an institution. [10.4. The Manuscript Identifier]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacollection">
+      <element name="collection">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a collection of manuscripts, not necessarily located within a single repository. [10.4. The Manuscript Identifier]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaltIdentifier">
+      <element name="altIdentifier">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternative identifier) contains an alternative or former structured identifier used for a manuscript, such as a former catalogue number. [10.4. The Manuscript Identifier]</a:documentation>
+         <group>
+            <optional>
+               <ref name="sgaplaceName"/>
+            </optional>
+            <optional>
+               <ref name="sgabloc"/>
+            </optional>
+            <optional>
+               <ref name="sgacountry"/>
+            </optional>
+            <optional>
+               <ref name="sgaregion"/>
+            </optional>
+            <optional>
+               <ref name="sgasettlement"/>
+            </optional>
+            <optional>
+               <ref name="sgadistrict"/>
+            </optional>
+            <optional>
+               <ref name="sgageogName"/>
+            </optional>
+     
+            <optional>
+               <ref name="sgainstitution"/>
+            </optional>
+     
+     
+            <optional>
+               <ref name="sgarepository"/>
+            </optional>
+     
+     
+            <optional>
+               <ref name="sgacollection"/>
+            </optional>
+     
+            <ref name="sgaidno"/>
+     
+            <optional>
+               <ref name="sganote"/>
+            </optional>
+     
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsName">
+      <element name="msName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternative name) contains any form of unstructured alternative name used for a manuscript, such as an ocellus nominum, or nickname. [10.4. The Manuscript Identifier]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="sgamodel.gLike"/>
+               <ref name="sgars"/>
+               <ref name="sganame"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacolophon">
+      <element name="colophon">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the colophon of a manuscript item: that is, a statement providing information regarding the date, place, agency, or reason for production of the manuscript. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaexplicit">
+      <element name="explicit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the explicit of a manuscript item, that is, the closing words of the text proper, exclusive of any rubric or colophon which might follow it. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafiliation">
+      <element name="filiation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information concerning the manuscript's filiation, i.e. its relationship to other surviving manuscripts of the same text, its protographs, antigraphs and apographs. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafinalRubric">
+      <element name="finalRubric">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the string of words that denotes the end of a text division, often with an assertion as to its author and title, usually set off from the text itself by red ink, by a different size or type of script, or by some other such visual device. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaincipit">
+      <element name="incipit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the incipit of a manuscript item, that is the opening words of the text proper, exclusive of any rubric which might precede it, of sufficient length to identify the work uniquely; such incipits were, in former times, frequently used a means of reference to a work, in place of a title. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsContents">
+      <element name="msContents">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript contents) describes the intellectual content of a manuscript or manuscript part, either as a series of paragraphs or as a series of structured manuscript items. [10.6. Intellectual Content]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+          
+        
+        
+               <optional>
+                  <ref name="sgatitlePage"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamsItem"/>
+                     <ref name="sgamsItemStruct"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <ref name="sgaatt.msClass.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsItem">
+      <element name="msItem">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript item) describes an individual work or item within the intellectual content of a manuscript or manuscript part. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgalocus"/>
+                  <ref name="sgalocusGrp"/>
+               </choice>
+            </zeroOrMore>
+      
+            <choice>
+        
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+        
+        
+               <oneOrMore>
+                  <choice>
+                     <ref name="sgamodel.titlepagePart"/>
+                     <ref name="sgamodel.msItemPart"/>
+                     <ref name="sgamodel.global"/>
+                  </choice>
+               </oneOrMore>
+        
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <ref name="sgaatt.msClass.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsItemStruct">
+      <element name="msItemStruct">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(structured manuscript item) contains a structured description for an individual work or item within the intellectual content of a manuscript or manuscript part. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <group>
+      
+            <optional>
+               <choice>
+                  <ref name="sgalocus"/>
+                  <ref name="sgalocusGrp"/>
+               </choice>
+            </optional>
+      
+            <choice>
+        
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+        
+               <group>
+          
+                  <zeroOrMore>
+                     <ref name="sgaauthor"/>
+                  </zeroOrMore>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgarespStmt"/>
+                  </zeroOrMore>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgatitle"/>
+                  </zeroOrMore>
+          
+          
+                  <optional>
+                     <ref name="sgarubric"/>
+                  </optional>
+          
+          
+                  <optional>
+                     <ref name="sgaincipit"/>
+                  </optional>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgamsItemStruct"/>
+                  </zeroOrMore>
+          
+          
+                  <optional>
+                     <ref name="sgaexplicit"/>
+                  </optional>
+          
+          
+                  <optional>
+                     <ref name="sgafinalRubric"/>
+                  </optional>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgacolophon"/>
+                  </zeroOrMore>
+          
+          
+                  <zeroOrMore>
+                     <ref name="sgadecoNote"/>
+                  </zeroOrMore>
+          
+          
+            
+          
+          
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgabibl"/>
+              
+                     </choice>
+                  </zeroOrMore>
+          
+                  <optional>
+                     <ref name="sgafiliation"/>
+                  </optional>
+            
+                  <zeroOrMore>
+                     <ref name="sgamodel.noteLike"/>
+                  </zeroOrMore>
+          
+          
+            
+          
+               </group>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <ref name="sgaatt.msClass.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarubric">
+      <element name="rubric">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the text of any rubric or heading attached to a particular manuscript item, that is, a string of words through which a manuscript signals the beginning of a text division, often with an assertion as to its author and title, which is in some way set off from the text itself, usually in red ink, or by use of different size or type of script, or some other such visual device. [10.6.1. The msItem and msItemStruct Elements]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.msExcerpt.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasummary">
+      <element name="summary">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an overview of the available information concerning some aspect of an item (for example, its intellectual content, history, layout, typography etc.) as a complement or alternative to the more detailed information carried by more specific elements. [10.6. Intellectual Content]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaphysDesc">
+      <element name="physDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical description) contains a full physical description of a manuscript or manuscript part, optionally subdivided using more specialized elements from the model.physDescPart class. [10.7. Physical Description]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.pLike"/>
+            </zeroOrMore>
+      
+      
+        
+            <optional>
+               <ref name="sgaobjectDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgahandDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgatypeDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgascriptDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgamusicNotation"/>
+            </optional>
+            <optional>
+               <ref name="sgadecoDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgaadditions"/>
+            </optional>
+            <optional>
+               <ref name="sgabindingDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgasealDesc"/>
+            </optional>
+            <optional>
+               <ref name="sgaaccMat"/>
+            </optional>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaobjectDesc">
+      <element name="objectDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the physical components making up the object which is being described. [10.7.1. Object Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasupportDesc"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgalayoutDesc"/>
+               </optional>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="form">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a short project-specific name identifying the physical form of the carrier, for example as a codex, roll, fragment, partial leaf, cutting etc.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasupportDesc">
+      <element name="supportDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(support description) groups elements describing the physical support for the written part of a manuscript. [10.7.1. Object Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasupport"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgaextent"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgafoliation"/>
+               </zeroOrMore>
+        
+        
+               <optional>
+                  <ref name="sgacollation"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgacondition"/>
+               </optional>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="material">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a short project-defined name for the material composing the majority of the support
+Suggested values include: 1] paper; 2] parch(parchment) ; 3] mixed</a:documentation>
+               <choice>
+                  <value>paper</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <value>parch</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(parchment) </a:documentation>
+                  <value>mixed</value>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasupport">
+      <element name="support">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the materials etc. which make up the physical support for the written part of a manuscript. [10.7.1. Object Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacollation">
+      <element name="collation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of how the leaves or bifolia are physically arranged. [10.7.1. Object Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafoliation">
+      <element name="foliation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the numbering system or systems used to count the leaves or pages in a codex. [10.7.1.4. Foliation]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacondition">
+      <element name="condition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the physical condition of the manuscript. [10.7.1.5. Condition]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalayoutDesc">
+      <element name="layoutDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(layout description) collects the set of layout descriptions applicable to a manuscript. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgalayout"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalayout">
+      <element name="layout">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes how text is laid out on the page, including information about any ruling, pricking, or other evidence of page-preparation techniques. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="columns">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of columns per page</a:documentation>
+               <list>
+                  <data type="nonNegativeInteger"/>
+                  <optional>
+                     <data type="nonNegativeInteger"/>
+                  </optional>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="ruledLines">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of ruled lines per column</a:documentation>
+               <list>
+                  <data type="nonNegativeInteger"/>
+                  <optional>
+                     <data type="nonNegativeInteger"/>
+                  </optional>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="writtenLines">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of written lines per column</a:documentation>
+               <list>
+                  <data type="nonNegativeInteger"/>
+                  <optional>
+                     <data type="nonNegativeInteger"/>
+                  </optional>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahandDesc">
+      <element name="handDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description of hands) contains a description of all the different kinds of writing used in a manuscript. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgahandNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <optional>
+            <attribute name="hands">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the number of distinct hands identified within the manuscript</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatypeDesc">
+      <element name="typeDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the typefaces or other aspects of the printing of an incunable or other printed source. [10.7.2.1. Writing]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgatypeNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatypeNote">
+      <element name="typeNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a particular font or other significant typographic feature distinguished within the description of a printed resource. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.handFeatures.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgascriptDesc">
+      <element name="scriptDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the scripts used in a manuscript or similar source. [10.7.2.1. Writing]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgascriptNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamusicNotation">
+      <element name="musicNotation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains description of type of musical notation. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadecoDesc">
+      <element name="decoDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(decoration description) contains a description of the decoration of a manuscript, either as a sequence of paragraphs, or as a sequence of topically organized decoNote elements. [10.7.3. Bindings, Seals, and Additional Material]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <ref name="sgadecoNote"/>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadecoNote">
+      <element name="decoNote">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(note on decoration) contains a note describing either a decorative component of a manuscript, or a fairly homogenous class of such components. [10.7.3. Bindings, Seals, and Additional Material]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadditions">
+      <element name="additions">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of any significant additions found within a manuscript, such as marginalia or other annotations. [10.7.2. Writing, Decoration, and Other Notations]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabindingDesc">
+      <element name="bindingDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(binding description) describes the present and former bindings of a manuscript, either as a series of paragraphs or as a series of distinct binding elements, one for each binding of the manuscript. [10.7.3.1. Binding Descriptions]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.pLike"/>
+                  <ref name="sgadecoNote"/>
+                  <ref name="sgacondition"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgabinding"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabinding">
+      <element name="binding">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of one binding, i.e. type of covering, boards, etc. applied to a manuscript. [10.7.3.1. Binding Descriptions]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgacondition"/>
+               <ref name="sgadecoNote"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <optional>
+            <attribute name="contemporary">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies whether or not the binding is contemporary with the majority of its contents</a:documentation>
+               <choice>
+                  <data type="boolean"/>
+                  <choice>
+                     <value>unknown</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>inapplicable</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasealDesc">
+      <element name="sealDesc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(seal description) describes the seals or other external items attached to a manuscript, either as a series of paragraphs or as a series of distinct seal elements, possibly with additional decoNotes. [10.7.3.2. Seals]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <oneOrMore>
+                  <choice>
+                     <ref name="sgadecoNote"/>
+                     <ref name="sgaseal"/>
+                     <ref name="sgacondition"/>
+                  </choice>
+               </oneOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaseal">
+      <element name="seal">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of one seal or similar attachment applied to a manuscript. [10.7.3.2. Seals]</a:documentation>
+         <oneOrMore>
+            <choice>
+               <ref name="sgamodel.pLike"/>
+               <ref name="sgadecoNote"/>
+            </choice>
+         </oneOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <optional>
+            <attribute name="contemporary">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies whether or not the seal is contemporary with the item to which it is affixed</a:documentation>
+               <choice>
+                  <data type="boolean"/>
+                  <choice>
+                     <value>unknown</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>inapplicable</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaccMat">
+      <element name="accMat">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(accompanying material) contains details of any significant additional material which may be closely associated with the manuscript being described, such as non-contemporaneous documents or fragments bound in with the manuscript at some earlier historical period. [10.7.3.3. Accompanying Material]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgahistory">
+      <element name="history">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups elements describing the full history of a manuscript or manuscript part. [10.8. History]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+        
+               <optional>
+                  <ref name="sgasummary"/>
+               </optional>
+        
+        
+               <optional>
+                  <ref name="sgaorigin"/>
+               </optional>
+        
+        
+               <zeroOrMore>
+                  <ref name="sgaprovenance"/>
+               </zeroOrMore>
+        
+        
+               <optional>
+                  <ref name="sgaacquisition"/>
+               </optional>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorigin">
+      <element name="origin">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any descriptive or other information concerning the origin of a manuscript or manuscript part. [10.8. History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaprovenance">
+      <element name="provenance">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any descriptive or other information concerning a single identifiable episode during the history of a manuscript or manuscript part, after its creation but before its acquisition. [10.8. History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaacquisition">
+      <element name="acquisition">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains any descriptive or other information concerning the process by which a manuscript or manuscript part entered the holding institution. [10.8. History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadditional">
+      <element name="additional">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">groups additional information, combining bibliographic information about a manuscript, or surrogate copies of it with curatorial or administrative information. [10.9. Additional Information]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgaadminInfo"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgasurrogates"/>
+            </optional>
+      
+      
+        
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaadminInfo">
+      <element name="adminInfo">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(administrative information) contains information about the present custody and availability of the manuscript, and also about the record description itself. [10.9.1. Administrative Information]</a:documentation>
+         <group>
+      
+            <optional>
+               <ref name="sgarecordHist"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgaavailability"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgacustodialHist"/>
+            </optional>
+      
+      
+            <optional>
+               <ref name="sgamodel.noteLike"/>
+            </optional>
+        
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarecordHist">
+      <element name="recordHist">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(recorded history) provides information about the source and revision status of the parent manuscript description itself. [10.9.1. Administrative Information]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+            <group>
+               <ref name="sgasource"/>
+        
+               <zeroOrMore>
+                  <ref name="sgachange"/>
+               </zeroOrMore>
+        
+            </group>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasource">
+      <element name="source">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes the original source for the information contained with a manuscript description. [10.9.1.1. Record History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacustodialHist">
+      <element name="custodialHist">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(custodial history) contains a description of a manuscript's custodial history, either as running prose or as a series of dated custodial events. [10.9.1.2. Availability and Custodial History]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <oneOrMore>
+               <ref name="sgacustEvent"/>
+            </oneOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacustEvent">
+      <element name="custEvent">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(custodial event) describes a single event during the custodial history of a manuscript. [10.9.1.2. Availability and Custodial History]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurrogates">
+      <element name="surrogates">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about any representations of the manuscript being described which may exist in the holding institution or elsewhere. [10.9. Additional Information]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsPart">
+      <element name="msPart">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript part) contains information about an originally distinct manuscript or part of a manuscript, which is now part of a composite manuscript. [10.10. Manuscript Parts]</a:documentation>
+         <group>
+            <ref name="sgamsIdentifier"/>
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+            <choice>
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+               <group>
+                  <optional>
+                     <ref name="sgamsContents"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaphysDesc"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgahistory"/>
+                  </optional>
+                  <optional>
+                     <ref name="sgaadditional"/>
+                  </optional>
+                  <zeroOrMore>
+                     <ref name="sgamsPart"/>
+                  </zeroOrMore>
+               </group>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgamsFrag">
+      <element name="msFrag">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript fragment) contains information about a fragment of a scattered manuscript now held as a single unit or bound into a larger manuscript. [10.11. Manuscript Fragments]</a:documentation>
+         <group>
+            <choice>
+                <ref name="sgaaltIdentifier"/>
+                <ref name="sgamsIdentifier"/>
+            </choice>
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+            <choice>
+                <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+                <group>
+                    <optional>
+                     <ref name="sgamsContents"/>
+                  </optional>
+                    <optional>
+                     <ref name="sgaphysDesc"/>
+                  </optional>
+                    <optional>
+                     <ref name="sgahistory"/>
+                  </optional>
+                    <optional>
+                     <ref name="sgaadditional"/>
+                  </optional>
+                </group>
+            </choice>
+        </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaatt.datable.custom.attributes">
+      <ref name="sgaatt.datable.custom.attribute.when-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.notBefore-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.notAfter-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.from-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.to-custom"/>
+      <ref name="sgaatt.datable.custom.attribute.datingPoint"/>
+      <ref name="sgaatt.datable.custom.attribute.datingMethod"/>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.when-custom">
+      <optional>
+         <attribute name="when-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of a date or time in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.notBefore-custom">
+      <optional>
+         <attribute name="notBefore-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the earliest possible date for the event in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.notAfter-custom">
+      <optional>
+         <attribute name="notAfter-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the latest possible date for the event in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.from-custom">
+      <optional>
+         <attribute name="from-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the starting point of the period in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.to-custom">
+      <optional>
+         <attribute name="to-custom">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the ending point of the period in some custom standard form.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="token">
+                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  </data>
+               </oneOrMore>
+            </list>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.datingPoint">
+      <optional>
+         <attribute name="datingPoint">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to some location defining a named point in time with reference to which the datable item is understood to have occurred</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.custom.attribute.datingMethod">
+      <optional>
+         <attribute name="datingMethod">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a pointer to a calendar element or other means of interpreting the values of the custom dating attributes.</a:documentation>
+            <data type="anyURI"/>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgamodel.persNamePart">
+      <choice>
+         <ref name="sgasurname"/>
+         <ref name="sgaforename"/>
+         <ref name="sgagenName"/>
+         <ref name="sganameLink"/>
+         <ref name="sgaaddName"/>
+         <ref name="sgaroleName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.persNamePart_alternation">
+      <choice>
+         <ref name="sgasurname"/>
+         <ref name="sgaforename"/>
+         <ref name="sgagenName"/>
+         <ref name="sganameLink"/>
+         <ref name="sgaaddName"/>
+         <ref name="sgaroleName"/>
+      </choice>
+   </define>
+   <define name="sgamodel.persNamePart_sequence">
+      <ref name="sgasurname"/>
+      <ref name="sgaforename"/>
+      <ref name="sgagenName"/>
+      <ref name="sganameLink"/>
+      <ref name="sgaaddName"/>
+      <ref name="sgaroleName"/>
+   </define>
+   <define name="sgamodel.persNamePart_sequenceOptional">
+      <optional>
+         <ref name="sgasurname"/>
+      </optional>
+      <optional>
+         <ref name="sgaforename"/>
+      </optional>
+      <optional>
+         <ref name="sgagenName"/>
+      </optional>
+      <optional>
+         <ref name="sganameLink"/>
+      </optional>
+      <optional>
+         <ref name="sgaaddName"/>
+      </optional>
+      <optional>
+         <ref name="sgaroleName"/>
+      </optional>
+   </define>
+   <define name="sgamodel.persNamePart_sequenceOptionalRepeatable">
+      <zeroOrMore>
+         <ref name="sgasurname"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaforename"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgagenName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sganameLink"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaaddName"/>
+      </zeroOrMore>
+      <zeroOrMore>
+         <ref name="sgaroleName"/>
+      </zeroOrMore>
+   </define>
+   <define name="sgamodel.persNamePart_sequenceRepeatable">
+      <oneOrMore>
+         <ref name="sgasurname"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaforename"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgagenName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sganameLink"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaaddName"/>
+      </oneOrMore>
+      <oneOrMore>
+         <ref name="sgaroleName"/>
+      </oneOrMore>
+   </define>
+   <define name="sgaatt.datable.iso.attributes">
+      <ref name="sgaatt.datable.iso.attribute.when-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.notBefore-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.notAfter-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.from-iso"/>
+      <ref name="sgaatt.datable.iso.attribute.to-iso"/>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.when-iso">
+      <optional>
+         <attribute name="when-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the value of a date or time in a standard form.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.notBefore-iso">
+      <optional>
+         <attribute name="notBefore-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the earliest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.notAfter-iso">
+      <optional>
+         <attribute name="notAfter-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the latest possible date for the event in standard form, e.g. yyyy-mm-dd.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.from-iso">
+      <optional>
+         <attribute name="from-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the starting point of the period in standard form.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaatt.datable.iso.attribute.to-iso">
+      <optional>
+         <attribute name="to-iso">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the ending point of the period in standard form.</a:documentation>
+            <choice>
+               <data type="date"/>
+               <data type="gYear"/>
+               <data type="gMonth"/>
+               <data type="gDay"/>
+               <data type="gYearMonth"/>
+               <data type="gMonthDay"/>
+               <data type="time"/>
+               <data type="dateTime"/>
+               <data type="token">
+                  <param name="pattern">[0-9.,DHMPRSTWYZ/:+\-]+</param>
+               </data>
+            </choice>
+         </attribute>
+      </optional>
+   </define>
+   <define name="sgaorgName">
+      <element name="orgName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(organization name) contains an organizational name. [13.2.2. Organizational Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapersName">
+      <element name="persName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(personal name) contains a proper noun or proper-noun phrase referring to a person, possibly including one or more of the person's forenames, surnames, honorifics, added names, etc. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasurname">
+      <element name="surname">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a family (inherited) name, as opposed to a given, baptismal, or nick name. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaforename">
+      <element name="forename">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a forename, given or baptismal name. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgagenName">
+      <element name="genName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(generational name component) contains a name component used to distinguish otherwise similar names on the basis of the relative ages or generations of the persons named. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganameLink">
+      <element name="nameLink">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name link) contains a connecting phrase or link used within a name but not regarded as part of it, such as van der or of. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaddName">
+      <element name="addName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(additional name) contains an additional name component, such as a nickname, epithet, or alias, or any other descriptive phrase used within a personal name. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaroleName">
+      <element name="roleName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a name component which indicates that the referent has a particular role or position in society, such as an official title or rank. [13.2.1. Personal Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaplaceName">
+      <element name="placeName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an absolute or relative place name. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.personal.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabloc">
+      <element name="bloc">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a geo-political unit consisting of two or more nation states or countries. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgacountry">
+      <element name="country">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a geo-political unit, such as a nation, country, colony, or commonwealth, larger than or administratively superior to a region and smaller than a bloc. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaregion">
+      <element name="region">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of an administrative unit such as a state, province, or county, larger than a settlement, but smaller than a country. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasettlement">
+      <element name="settlement">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a settlement such as a city, town, or village identified as a single geo-political or administrative unit. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadistrict">
+      <element name="district">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of any kind of subdivision of a settlement, such as a parish, ward, or other administrative or geographic unit. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaoffset">
+      <element name="offset">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">marks that part of a relative temporal or spatial expression which indicates the direction of the offset between the two place names, dates, or times involved in the expression. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageogName">
+      <element name="geogName">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographical name) identifies a name associated with some geographical feature such as Windrush Valley or Mount Sinai. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageogFeat">
+      <element name="geogFeat">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographical feature name) contains a common noun identifying some geographical feature contained within a geographic name, such as valley, mount, etc. [13.2.3. Place Names]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaaffiliation">
+      <element name="affiliation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an informal description of a person's present or past affiliation with some organization, for example an employer or sponsor. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] sponsor; 2] recommend; 3] discredit; 4] pledged</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaage">
+      <element name="age">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the age of a person. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] western; 2] sui; 3] subjective; 4] objective; 5] inWorld(in world) ; 6] chronological; 7] biological; 8] psychological; 9] functional</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="value">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a numeric code representing the age or age group</a:documentation>
+               <data type="nonNegativeInteger"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgabirth">
+      <element name="birth">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a person's birth, such as its date and place. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] caesarean(caesarean section) ; 2] vaginal(vaginal delivery) ; 3] exNihilo(ex nihilo) ; 4] incorporated; 5] founded; 6] established</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaclimate">
+      <element name="climate">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the physical climate of a place. [13.3.4.3. States, Traits, and Events]</a:documentation>
+         <group>
+      
+         
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+          
+        
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.labelLike"/>
+               </oneOrMore>
+          
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgaclimate"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgadeath">
+      <element name="death">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a person's death, such as its date and place. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] proclaimed; 2] assumed; 3] verified; 4] clinical; 5] brain; 6] natural; 7] unnatural; 8] fragmentation; 9] dissolution</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaeducation">
+      <element name="education">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of the educational experience of a person. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] secondary; 3] undergraduate; 4] graduate; 5] residency; 6] apprenticeship</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaevent">
+      <element name="event">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains data relating to any kind of significant event associated with a person, place, or organization. [13.3.1. Basic Principles]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+          
+        
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.labelLike"/>
+               </oneOrMore>
+          
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgalinkGrp"/>
+                  <ref name="sgalink"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgaevent"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="where">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the location of an event by pointing to a place element</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafaith">
+      <element name="faith">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the faith, religion, or belief set of a person. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] practicing; 2] clandestine; 3] patrilineal; 4] matrilineal; 5] convert</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgafloruit">
+      <element name="floruit">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about a person's period of activity. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgageo">
+      <element name="geo">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographical coordinates) contains any expression of a set of geographic coordinates, representing a point, line, or area on the surface of the earth in some notation. [13.3.4.1. Varieties of Location]</a:documentation>
+         <text/>
+         <ref name="sgaatt.global.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalangKnowledge">
+      <element name="langKnowledge">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language knowledge) summarizes the state of a person's linguistic knowledge, either as prose or by a list of langKnown elements. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <group>        
+       
+            <choice>
+	              <ref name="sgamodel.pLike"/>
+	              <oneOrMore>
+                  <ref name="sgalangKnown"/>
+               </oneOrMore>
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] listening; 2] speaking; 3] reading; 4] writing</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="tags">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies one or more valid language tags for the languages specified</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <choice>
+                        <data type="language"/>
+                        <choice>
+                           <value/>
+                           <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        </choice>
+                     </choice>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalangKnown">
+      <element name="langKnown">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language known) summarizes the state of a person's linguistic competence, i.e., knowledge of a single language. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq.limited"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <attribute name="tag">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a valid language tag for the language concerned.</a:documentation>
+            <choice>
+               <data type="language"/>
+               <choice>
+                  <value/>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+               </choice>
+            </choice>
+         </attribute>
+         <optional>
+            <attribute name="level">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a code indicating the person's level of knowledge for this language</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistOrg">
+      <element name="listOrg">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of organizations) contains a list of elements, each of which provides information about an identifiable organization. [13.2.2. Organizational Names]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgaorg"/>
+                  <ref name="sgalistOrg"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistEvent">
+      <element name="listEvent">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of events) contains a list of descriptions, each of which provides information about an identifiable event. [13.3.1. Basic Principles]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgaevent"/>
+                  <ref name="sgalistEvent"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistPerson">
+      <element name="listPerson">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of persons) contains a list of descriptions, each of which provides information about an identifiable person or a group of people, for example the participants in a language interaction, or the people referred to in a historical source. [13.3.2. The Person Element 15.2. Contextual Information 2.4. The Profile Description 15.3.2. Declarable Elements]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.personLike"/>
+                  <ref name="sgalistPerson"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistPlace">
+      <element name="listPlace">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of places) contains a list of places, optionally followed by a list of relationships (other than containment) defined amongst them. [2.2.7. The Source Description 13.3.4. Places]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sgamodel.placeLike"/>
+                  <ref name="sgalistPlace"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalocation">
+      <element name="location">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">defines the location of a place as a set of geographical coordinates, in terms of other named geo-political entities, or as an address. [13.3.4. Places]</a:documentation>
+         <zeroOrMore>
+            <choice>
+        
+               <ref name="sgamodel.labelLike"/>
+               <ref name="sgamodel.placeNamePart"/>
+               <ref name="sgamodel.offsetLike"/>
+               <ref name="sgamodel.measureLike"/>
+               <ref name="sgamodel.addressLike"/>
+               <ref name="sgamodel.noteLike"/>
+               <ref name="sgamodel.biblLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganationality">
+      <element name="nationality">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an informal description of a person's present or past nationality or citizenship. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] birth; 2] naturalised; 3] self-assigned</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaoccupation">
+      <element name="occupation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains an informal description of a person's trade, profession or occupation. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.specialPara"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] other; 3] paid; 4] unpaid</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates the classification system or taxonomy in use, for example by supplying the identifier of a taxonomy element, or pointing to some other resource.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="code">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies an occupation code defined within the classification system or taxonomy defined by the scheme attribute.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaorg">
+      <element name="org">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(organization) provides information about an identifiable organization such as a business, a tribe, or any other grouping of people. [13.2.2. Organizational Names]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <zeroOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </zeroOrMore>
+          
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.labelLike"/>
+                     <ref name="sgamodel.nameLike"/>
+                     <ref name="sgamodel.placeLike"/>
+                     <ref name="sgamodel.orgPart"/>
+	                    <ref name="sgamodel.milestoneLike"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgalinkGrp"/>
+                  <ref name="sgalink"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.personLike"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a primary role or classification for the organization.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistRelation">
+      <element name="listRelation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about relationships identified amongst people, places, and organizations, either informally as prose or as formally expressed relation links. [13.3.2.3. Personal Relationships]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+               <ref name="sgamodel.pLike"/>
+        
+               <oneOrMore>
+                  <choice>
+                     <ref name="sgarelation"/>
+                     <ref name="sgalistRelation"/>
+                  </choice>
+               </oneOrMore>
+        
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaperson">
+      <element name="person">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about an identifiable individual, for example a participant in a language interaction, or a person referred to in a historical source. [13.3.2. The Person Element 15.2.2. The Participant Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.personPart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a primary role or classification for the person.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="sex">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of the person.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="age">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies an age group for the person.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapersona">
+      <element name="persona">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">provides information about one of the personalities identified for a given individual, where an individual has multiple personalities. [13.3.2. The Person Element]</a:documentation>
+         <choice>   
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.personPart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies a primary role or classification for the persona.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="sex">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of the persona.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="age">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies an age group for the persona.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapersonGrp">
+      <element name="personGrp">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(personal group) describes a group of individuals treated as a single person for analytic purposes. [15.2.2. The Participant Description]</a:documentation>
+         <choice>
+      
+            <oneOrMore>
+               <ref name="sgamodel.pLike"/>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.personPart"/>
+                  <ref name="sgamodel.global"/>
+               </choice>
+            </zeroOrMore>
+      
+         </choice>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="role">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the role of this group of participants in the interaction.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="sex">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of the participant group.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="age">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the age group of the participants.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="size">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes informally the size or approximate size of the group for example by means of a number and an indication of accuracy e.g. approx 200.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaplace">
+      <element name="place">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains data about a geographic location [13.3.4. Places]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <zeroOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </zeroOrMore>
+          
+        
+        
+               <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.labelLike"/>
+                     <ref name="sgamodel.placeStateLike"/>
+                     <ref name="sgamodel.eventLike"/>
+                  </choice>
+               </zeroOrMore>
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+                  <ref name="sgaidno"/>
+                  <ref name="sgalinkGrp"/>
+                  <ref name="sgalink"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.placeLike"/>
+                  <ref name="sgalistPlace"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgapopulation">
+      <element name="population">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the population of a place. [13.3.4.3. States, Traits, and Events]</a:documentation>
+         <group>
+      
+         
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <optional>
+               <group>
+                  <choice>
+          
+            
+                     <oneOrMore>
+                        <ref name="sgamodel.pLike"/>
+                     </oneOrMore>
+            
+          
+          
+            
+                     <oneOrMore>
+                        <ref name="sgamodel.labelLike"/>
+                     </oneOrMore>
+            
+          
+                  </choice>
+        
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.noteLike"/>
+                        <ref name="sgamodel.biblLike"/>
+                     </choice>
+                  </zeroOrMore>
+        
+               </group>
+            </optional>
+      
+            <zeroOrMore>
+               <ref name="sgapopulation"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgarelation">
+      <element name="relation">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(relationship) describes any kind of relationship or linkage amongst a specified group of places, events, persons, objects or other items. [13.3.2.3. Personal Relationships]</a:documentation>
+         <optional>
+            <ref name="sgadesc"/>
+         </optional>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relation-reforkeyorname-constraint-assert-20">
+            <rule context="tei:relation">
+               <assert xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="@ref or @key or @name">One of the attributes  'name', 'ref' or 'key' must be supplied</assert>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relation-activemutual-constraint-report-17">
+            <rule context="tei:relation">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0" test="@active and @mutual">Only one of the attributes
+@active and @mutual may be supplied</report>
+            </rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="shelley_godwin_odd-relation-activepassive-constraint-report-18">
+            <rule context="tei:relation">
+               <report xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       test="@passive and not(@active)">the attribute 'passive'
+	may be supplied only if the attribute 'active' is
+	supplied</report>
+            </rule>
+         </pattern>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.canonical.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <optional>
+            <attribute name="name">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a name for the kind of relationship of which this is an instance.</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <choice>
+            <optional>
+               <attribute name="active">
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the active participants in a non-mutual relationship, or all the participants in a mutual one.</a:documentation>
+                  <list>
+                     <oneOrMore>
+                        <data type="anyURI"/>
+                     </oneOrMore>
+                  </list>
+               </attribute>
+            </optional>
+            <optional>
+               <attribute name="mutual">
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a list of participants amongst all of whom the relationship holds equally.</a:documentation>
+                  <list>
+                     <oneOrMore>
+                        <data type="anyURI"/>
+                     </oneOrMore>
+                  </list>
+               </attribute>
+            </optional>
+         </choice>
+         <optional>
+            <attribute name="passive">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the passive participants in a non-mutual relationship.</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaresidence">
+      <element name="residence">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">describes a person's present or past places of residence. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] primary; 2] secondary; 3] temporary; 4] permanent</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasex">
+      <element name="sex">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the sex of a person. [13.3.2.1. Personal Characteristics]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] explicit; 2] implicit</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="value">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies a coded value for sex</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="token">
+                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     </data>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgasocecStatus">
+      <element name="socecStatus">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(socio-economic status) contains an informal description of a person's perceived social or economic status. [15.2.2. The Participant Description]</a:documentation>
+         <ref name="sgamacro.phraseSeq"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attribute.subtype"/>
+         <optional>
+            <attribute name="type">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">characterizes the element in some sense, using any convenient classification scheme or typology.
+Sample values include: 1] atBirth; 2] atDeath; 3] dependent; 4] inherited; 5] independent</a:documentation>
+               <data type="token">
+                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               </data>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="scheme">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies the classification system or taxonomy in use, for example by pointing to a locally-defined taxonomy element or by supplying a URI for an externally-defined system.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <optional>
+            <attribute name="code">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">identifies a status code defined within the classification system or taxonomy defined by the scheme attribute.</a:documentation>
+               <data type="anyURI"/>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgastate">
+      <element name="state">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of some status or quality attributed to a person, place, or organization often at some specific time or for a specific date range. [13.3.1. Basic Principles 13.3.2.1. Personal Characteristics]</a:documentation>
+         <group>
+        
+           
+        
+            <choice>
+           
+              <oneOrMore>
+                  <ref name="sgastate"/>
+               </oneOrMore>
+           
+               <group>
+              
+                 <zeroOrMore>
+                     <ref name="sgamodel.headLike"/>
+                  </zeroOrMore>
+              
+              
+                 <oneOrMore>
+                     <ref name="sgamodel.pLike"/>
+                  </oneOrMore>
+              
+              
+                 <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.noteLike"/>
+                        <ref name="sgamodel.biblLike"/>
+                     </choice>
+                  </zeroOrMore>
+              
+               </group>
+           
+              
+                 <zeroOrMore>
+                  <choice>
+                    <ref name="sgamodel.labelLike"/>
+                    <ref name="sgamodel.noteLike"/>
+                    <ref name="sgamodel.biblLike"/>
+                 </choice>
+               </zeroOrMore>
+              
+           
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgaterrain">
+      <element name="terrain">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains information about the physical terrain of a place. [13.3.4.3. States, Traits, and Events]</a:documentation>
+         <group>
+      
+         
+      
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+            <choice>
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.pLike"/>
+               </oneOrMore>
+          
+        
+        
+          
+               <oneOrMore>
+                  <ref name="sgamodel.labelLike"/>
+               </oneOrMore>
+          
+        
+            </choice>
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgamodel.noteLike"/>
+                  <ref name="sgamodel.biblLike"/>
+               </choice>
+            </zeroOrMore>
+      
+      
+            <zeroOrMore>
+               <ref name="sgaterrain"/>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgatrait">
+      <element name="trait">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains a description of some status or quality attributed to a person, place, or organization typically, but not necessarily, independent of the volition or action of the holder and usually not at some specific time or for a specific date range. [13.3.1. Basic Principles 13.3.2.1. Personal Characteristics]</a:documentation>
+         <group>
+       
+          
+       
+            <choice>
+          
+               <oneOrMore>
+                  <ref name="sgatrait"/>
+               </oneOrMore>
+          
+               <group>
+             
+                  <zeroOrMore>
+                     <ref name="sgamodel.headLike"/>
+                  </zeroOrMore>
+             
+             
+                  <oneOrMore>
+                     <ref name="sgamodel.pLike"/>
+                  </oneOrMore>
+             
+             
+                  <zeroOrMore>
+                     <choice>
+                        <ref name="sgamodel.noteLike"/>
+                        <ref name="sgamodel.biblLike"/>
+                     </choice>
+                  </zeroOrMore>
+             
+               </group>
+          
+             
+                <zeroOrMore>
+                  <choice>
+                     <ref name="sgamodel.labelLike"/>
+                     <ref name="sgamodel.noteLike"/>
+                     <ref name="sgamodel.biblLike"/>
+                  </choice>
+               </zeroOrMore>
+             
+          
+            </choice>
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.datable.attributes"/>
+         <ref name="sgaatt.editLike.attributes"/>
+         <ref name="sgaatt.naming.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sganym">
+      <element name="nym">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(canonical name) contains the definition for a canonical name or name component of any kind. [13.3.5. Names and Nyms]</a:documentation>
+         <group>
+      
+        
+            <zeroOrMore>
+               <ref name="sgamodel.entryPart"/>
+            </zeroOrMore>
+        
+      
+      
+        
+            <zeroOrMore>
+               <ref name="sgamodel.pLike"/>
+            </zeroOrMore>
+        
+      
+      
+        
+            <zeroOrMore>
+               <ref name="sganym"/>
+            </zeroOrMore>
+        
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <optional>
+            <attribute name="parts">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">points to constituent nyms</a:documentation>
+               <list>
+                  <oneOrMore>
+                     <data type="anyURI"/>
+                  </oneOrMore>
+               </list>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgalistNym">
+      <element name="listNym">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list of canonical names) contains a list of nyms, that is, standardized names for any thing. [13.3.5. Names and Nyms]</a:documentation>
+         <group>
+      
+            <zeroOrMore>
+               <ref name="sgamodel.headLike"/>
+            </zeroOrMore>
+      
+      
+            <oneOrMore>
+               <choice>
+                  <ref name="sganym"/>
+                  <ref name="sgalistNym"/>
+               </choice>
+            </oneOrMore>
+      
+      
+            <zeroOrMore>
+               <choice>
+                  <ref name="sgarelation"/>
+                  <ref name="sgalistRelation"/>
+               </choice>
+            </zeroOrMore>
+      
+         </group>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <ref name="sgaatt.declarable.attributes"/>
+         <ref name="sgaatt.sortable.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <define name="sgac">
+      <element name="c">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(character) represents a character. [17.1. Linguistic Segment Categories]</a:documentation>
+         <ref name="sgamacro.xtext"/>
+         <ref name="sgaatt.global.attributes"/>
+         <ref name="sgaatt.segLike.attributes"/>
+         <ref name="sgaatt.typed.attributes"/>
+         <empty/>
+      </element>
+   </define>
+   <start>
+      <choice>
+         <ref name="sgaTEI"/>
+      </choice>
+   </start>
+</grammar>

--- a/data/tei/ox/ox-ms_abinger_c56/ox-ms_abinger_c56-0076.xml
+++ b/data/tei/ox/ox-ms_abinger_c56/ox-ms_abinger_c56-0076.xml
@@ -19,7 +19,7 @@
         <add place="sublinear"><metamark function="displacement" xml:id="c56-0076.01"
             >^</metamark></add> <del rend="strikethrough">and</del></mod> yet her words</line>
     <line><add place="interlinear" hand="#pbs" corresp="#c56-0076.01"><del rend="strikethrough">of th</del> as the cause of his death&#x2014;</add></line>
-    <line>pierce my heart. We are all unhpappy</line>
+    <line>pierce my heart. We are all unhappy</line>
     <line>but <del rend="strikethrough">that</del> will not that be an additio</line>
     <line>nal motive <mod>
         <del rend="overwritten">to</del>

--- a/data/tei/ox/ox-ms_abinger_c56Full.xml
+++ b/data/tei/ox/ox-ms_abinger_c56Full.xml
@@ -1,0 +1,9168 @@
+<!--<?xml-model href="../../schemata/shelley_godwin_odd.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>-->
+<?xml-model href="../../schemata/shelley_godwin_Pgh_odd.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../../schemata/shelley_godwin_Pgh_odd.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="ox-ms_abinger_c56">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title type="main">Frankenstein, MS. Abinger C. 56</title>
+                <title type="sub">An electronic transcription</title>
+                <respStmt xml:id="md_editor">
+                    <resp>Metadata editor</resp>
+                    <name xml:id="RV">Raffaele Viglianti</name>
+                </respStmt>
+            </titleStmt>
+            <editionStmt>
+                <edition>Shelley-Godwin Archive edition, <date>2012-2016</date>
+                </edition>
+            </editionStmt>
+            <publicationStmt>
+                <distributor>Oxford University</distributor>
+                <address>
+                    <addrLine>
+                        <ref target="http://www.shelleygodwinarchive.org/">http://www.shelleygodwinarchive.org/</ref>
+                    </addrLine>
+                </address>
+                <availability status="free">
+                    <licence target="http://creativecommons.org/publicdomain/zero/1.0/">
+                        <p>CC0 1.0 Universal.</p>
+                        <p> To the extent possible under law, the creators of the metadata records for the Shelley-Godwin Archive 
+                            have waived all copyright and related or neighboring rights to this work.</p>
+                    </licence>
+                </availability>
+                <pubPlace>Oxford, UK, and College Park, MD</pubPlace>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <settlement>Oxford</settlement>
+                        <repository>Bodleian Library, University of Oxford</repository>
+                        <idno type="Bod">MS. Abinger c.56</idno>
+                    </msIdentifier>
+                    <msContents>
+                        <msItem class="#work">
+                            <bibl status="draft">
+                                <author>Mary Shelley</author>
+                                <title>Frankenstein</title>
+                            </bibl>
+                            <msItem class="#volume" n="I" xml:id="ox-frankenstein_volume_i">
+                                <locusGrp>
+                                    <locus target="#ox-ms_abinger_c56-0001                                         #ox-ms_abinger_c56-0002                                         #ox-ms_abinger_c56-0003                                         #ox-ms_abinger_c56-0004                                         #ox-ms_abinger_c56-0005                                         #ox-ms_abinger_c56-0006                                         #ox-ms_abinger_c56-0007                                         #ox-ms_abinger_c56-0008                                         #ox-ms_abinger_c56-0009                                         #ox-ms_abinger_c56-0010                                         #ox-ms_abinger_c56-0011                                         #ox-ms_abinger_c56-0012                                         #ox-ms_abinger_c56-0013                                         #ox-ms_abinger_c56-0014                                         #ox-ms_abinger_c56-0015                                         #ox-ms_abinger_c56-0016                                         #ox-ms_abinger_c56-0017                                         #ox-ms_abinger_c56-0018                                         #ox-ms_abinger_c56-0019                                         #ox-ms_abinger_c56-0020                                         #ox-ms_abinger_c56-0021                                         #ox-ms_abinger_c56-0022                                         #ox-ms_abinger_c56-0023                                         #ox-ms_abinger_c56-0024                                         #ox-ms_abinger_c56-0025                                         #ox-ms_abinger_c56-0026                                         #ox-ms_abinger_c56-0027                                         #ox-ms_abinger_c56-0028                                         #ox-ms_abinger_c56-0029                                         #ox-ms_abinger_c56-0030                                         #ox-ms_abinger_c56-0031                                         #ox-ms_abinger_c56-0032                                         #ox-ms_abinger_c56-0033                                         #ox-ms_abinger_c56-0034                                         #ox-ms_abinger_c56-0035                                         #ox-ms_abinger_c56-0036                                         #ox-ms_abinger_c56-0037                                         #ox-ms_abinger_c56-0038                                         #ox-ms_abinger_c56-0039                                         #ox-ms_abinger_c56-0040                                         #ox-ms_abinger_c56-0041                                         #ox-ms_abinger_c56-0042                                         #ox-ms_abinger_c56-0043                                         #ox-ms_abinger_c56-0044                                         #ox-ms_abinger_c56-0045                                         #ox-ms_abinger_c56-0046                                         #ox-ms_abinger_c56-0047                                         #ox-ms_abinger_c56-0048                                         #ox-ms_abinger_c56-0049                                         #ox-ms_abinger_c56-0050                                         #ox-ms_abinger_c56-0051                                         #ox-ms_abinger_c56-0052                                         #ox-ms_abinger_c56-0053                                         #ox-ms_abinger_c56-0054                                         #ox-ms_abinger_c56-0055                                         #ox-ms_abinger_c56-0056                                         #ox-ms_abinger_c56-0057                                         #ox-ms_abinger_c56-0058                                         #ox-ms_abinger_c56-0059                                         #ox-ms_abinger_c56-0060                                         #ox-ms_abinger_c56-0061                                         #ox-ms_abinger_c56-0062                                         #ox-ms_abinger_c56-0063                                         #ox-ms_abinger_c56-0064                                         #ox-ms_abinger_c56-0065                                         #ox-ms_abinger_c56-0066                                         #ox-ms_abinger_c56-0067                                         #ox-ms_abinger_c56-0068                                         #ox-ms_abinger_c56-0069                                         #ox-ms_abinger_c56-0070                                         #ox-ms_abinger_c56-0071                                         #ox-ms_abinger_c56-0072                                         #ox-ms_abinger_c56-0073                                         #ox-ms_abinger_c56-0074                                         #ox-ms_abinger_c56-0075                                         #ox-ms_abinger_c56-0076                                         #ox-ms_abinger_c56-0077                                         #ox-ms_abinger_c56-0078                                         #ox-ms_abinger_c56-0079                                         #ox-ms_abinger_c56-0080                                         #ox-ms_abinger_c56-0081                                         #ox-ms_abinger_c56-0082                                         #ox-ms_abinger_c56-0083                                         #ox-ms_abinger_c56-0084                                         #ox-ms_abinger_c56-0085                                         #ox-ms_abinger_c56-0086                                         #ox-ms_abinger_c56-0087                                         #ox-ms_abinger_c56-0088                                         #ox-ms_abinger_c56-0089                                         #ox-ms_abinger_c56-0090                                         #ox-ms_abinger_c56-0091                                         #ox-ms_abinger_c56-0092                                         #ox-ms_abinger_c56-0093                                         #ox-ms_abinger_c56-0094                                         #ox-ms_abinger_c56-0095                                         #ox-ms_abinger_c56-0096                                         #ox-ms_abinger_c56-0097                                         #ox-ms_abinger_c56-0098                                         #ox-ms_abinger_c56-0099                                         #ox-ms_abinger_c56-0100                                         #ox-ms_abinger_c56-0101                                         #ox-ms_abinger_c56-0102                                         #ox-ms_abinger_c56-0103                                         #ox-ms_abinger_c56-0104                                         #ox-ms_abinger_c56-0105                                         #ox-ms_abinger_c56-0106                                         #ox-ms_abinger_c56-0107                                         #ox-ms_abinger_c56-0108                                         #ox-ms_abinger_c56-0109                                         #ox-ms_abinger_c56-0110                                         #ox-ms_abinger_c56-0111                                         #ox-ms_abinger_c56-0112                                         #ox-ms_abinger_c56-0113                                         #ox-ms_abinger_c56-0114                                         #ox-ms_abinger_c56-0115                                         #ox-ms_abinger_c56-0116                                         #ox-ms_abinger_c56-0117                                         #ox-ms_abinger_c56-0118                                         #ox-ms_abinger_c56-0119                                         #ox-ms_abinger_c56-0120                                         #ox-ms_abinger_c56-0121                                         #ox-ms_abinger_c56-0122                                         #ox-ms_abinger_c56-0123                                         #ox-ms_abinger_c56-0124                                         #ox-ms_abinger_c56-0125                                         #ox-ms_abinger_c56-0126                                         #ox-ms_abinger_c56-0127                                         #ox-ms_abinger_c56-0128                                         #ox-ms_abinger_c56-0129                                         #ox-ms_abinger_c56-0130                                         #ox-ms_abinger_c56-0131                                         #ox-ms_abinger_c56-0132                                         #ox-ms_abinger_c56-0133                                         #ox-ms_abinger_c56-0134"></locus>
+                                </locusGrp>
+                                <bibl>
+                                    <title>Volume I</title>
+                                    <date notAfter="1816-12" notBefore="1816-08">[August or September]-[?December] 1816</date>
+                                </bibl>
+                            </msItem>
+                        </msItem>
+                    </msContents>
+                    <physDesc>
+                        <handDesc>
+                            <handNote scope="major" xml:id="mws"><persName>Mary Shelley</persName></handNote>
+                            <handNote scope="minor" xml:id="pbs"><persName>Percy Shelley</persName></handNote>
+                        </handDesc>
+                    </physDesc>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <classDecl xml:base="../shared/classDecl.xml">
+    <taxonomy>
+        <category xml:id="work">
+            <catDesc>A work in the Shelley-Godwin Archive, e.g. Frankenstein</catDesc>
+        </category>
+        <category xml:id="work_part">
+            <catDesc>Metadata about a work in the Shelley-Godwin Archive split across multiple manuscripts</catDesc>
+        </category>
+        <category xml:id="notebook">
+            <catDesc>A manuscript notebook containing one or more works in the Shelley-Godwin
+                Archive, e.g. Frankenstein Notebook A</catDesc>
+        </category>
+        <category xml:id="volume">
+            <catDesc>The volume of a work in the Shelley-Godwin Archive, e.g. Frankenstein Vol
+                I</catDesc>
+        </category>
+        <category xml:id="chapter">
+            <catDesc>The chapter in a volume of a work in the Shelley-Godwin Archive, e.g.
+                Frankenstein Vol I, Chapter 1</catDesc>
+        </category>
+        <category xml:id="miscellaneous">
+            <catDesc>A part of a manuscript in the Shelley-Godwin Archive that does not fit in other
+                categories of this taxonomy.</catDesc>
+        </category>
+    </taxonomy>
+</classDecl>
+        </encodingDesc>
+    </teiHeader>
+    <sourceDoc>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5078" lry="7304" ulx="0" uly="0" mith:folio="i recto" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0001.xml" xml:id="ms_abinger_c56-0001">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0001.jp2"></graphic>
+  <zone type="main">
+    <addSpan hand="#library" spanTo="#c56-0001.01"></addSpan>
+    <line rend="indent3"><del rend="strikethrough">A12</del></line>
+    <line rend="center">A 11</line>
+    <line rend="center"><unclear extent="1" unit="chars"></unclear> Autograph</line>
+    <line rend="center"><metamark function="separate">__________</metamark></line>
+    <line rend="center">Part of the MS of</line>
+    <line rend="center">Frankenstein</line>
+    <line rend="center"><metamark function="separate">__________</metamark></line>
+    <line rend="center">pp 64-172 (of vol I.?)</line>
+    <line rend="center">ch. 6-17</line>
+    <line rend="center">vol. II. pp 1-150</line>
+    <line rend="center">ch I-XIV</line>
+    <line rend="center">Corrections in another</line>
+    <line rend="center">hand</line>
+    <line rend="center">Dep. c. 477/1</line>
+    <anchor xml:id="c56-0001.01"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5078" lry="7304" ulx="0" uly="0" mith:folio="i verso" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0002.xml" xml:id="ox-ms_abinger_c56-0002">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0002.jp2"></graphic>
+  <zone type="main">
+    
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7248" ulx="0" uly="0" mith:folio="ii recto" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0003.xml" xml:id="ox-ms_abinger_c56-0003">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0003.jp2"></graphic>
+  <zone type="library"><line>ii (<unclear extent="2" unit="chars"></unclear>)</line></zone>
+  <zone type="main">
+    <addSpan hand="#library" spanTo="#c56-0003.01"></addSpan>
+    <line>The first fragment contains</line>
+    <line>pp. 24-97 of the Standard</line>
+    <line>Novel edition.</line>
+    <milestone unit="tei:p"></milestone>
+    <line>The second pp. 104-202, with</line>
+    <line>a slight interruption.</line>
+    <milestone unit="tei:p"></milestone>
+    <line>The third pp. 168-202, with</line>
+    <line>many imperfections.</line>
+    <anchor xml:id="c56-0003.01"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5342" lry="7220" ulx="0" uly="0" mith:folio="ii verso" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0004.xml" xml:id="ox-ms_abinger_c56-0004">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0004.jp2"></graphic>
+  <zone type="main">
+    
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5088" lry="7082" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="1r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0005.xml" xml:id="ox-ms_abinger_c56-0005">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0005.jp2"></graphic>
+  <zone type="library"><line>1</line></zone>
+
+  <zone type="main">
+    <handShift medium="pen" new="#mws"></handShift>
+    <line rend="center"><milestone spanTo="#c56-0005.06" unit="tei:head"></milestone>Chapt. 2<anchor xml:id="c56-0005.06"></anchor></line>
+    <line>Those events which materially influence our fu</line>
+    <line>ture destinies <del rend="strikethrough">are</del> often <mod>
+        <del rend="strikethrough">caused</del>
+        <del rend="strikethrough">by slight or</del>
+        <add hand="#pbs" place="superlinear">derive thier origin from a</add>
+      </mod> tri</line>
+    <line>vial occurence<del rend="strikethrough">s</del>. <mod spanTo="#c56-0005.01"></mod><del next="#c56-0005.02" rend="strikethrough">Strange as the</del>
+      <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">statement of the</add></del>
+      </mod>
+      <del next="#c56-0005.03" rend="strikethrough" xml:id="c56-0005.02">simple fact</del></line>
+    <line><del rend="strikethrough" xml:id="c56-0005.03">may appear my fate had been</del>
+      <del rend="strikethrough">Chemist</del><anchor xml:id="c56-0005.01"></anchor> Natu</line>
+    <line>ral philosophy <del rend="strikethrough">has</del> is the genius that has</line>
+    <line>regulated my fate I <mod>
+        <del rend="strikethrough">wish</del>
+        <add hand="#pbs" place="superlinear">desire</add>
+      </mod> the<mod xml:space="preserve"><del rend="overwritten">ir</del><add place="intralinear">refore</add></mod> in this account</line>
+    <line>of my early years to state those facts which</line>
+    <line>led to my<mod>
+        <del rend="strikethrough">love</del>
+        <del rend="strikethrough">pursuit</del>
+        <del rend="strikethrough"><add place="superlinear">first aqu</add></del>
+      </mod>
+      <mod>
+        <del rend="strikethrough">of that study.</del>
+        <add place="superlinear">predeliction for that science.</add>
+      </mod> When</line>
+    <line>I was eleven years old we all went on a party</line>
+    <line>of pleasure to <mod>
+        <del rend="strikethrough">Thonon</del>
+        <retrace cause="fix" hand="#pbs">
+          <add place="superlinear">the baths near</add>
+        </retrace>
+        <add hand="#pbs" place="superlinear">Thonon.</add>
+      </mod>
+      <del rend="strikethrough">and were confined there</del></line>
+    <line><del rend="strikethrough">b</del>
+      <del rend="strikethrough">obil</del>
+      <del rend="strikethrough">obliged by the rain</del>
+      <del rend="strikethrough">and</del>
+      <mod xml:space="preserve"><del rend="overwritten">t</del><add hand="#pbs" place="intralinear">T</add></mod>he inclemen</line>
+    <line>cy of the weather obliged us to remain a day</line>
+    <line>confined to the inn. In this house I chanced</line>
+    <line>to fin<mod xml:space="preserve"><del rend="overwritten">ed</del><add place="intralinear">d</add></mod> a <del rend="strikethrough">fo</del> volume<del rend="strikethrough">s</del> of the
+      Works of Corne</line>
+    <line>lius Agrippa. <del rend="strikethrough">And</del> I opened it with apathy</line>
+    <line><mod>
+        <del next="#c56-0005.04" rend="strikethrough">but</del>
+      <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">the theory that he attempted to d<add next="#c56-0005.05" place="superlinear">demonstrate and the wonderful facts that</add></add>
+        <add place="sublinear" xml:id="c56-0005.05">he relates <del rend="strikethrough">chan</del>
+          soon changed this feeling into</add>
+        <del rend="strikethrough" xml:id="c56-0005.04">continued <unclear>to re</unclear> with</del>
+      </mod> enthusiasm. A new</line>
+    <line>light dawned upon my mind and <del rend="strikethrough">I</del>
+      <del rend="strikethrough">com</del></line>
+    <line>bounding with joy I communicated my</line>
+    <line>discovery to my father. I cannot help here remark</line>
+    <line>ing the many opportunities <mod>
+        <del rend="strikethrough">parents</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">instructors</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">have</del>
+        <add hand="#pbs" place="superlinear">posess</add>
+      </mod></line>
+    <line>of directing the attention of their pupils to</line>
+    <line>useful knowledge, which they utterly neglect.</line>
+    <line>My father looked carelessly at the tit<del rend="strikethrough">t</del>le page</line>
+    <line>of my book — <del rend="strikethrough">Ah</del> and said Ah! Cornelius</line>
+    <line>Agrippa! — My dear Victor do not waste</line>
+    <line>your time upon this – it is sad trash.</line>
+    <line>If instead of this remark or rather excla</line>
+    <line>mation my father had taken the pains to</line>
+    <line>exp<mod>
+        <del rend="strikethrough">ound</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">lain</add>
+      </mod> to me that the principles of</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5088" lry="7082" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="1v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0006.xml" xml:id="ox-ms_abinger_c56-0006">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0006.jp2"></graphic>
+  <zone type="main">
+    <line>Agrippa had been entirely exploded. <del rend="strikethrough">And</del></line>
+    <line><del rend="strikethrough">aan</del> and that <mod>
+        <del rend="strikethrough">another</del>
+        <add place="superlinear">a modern</add>
+      </mod>system of science</line>
+    <line>had been introduced which possessed much</line>
+    <line>greater power than the ancient because</line>
+    <line>the powers of the ancient were pretended</line>
+    <line>and chimerical, while those of the moderns</line>
+    <line>are real and practical; under such</line>
+    <line>circumstances I should certainly have thrown</line>
+    <line>Agrippa aside, and with my imagination</line>
+    <line>warmed as it was
+	<mod xml:space="preserve"><del rend="overwritten">w</del><add hand="#pbs" place="intralinear">sh</add></mod>ould probably have</line>
+    <line>aplied myself to <del rend="strikethrough">m</del> the more <del rend="strikethrough">ra</del> rational</line>
+    <line>theory of chemistry which <mod spanTo="#c56-0006.04"></mod><del next="#c56-0006.01" rend="strikethrough">has at present</del>
+      <add hand="#pbs" next="#c56-0006.02" place="superlinear">has resulted from modern
+        discoveries</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0006.01">the approbation of the learned.</del>
+      <add hand="#pbs" next="#c56-0006.03" place="superlinear" xml:id="c56-0006.02">It is even
+        possible that the train of my ideas might never have recieved</add>
+      <add hand="#pbs" place="sublinear" xml:id="c56-0006.03">that fatal impulse which led me to my
+        ruin.</add><anchor xml:id="c56-0006.04"></anchor> But the</line>
+    <line>cursory glance my father had taken of</line>
+    <line>my volume by no means assured me</line>
+    <line>that he was acquainted with <mod>
+        <del rend="strikethrough">the</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">its</add>
+      </mod> contents;</line>
+    <line>and I continued to read with the greatest</line>
+    <line>avidity. <milestone unit="tei:p"></milestone><metamark function="paragraph">[</metamark>When I
+      returned home, my first</line>
+    <line>care was to procure <mod>
+        <del rend="strikethrough">this</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">the</add>
+      </mod>
+      <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">whole</add>
+      </mod> works of this</line>
+    <line>author and afterwards those of Paracel-</line>
+    <line>sus and Albertus Magnus. I read and studi<damage>ed</damage></line>
+    <line>the wild fancies of the<add hand="#pbs" place="intralinear">se</add> authors with</line>
+    <line>delight, they appeared to me treasures</line>
+    <line>known to few besides myself; and, althoug<damage>h</damage></line>
+    <line>I often wished to <mod>
+        <del rend="strikethrough">discover</del>
+        <add hand="#pbs" place="superlinear">communicate</add>
+      </mod> these secret stores</line>
+    <line>of knowledge <del rend="strikethrough">from</del> to my father yet his in</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5088" lry="7082" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="2r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0007.xml" xml:id="ox-ms_abinger_c56-0007">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0007.jp2"></graphic>
+
+  <zone type="library"><line>2</line></zone>
+
+  <zone type="main">
+    <line>definite censure of my favorite Agrippa,</line>
+    <line>always withheld me. <del rend="strikethrough">I let</del> I disclosed my secret</line>
+    <line>to Elizabeth therefore, under a strict promise</line>
+    <line>of secrecy; but she did not interest herself</line>
+    <line>in <mod>
+        <del rend="strikethrough">them</del>
+        <del rend=" strikethrough"><add hand="#pbs" place="superlinear">m<unclear>y</unclear></add></del>
+        <add hand="#pbs" place="superlinear">the subject,</add>
+      </mod> and I was left by her to pursue</line>
+    <line>my studies alone. –</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">It may appear very strange that a desci</line>
+    <line>ple of Albertus Magnus should arise in the</line>
+    <line>eighteenth century, but our family was not</line>
+    <line>scientifical, and I <mod>
+        <del rend="strikethrough">did</del>
+        <add hand="#pbs" place="superlinear">had</add>
+      </mod> not attend<add hand="#pbs" place="intralinear">ed</add> any of the</line>
+    <line> lectures given at Geneva. My dreams were</line>
+    <line> therefore undisturbed by reality, and I entered</line>
+    <line>with the greates diligence into the search</line>
+    <line> of the philosophers stone and the <add hand="#pbs" place="superlinear"><note>or if you
+          chose petrum philosophale</note></add>
+      <mod spanTo="#c56-0007.01"></mod>
+      <del next="#c56-0007.02" rend="strikethrough">elizer vi</del>
+      <add hand="#pbs" place="superlinear">elixer of life</add></line>
+    <line><del rend=" strikethrough" xml:id="c56-0007.02">tæ</del><anchor xml:id="c56-0007.01"></anchor>. But the latter obtained my most undi</line>
+    <line>ved attention; wealth was an inferior</line>
+    <line>object but what would be the glory</line>
+    <line> of the discovery if I could <del rend=" strikethrough">besto</del>
+      <del rend=" strikethrough">forever</del></line>
+    <line>banish disease from the human frame</line>
+    <line>and render man <mod>
+        <del rend=" strikethrough">unatainable</del>
+        <del rend=" strikethrough">by</del>
+        <add place="superlinear">invunerable to</add>
+      </mod> any</line>
+    <damage type="tear"></damage>
+  </zone>
+
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5088" lry="7082" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="2v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0008.xml" xml:id="ox-ms_abinger_c56-0008">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0008.jp2"></graphic>
+  <zone type="main">
+    <line><mod>
+        <del rend="overwritten"><unclear extent="2" unit="chars"></unclear></del>
+        <add place="intralinear">b</add>
+        <add hand="#pbs" place="sublinear">ut a</add>
+      </mod> violent death.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Nor were these my only visions, the</line>
+    <line>raising of ghosts or devils <mod spanTo="#c56-0008.01"></mod><add place="sublinear"><metamark function="insert">^</metamark></add>
+      <del next="#c56-0008.02" rend="strikethrough">was also a favour</del><add hand="#pbs" next="#c56-0008.05" place="superlinear">was a promise liberally accorded by</add></line>
+    <line><del next="#c56-0008.03" rend="strikethrough" xml:id="c56-0008.02">ite</del>
+      <del next="#c56-0008.04" rend="strikethrough" xml:id="c56-0008.03">pursuit</del>
+      <del rend="unmarked">and</del>
+      <del rend="strikethrough" xml:id="c56-0008.04">If I never saw any</del><add hand="#pbs" next="#c56-0008.06" place="superlinear" xml:id="c56-0008.05">my favourite authors; the
+        fulfilment of which I most eagerly sought;</add></line>
+    <line><add hand="#pbs" place="superlinear" xml:id="c56-0008.06">&amp; if my incantations were
+        always unsuccessful</add><anchor xml:id="c56-0008.01"></anchor>attributed <mod>
+        <del rend="strikethrough">it</del>
+        <add hand="#pbs" place="sublinear">the failure</add>
+      </mod> rather to my own inexperience</line>
+    <line><del rend="strikethrough">th</del> and mistake, than <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">to a</add>
+      </mod> want of skill <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">or fidelity</add>
+      </mod> in</line>
+    <line>my instructor<add hand="#pbs" place="intralinear">s</add>.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del rend="strikethrough">When I was about fifteen my
+        f</del></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The natural phænonema that takes</line>
+    <line>place every day before our eyes did not</line>
+    <line>escape my exa<mod xml:space="preserve"><del rend="overwritten">n</del><add hand="#pbs" place="intralinear">m</add></mod>i<mod><del rend="overwritten">m</del><add hand="#pbs" place="intralinear">n</add></mod>ations. 
+	<del rend="strikethrough">I remember</del>
+      <del rend="strikethrough">The</del></line>
+    <line><del rend="strikethrough">fermentation</del>
+      <del rend="strikethrough">of liquors</del> – <del rend="strikethrough">di</del><hi rend="underline">stillation</hi> of which</line>
+    <line>my favorite authors were utterly<add hand="#pbs" place="superlinear"><note><unclear>no</unclear></note></add> ignorant</line>
+    <line>excited my astonishment, but my utmost</line>
+    <line>wonder was <mod>
+        <del rend="strikethrough">caused</del>
+        <del rend="strikethrough">by an</del>
+        <add hand="#pbs" place="superlinear">engaged by some experiements</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">air pump</del>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">electrical
+          machine</add></del>
+        <add hand="#pbs" place="sublinear">on an air pump</add>
+      </mod></line>
+    <line>which I saw <mod>
+        <add hand="#pbs" place="superlinear">employed</add>
+        <del rend="strikethrough">used</del>
+      </mod> by a gentleman whom </line>
+    <line>we were in the habit of visiting.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The ignorance of my philosopher<mod xml:space="preserve"><del rend="overwritten">es</del><add hand="#pbs" place="intralinear">s</add></mod>
+	on these</line>
+    <line>and several other points, served to decrease</line>
+    <damage></damage>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5088" lry="7082" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="3r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0009.xml" xml:id="ox-ms_abinger_c56-0009">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0009.jp2"></graphic>
+  <zone type="library"><line>3</line></zone>
+  <zone type="main">
+    <line><mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">thier</add>
+      </mod> credit with <mod>
+        <add place="superlinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">me</add>
+      </mod> – but I could not entirely throw</line>
+    <line>them aside before <mod>
+        <del rend="strikethrough">any</del>
+        <add hand="#pbs" place="superlinear"><del rend="strikethrough"><unclear>some</unclear></del>
+          some</add>
+      </mod> other system <mod>
+        <del rend="strikethrough">cocc</del>
+        <add hand="#pbs" place="superlinear">should</add>
+      </mod></line>
+    <line>occup<mod>
+        <del rend="overwritten">ie</del>
+        <add hand="#pbs" place="intralinear">y</add>
+      </mod>d their place<mod>
+        <del rend="overwritten">.</del>
+        <add hand="#pbs" place="intralinear">,</add>
+      </mod>
+      <unclear extent="1" unit="chars"></unclear> in my mind–</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent3"><mod>
+        <del rend="strikethrough">An</del>
+        <del rend="unmarked">d</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">Among other questions suggested by natural
+          objects</add>
+      </mod> I <del rend="strikethrough">as</del> eagerly enquired of my father</line>
+    <line><mod>
+        <del rend="strikethrough">what</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">the nature <space extent="3" unit="chars"></space> &amp; the
+          origin of</add>
+      </mod> thunder and lightening. <del rend="strikethrough">was.</del> He</line>
+    <line>replied, electricity; describing at the same</line>
+    <line>time the effect of that power. He <mod>
+        <del rend="strikethrough">made</del>
+        <add hand="#pbs" place="superlinear">constructed</add>
+      </mod></line>
+    <line>a small electrical machine and exhi</line>
+    <line>bited a few experiments and made a</line>
+    <line>kite with a wire <add hand="#pbs" place="intralinear">&amp;</add> string <mod>
+        <del rend="strikethrough">and</del>
+        <add hand="#pbs" place="superlinear">which</add>
+      </mod> drew down</line>
+    <line>that fluid from the clouds.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">This last <del rend="strikethrough">blow</del>
+      <del rend="strikethrough">st</del> stroke compleated</line>
+    <line>the overthrow of Cornelius Agrippa, Albertus</line>
+    <line>Magnus and Paracelsus, who had so long</line>
+    <line>reigned the lords of my imagination. But</line>
+    <line>by some fatality I did not feel enclined to</line>
+    <line>commence any modern system and this</line>
+    <line><mod>
+        <del rend="strikethrough">inclination</del>
+        <add hand="#pbs" place="superlinear">disinclination</add>
+      </mod> was influenced by the following</line>
+    <line>circumstance.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">My father expressed a wish that I</line>
+    <line>should attend a course of lectures upon</line>
+    <line>natural philosophy, to which I <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">cheerfully</add>
+      </mod>consented <delSpan rend="strikethrough" spanTo="#c56-0009.02"></delSpan>and</line>
+    <line><delSpan rend="vertical_line" spanTo="#c56-0009.01"></delSpan>one evening<anchor xml:id="c56-0009.02"></anchor> that I spent in town at the</line>
+    <line>house of Clerval's father I <delSpan rend="strikethrough" spanTo="#c56-0009.03"></delSpan>heard
+      that</line>
+    <line>M<hi rend="sup">r</hi> — was lef at<anchor xml:id="c56-0009.03"></anchor> met M. <del rend="strikethrough">O P</del> a proficient</line>
+    <line>in Chemistry who left the company at</line>
+    <line>an early hour to <del rend="strikethrough">h</del> give his lecture upon</line>
+    <line>tha<mod>
+        <del rend="overwritten">n</del>
+        <add place="intralinear">t</add>
+      </mod> science enquiring as he went out<anchor xml:id="c56-0009.01"></anchor></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5088" lry="7082" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="3v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0010.xml" xml:id="ox-ms_abinger_c56-0010">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0010.jp2"></graphic>
+  <zone type="library"><line>3<hi rend="sup">v</hi></line></zone>
+
+  <zone type="main">
+    <line><mod spanTo="#c56-0010.04"></mod><del rend="strikethrough">if any one would <unclear extent="5" unit="chars"></unclear>
+        <unclear>him</unclear> I went</del>
+      <del rend="unmarked">but</del><add hand="#pbs" next="#c56-0010.01" place="superlinear">Some
+        accident prevented my attending the <del rend="strikethrough">series of</del> these
+        lectures</add></line>
+    <line><del next="#c56-0010.03" rend="strikethrough">this lecture was unfortunately nearly
+        the</del>
+      <add hand="#pbs" next="#c56-0010.02" place="superlinear" xml:id="c56-0010.01">until <del rend="strikethrough">they were nearly over </del>
+        <del rend="strikethrough">they</del> it was nearly finihsed. The</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0010.03">last</del><add hand="#pbs" place="superlinear" xml:id="c56-0010.02">lecture which I attended being thus <del rend="strikethrough">the</del> almost the last <del rend="strikethrough">in his
+        </del></add><anchor xml:id="c56-0010.04"></anchor> in his course <mod>
+        <add><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="sublinear">was entirely incomprehensible to me.</add>
+      </mod> – the professor talked</line>
+    <line>with the greatest fluency of potassium &amp;</line>
+    <line>Boron <del rend="strikethrough">zinc bismuth</del> – of sulphats and oxids</line>
+    <line><del rend="strikethrough">and displayed so many</del>
+      <mod>
+        <del rend="strikethrough">words</del>
+        <add hand="#pbs" place="superlinear">terms</add>
+      </mod> to which</line>
+    <line>I could <del rend="strikethrough">not</del> affix <mod>
+        <del rend="strikethrough">any</del>
+        <add hand="#pbs" place="superlinear">no</add>
+      </mod> idea: <del rend="strikethrough">that</del> I was</line>
+    <line>disgusted with <del rend="strikethrough">the appearance</del>
+      <del rend="strikethrough">of</del> a science</line>
+    <line>that appeared to me to contain only words.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">From this time untill I went to</line>
+    <line>Colledge I entirely neglected my formerly</line>
+    <line>adored study of <mod>
+        <del rend="strikethrough">chemistry</del>
+        <add place="superlinear">the science of</add>
+        <add hand="#pbs" place="superlinear"> natural philosophy</add>
+      </mod> although I still</line>
+    <line>read with delight Pliny and Buffons</line>
+    <line>authors <mod>
+        <del rend="strikethrough">that stood about on a par</del>
+        <add hand="#pbs" place="superlinear"><del rend="strikethrough">ar</del>
+          <del rend="strikethrough">of</del></add>
+      </mod></line>
+    <line>in my estimation <add hand="#pbs" place="intralinear">of nearly equal interest &amp;
+        utility.</add></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">My <mod>
+        <del rend="strikethrough">studies</del>
+        <add hand="#pbs" place="superlinear">occupations</add>
+      </mod> at this age were <del rend="strikethrough">th</del> principally the</line>
+    <line>mathematics, <del rend="strikethrough">which I delighted in an</del> and most</line>
+    <line>of the branches of study appertaining <del rend="strikethrough">th</del> to that</line>
+    <line>science. I was also busily employed in learning</line>
+    <line>languages Latin was <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">already</add>
+      </mod> familiar to me and I began to</line>
+    <line>read without the help of the <mod>
+        <del rend="strikethrough">dictionary</del>
+        <add hand="#pbs" place="superlinear">lexicon</add>
+      </mod> some of the</line>
+    <line>easiest greek authors. –I <add place="superlinear">also</add> understood English
+      &amp;</line>
+    <line>german perfectly: th<mod xml:space="preserve"><del rend="overwritten">ese</del><add place="intralinear">is</add>
+        <del rend="strikethrough">are</del>
+        <add place="superlinear">is</add>
+      </mod> list of my accom-</line>
+    <line>plishments at <mod>
+        <del rend="strikethrough">that</del>
+        <del rend="strikethrough">time</del>
+        <add hand="#pbs" place="superlinear"><del rend="unmarked">th</del><del rend="strikethrough">e period</del> the age of</add>
+      </mod> and you may</line>
+    <line>conceive that my hours were fully employd</line>
+    <line>in acquiring and maintaining a knowledge</line>
+    <line> of this various literature.</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="4r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0011.xml" xml:id="ox-ms_abinger_c56-0011">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0011.jp2"></graphic>
+
+  <zone rend="bordered" type="pagination">
+    <line>41</line>
+  </zone>
+
+  <zone type="library">
+    <line>4</line>
+  </zone>
+
+  <zone type="main">
+    <line><del instant="true" rend="strikethrough">sevr</del> servants had any request to
+      make</line>
+    <line>it always through <mod>
+        <del rend="strikethrough">the</del>
+        <add place="superlinear">her</add>
+      </mod> intercession <delSpan rend="strikethrough" spanTo="#c56-0011.02"></delSpan>of</line>
+    <line>Elizabeth<anchor xml:id="c56-0011.02"></anchor><del rend="strikethrough"> For me I loved he</del>
+      <delSpan rend="strikethrough" spanTo="#c56-0011.03"></delSpan>We agreed</line>
+    <line>perfectly although there were many<anchor xml:id="c56-0011.03"></anchor>
+      <anchor xml:id="c56-0011.04"></anchor></line>
+    <line rend="right"><add hand="#pbs" place="interlinear"><del rend="strikethrough">There</del>
+        For, although</add></line>
+    <line>was a great dissimilitude in our</line>
+    <line>characters.<mod>
+        <add hand="#pbs"><metamark function="displacement" xml:id="c56-0011.09">X</metamark></add>
+      </mod> I was more calm and phi</line>
+    <line>losphical than my companion</line>
+    <line>Yet I was not <del rend="strikethrough">n</del> so mild or yielding.</line>
+    <line>My application was of longer endurance</line>
+    <line><del rend="strikethrough">than hers</del> but it was not so severe</line>
+    <line><del rend="strikethrough">as hers</del> whil<mod xml:space="preserve"><del type="overwritten">e</del><add hand="#pbs" place="intralinear">st</add>
+      </mod> it <mod>
+        <del rend="strikethrough">lasted</del>
+        <add hand="#pbs" place="superlinear">endured</add>
+      </mod>
+      <mod spanTo="#c56-0011.11"></mod><delSpan rend="strikethrough" spanTo="#c56-0011.12"></delSpan>my
+      amusements</line>
+    <line>were studying old books of chemistry</line>
+    <line>and natural magic those of Elizabeth were</line>
+    <line>dra wing &amp; music.<space extent="3" unit="char"></space><anchor xml:id="c56-0011.12"></anchor><add hand="#pbs" place="superlinear"><metamark function="displacement" xml:id="c56-0011.13">X</metamark></add><anchor xml:id="c56-0011.11"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del instant="true" rend="strikethrough">When I</del>
+      <del instant="true" rend="strikethrough">I had</del> My brothers were consi</line>
+    <line>derably younger than myself but I had</line>
+    <line>a friend <del instant="true" rend="strikethrough">who</del>
+      <del instant="true" rend="strikethrough">who</del> in one of my school</line>
+    <line>fellows who compensated for this. <add hand="#pbs" place="superlinear">deficiency.</add>
+      Henry</line>
+    <line><mod>
+        <del rend="strikethrough">Carignan</del>
+        <add place="superlinear">Clerval</add>
+      </mod> was the son<del rend="strikethrough">s</del> of a merchant</line>
+    <line><del instant="true" rend="strikethrough">an</del> of Geneva <del instant="true" rend="strikethrough">and</del> an intimate friend</line>
+    <line>of my father<del rend="strikethrough">'s</del> – he was a boy of singu</line>
+    <line>lar talent &amp; <del instant="true" rend="strikethrough">fancy</del> fancy I
+      remember</line>
+    <line>when he was only nine years old he</line>
+    <line>wrote a fairy tale which was the</line>
+    <line>delight and amazement of all his</line>
+    <line>companions. <del rend="strikethrough">Like Don Quixote</del> his</line>
+    <line>favourite study <mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">consisted in</add>
+      </mod> books of chi</line>
+    <line>valry &amp; romance and <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" next="#c56-0011.15" place="superlinear">when very young, I can</add>
+        <add hand="#pbs" place="sublinear" xml:id="c56-0011.15">remember that</add>
+      </mod> we used to</line>
+    <line>act plays composed by him out of</line>
+    <line>th<mod xml:space="preserve"><del rend="overwritten">is</del><add hand="#pbs" place="intralinear">ese</add></mod>
+      <del rend="strikethrough">favourite</del> books, the principal</line>
+    <line><del instant="true" rend="strikethrough">car</del>characters of which were Orlando</line>
+    <line>Robin Hood, Amadis and St. George–</line>
+    <line>No youth could could be more happy</line>
+  </zone>
+
+  <zone corresp="#c56-0011.04" lrx="1289" lry="687" type="left_margin" ulx="0" uly="46">
+    <addSpan hand="#pbs" spanTo="#c56-0011.05"></addSpan>
+    <metamark function="displacement" spanTo="#c56-0011.06" xml:id="c56-0011.07"></metamark>
+    <line rend="right">X</line>
+    <line rend="right">X</line>
+    <anchor xml:id="c56-0011.06"></anchor>
+    <anchor xml:id="c56-0011.05"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0011.09" lrx="1289" lry="1804" type="left_margin" ulx="0" uly="811">
+    <addSpan hand="#pbs" spanTo="#c56-0011.10"></addSpan>
+    <line rend="right"><metamark>X</metamark> yet</line>
+    <line>there was an</line>
+    <line>harmony in</line>
+    <line>that very diss</line>
+    <line>imilitude–</line>
+    <line><metamark function="separate">_____________</metamark></line>
+    <anchor xml:id="c56-0011.10"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0011.07" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0011.08"></addSpan>
+    <line><metamark function="displacement">X</metamark> We were strangers</line>
+    <line>to any species</line>
+    <line><metamark>X</metamark> of disunion</line>
+    <line>or dispute</line>
+    <line><metamark function="separate">_____________</metamark></line>
+    <anchor xml:id="c56-0011.08"></anchor>
+  </zone>
+
+  <zone type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0011.14"></addSpan>
+    <line><metamark function="displacement">X</metamark></line>
+    <line>I delighted in</line>
+    <line>investigating</line>
+    <line>the facts relating</line>
+    <line>to the actual</line>
+    <line>world, she</line>
+    <line>busied herself</line>
+    <line>in <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">following</add>
+      </mod> the aerial</line>
+    <line>creations of the</line>
+    <line>poets.– The</line>
+    <line>world was to me</line>
+    <line>a secret which</line>
+    <line>I desired to disco</line>
+    <line>-ver,–to her it</line>
+    <line>was a <del instant="true" rend="strikethrough">haven</del></line>
+    <line>vacancy which</line>
+    <line>she sought to</line>
+    <line>people with</line>
+    <line>imaginations of</line>
+    <line>her own.</line><anchor xml:id="c56-0011.14"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="4v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0012.xml" xml:id="ox-ms_abinger_c56-0012">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0012.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>42</line></zone>
+  <zone type="main">
+    <line>than mine. – <mod>
+        <del rend="strikethrough">Our</del>
+        <add hand="#pbs" place="superlinear">My</add>
+      </mod> parents were indul</line>
+    <line>gent, and my companions amiable.</line>
+    <line><del rend="strikethrough">and our stud</del> Our studies were never</line>
+    <line>forced, and by some means we al-</line>
+    <line>ways had an end placed in view which</line>
+    <line>excited us to ardour.<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">in the prosecution of them.</add>
+      </mod> It was by this <mod>
+        <del rend="strikethrough">&amp;</del>
+        <add hand="#pbs" place="superlinear">method</add>
+      </mod></line>
+    <line>not by emulation that we were</line>
+    <line>urged. Elizabeth was not told to apply</line>
+    <line>herself to drawing <mod>
+        <del rend="strikethrough">or</del>
+        <add hand="#pbs" place="superlinear">that</add>
+      </mod> her companions</line>
+    <line><mod>
+        <del rend="strikethrough">would</del>
+        <add hand="#pbs" place="superlinear">might not</add>
+      </mod> outstrip her, but <mod spanTo="#c56-0012.01"></mod><del type="overwritten">she</del><add hand="#pbs" place="intralinear">by</add><del next="#c56-0012.02" rend="strikethrough">was</del><add hand="#pbs" place="superlinear">the</add><anchor xml:id="c56-0012.03"></anchor></line>
+    <line><del rend="strikethrough" xml:id="c56-0012.02">knew how</del><anchor xml:id="c56-0012.01"></anchor> pleas<mod xml:space="preserve"><del type="overwritten">ed</del><add hand="#pbs" place="intralinear">ing</add></mod> her Aunt <delSpan rend="strikethrough" spanTo="#c56-0012.04"></delSpan>would</line>
+    <line>be<anchor xml:id="c56-0012.04"></anchor> by <mod>
+        <del rend="strikethrough">a painting</del>
+        <add hand="#pbs" place="superlinear">the representation</add>
+      </mod> of some <del rend="strikethrough">of her</del></line>
+    <line>favourite scene<del rend="strikethrough">s</del> done by her own</line>
+    <line>hand. <del rend="strikethrough">Latin</del> We learned Latin &amp;</line>
+    <line>English <mod>
+        <del rend="strikethrough">to</del>
+        <add hand="#pbs" place="superlinear">that we might</add>
+      </mod> read the writ<mod xml:space="preserve"><del type="overwritten">ers</del><add hand="#pbs" place="intralinear">ings</add></mod>
+      <mod>
+        <del rend="strikethrough">of</del>
+        <add hand="#pbs" place="superlinear">in</add>
+      </mod> those</line>
+    <line>languages and so far from study</line>
+    <line>begin rendered odious <del rend="strikethrough">by</del> to us th<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">r</add>
+      </mod>ough</line>
+    <line>punishment, we loved application</line>
+    <line>and our amusements <mod>
+        <del rend="strikethrough">were</del>
+        <add hand="#pbs" place="superlinear">would have been</add>
+      </mod> the</line>
+    <line>labours of other children. perhaps</line>
+    <line>we did not read so many books</line>
+    <line>or learn <del rend="strikethrough">a</del> languages so quickly</line>
+    <line>as <mod>
+        <del rend="strikethrough">another child</del>
+        <add hand="#pbs" place="superlinear">those who are disciplined according to the
+          ordinary</add>
+        <add hand="#pbs" place="sublinear">method,</add>
+      </mod> but what we</line>
+    <line>learned was impressed <add hand="#pbs" place="superlinear">the more deeply</add> on
+      our</line>
+    <line>memory. <mod>
+      <add hand="#pbs" place="superlinear"><metamark function="displacement" xml:id="c56-0012.05">X</metamark></add>
+        <del rend="strikethrough">I include</del></mod>
+      <del rend="strikethrough">Hen</del> Henry <mod spanTo="#c56-0012.07"></mod><del next="#c56-0012.08" rend="strikethrough">Carignan</del><add place="superlinear">Clerval,</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0012.08">in this account</del><anchor xml:id="c56-0012.07"></anchor> for <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">he</add>
+      </mod> was<del rend="strikethrough">con</del> constantly</line>
+    <line>with us. he went to <del rend="strikethrough">sho</del> school</line>
+    <line>with me and generally passed</line>
+    <line>the afternoon at our house for</line>
+  </zone>
+
+  <zone corresp="#c56-0012.03" type="left_margin">
+    <line><add hand="#pbs">desire of</add></line>
+  </zone>
+
+  <zone corresp="#c56-0012.05" type="left_margin">
+    <addSpan spanTo="#c56-0012.06"></addSpan>
+    <line><add hand="#pbs" place="superlinear"><metamark function="displacement">X</metamark></add>In <mod>
+        <del rend="strikethrough">this</del>
+        <add hand="#pbs" place="superlinear">the</add>
+      </mod> descrip</line>
+    <line>tion of our do</line>
+    <line>mestic circle</line>
+    <line>I include</line>
+    <anchor xml:id="c56-0012.06"></anchor>
+  </zone>
+
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="5r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0013.xml" xml:id="ox-ms_abinger_c56-0013">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0013.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>43</line></zone>
+  <zone type="library"><line>5</line></zone>
+  <zone type="main">
+    <line>being an only child, and desti</line>
+    <line>tute of companions at home, h<mod>
+        <del rend="overwritten"><unclear>is</unclear></del>
+        <add hand="#pbs" place="intralinear">is</add>
+      </mod></line>
+    <line><del rend="strikethrough"><unclear>to</unclear></del> father was pleased that he</line>
+    <line>should find associates at our</line>
+    <line>house and we were never com</line>
+    <line>pletely happy when Clerval was</line>
+    <line>absent.</line>
+    <milestone unit="tei:p"></milestone>
+    <delSpan rend="vertical_line" spanTo="#c56-0013.01"></delSpan>
+    <delSpan rend="strikethrough" spanTo="#c56-0013.02"></delSpan>
+    <line rend="indent1">In this account of my early</line>
+    <line>youth I wish particularly to <mod spanTo="#c56-0013.03"></mod>men</line>
+    <line>tion <anchor xml:id="c56-0013.04"></anchor><anchor xml:id="c56-0013.03"></anchor> those
+        circumstances<anchor xml:id="c56-0013.02"></anchor> which</line>
+    <line>led to and nourished my taste</line>
+    <line>for that science which was</line>
+    <line>the principal amusement of my</line>
+    <line>boyish days and in <delSpan rend="strikethrough" spanTo="#c56-0013.05"></delSpan>the end
+      deci</line>
+    <line>ded my destiny<anchor xml:id="c56-0013.05"></anchor>. I mentioned before</line>
+    <line>my taste for old books of chemist</line>
+    <line>ry and natural magic and I remem</line>
+    <line>ber very well that I learned latin</line>
+    <line>principally that I might read</line>
+    <line>Pliny's Natural History my father</line>
+    <line>refusing to allow me to read a</line>
+    <line>translation. I used when very young</line>
+    <line>to attend lectures of chemistry</line>
+    <line>given in Geneva and athough</line>
+    <line>I did not understand them the</line>
+    <line>experiments never failed to</line>
+    <line>attract my attention.<anchor xml:id="c56-0013.01"></anchor><del next="#c56-0013.06" rend="strikethrough">I reme<mod><add place="sublinear"><metamark function="insert">^</metamark></add><add hand="#pbs" place="superlinear">m</add></mod>ber</del></line>
+    <line><del rend="strikethrough" xml:id="c56-0013.06">also</del><milestone unit="tei:p"></milestone><metamark function="paragraph"> [</metamark><mod>
+        <del rend="overwritten">w</del>
+        <add place="intralinear">W</add>
+      </mod>hen I was about <mod>
+        <del rend="strikethrough">twelve</del>
+        <add place="superlinear">fourteen</add>
+      </mod> years</line>
+    <line>old we were at our house near</line>
+    <line>Belrive when we witnessed <del rend="strikethrough">the</del> a</line>
+    <line>violent <mod>
+        <del rend="strikethrough">at</del>
+        <add hand="#pbs" place="superlinear">and</add>
+      </mod> terrible thunder storm</line>
+  </zone>
+  <zone corresp="#c56-0013.04" type="left_margin">
+    <line><del rend="strikethrough"><add>record </add></del></line></zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="5v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0014.xml" xml:id="ox-ms_abinger_c56-0014">
+    <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0014.jp2"></graphic>
+    <zone rend="bordered" type="pagination"><line>44</line></zone>
+    <zone type="main">
+        <line>it advanced from behind Jura <delSpan rend="strikethrough" spanTo="#c56-0014.01"></delSpan>and</line>
+        <line>the<anchor xml:id="c56-0014.01"></anchor> and the thunder <delSpan rend="strikethrough" spanTo="#c56-0014.02"></delSpan>was heard at</line>
+        <line>once from<anchor xml:id="c56-0014.02"></anchor>
+            <del rend="strikethrough">the <unclear>d</unclear></del>
+            <delSpan spanTo="#c56-0014.03"></delSpan><del rend="strikethrough">several quarte</del><del rend="unmarked">rs</del></line>
+        <line>of the heavens and<anchor xml:id="c56-0014.03"></anchor> burst <add place="superlinear">at
+                once</add> with <del rend="strikethrough">and</del></line>
+        <line>frightful loudness.<mod>
+            <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear">from various quarters of the heavens</add>
+            </mod> I <delSpan rend="strikethrough" spanTo="#c56-0014.04"></delSpan>witnessed th<mod>
+                <del rend="overwritten">is</del>
+                <add place="intralinear">e</add>
+            </mod></line>
+        <line>elemental<anchor xml:id="c56-0014.04"></anchor>
+            <del rend="strikethrough">storm with pleasure</del></line>
+        <line>and remain<add place="intralinear">ed</add> while <mod>
+                <del rend="strikethrough">it</del>
+                <add hand="#pbs" place="superlinear">the storm</add>
+            </mod> lasted <mod spanTo="#c56-0014.05"></mod><del next="#c56-0014.06" rend="strikethrough">at</del><add place="superlinear">watching its</add><anchor xml:id="c56-0014.07"></anchor></line>
+        <line><del rend="strikethrough" xml:id="c56-0014.06">the door</del>
+            <del rend="strikethrough">watchin</del><del rend="unmarked">g</del><anchor xml:id="c56-0014.05"></anchor>. <mod spanTo="#c56-0014.09"></mod><del next="#c56-0014.10" rend="strikethrough">When it was most</del><add hand="#pbs" next="#c56-0014.15" place="superlinear">As I stood at the door</add></line>
+        <line><del rend="strikethrough" xml:id="c56-0014.10">violent</del>,<add hand="#pbs" place="superlinear" xml:id="c56-0014.15">on a sudden</add><anchor xml:id="c56-0014.09"></anchor> I
+            beheld <mod>
+                <del rend="strikethrough">the</del>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add hand="#pbs" place="superlinear">a stream of</add>
+            </mod> fire issue</line>
+        <line>from an old <del rend="strikethrough">be</del> and beautiful</line>
+        <line>oak about <del rend="strikethrough">wh</del> twenty y<retrace cause="unclear" hand="#pbs">a</retrace>rds from</line>
+        <line>our house and <mod>
+                <del rend="strikethrough">when</del>
+                <add hand="#pbs" place="superlinear">so soon as</add>
+            </mod> the <del rend="strikethrough">dazz</del></line>
+        <line>dazzling light <del rend="strikethrough">had</del>
+            <del rend="strikethrough">dissa</del>
+            <del rend="strikethrough">dissappeared</del></line>
+        <line><del rend="strikethrough">the</del>
+            <del rend="strikethrough"><unclear>pa</unclear></del> vanished, the oak <del rend="strikethrough">hand</del></line>
+        <line>had dissappeared <mod>
+                <del rend="strikethrough">an</del>
+                <add hand="#pbs" place="superlinear">&amp;</add>
+            </mod> nothing<add place="superlinear">remained</add> but a</line>
+        <line><mod>
+                <del rend="strikethrough">rent</del>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear">blasted</add>
+            </mod> stump. <del rend="strikethrough">remained</del>. When we</line>
+        <line>visited it the next morning we found</line>
+        <line>the <del rend="strikethrough">trea</del> tree shattered in a</line>
+        <line>singular manner. It was not splin</line>
+        <line>tered by the shock, but entirely</line>
+        <line>reduced to thin ribands of wood. <del rend="strikethrough">The</del></line>
+        <line><del rend="strikethrough">C</del> I never saw any thing so utterly</line>
+        <line>destroyed. The catastrophe of the</line>
+        <line>tree excited my extreme astonish</line>
+        <line>ment <delSpan rend="vertical_line" spanTo="#c56-0014.11"></delSpan><del next="#c56-0014.12" rend="strikethrough">and</del><mod>
+                <del next="#c56-0014.13" rend="strikethrough" xml:id="c56-0014.12">caused</del>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear">induced</add>
+            </mod>
+            <del next="#c56-0014.14" rend="strikethrough" xml:id="c56-0014.13">me to aply
+                wi</del><del rend="unmarked">ith</del></line>
+        <line><del rend="strikethrough" xml:id="c56-0014.14">fresh di</del>ligence to the study
+            of</line>
+        <line><mod>
+                <del rend="strikethrough">chemistry</del>
+                <add hand="#pbs" place="superlinear">natural philosophy</add>
+            </mod> which promised an ex-</line>
+        <line><del rend="strikethrough">clamatio</del> planation of th<mod>
+                <del rend="overwritten">e</del>
+                <add place="intralinear">i</add>
+            </mod>se sort of<anchor xml:id="c56-0014.11"></anchor></line>
+    </zone>
+
+    <zone corresp="#c56-0014.07" type="left_margin">
+        <addSpan spanTo="#c56-0014.08"></addSpan>
+        <line> its progress</line>
+        <line>with curiosity</line>
+        <line> &amp; delight</line>
+        <anchor xml:id="c56-0014.08"></anchor>
+    </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="6r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0015.xml" xml:id="ox-ms_abinger_c56-0015">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0015.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>45</line></zone>
+  <zone type="library"><line>6</line></zone>
+  <zone type="main">
+    <delSpan rend="vertical_line" spanTo="#c56-0015.01"></delSpan>
+    <line>phænonema. On Elizabeth and</line>
+    <line>Clerval it produced a <del rend="strikethrough">di</del> very different</line>
+    <line>effect. They admired the beauty</line>
+    <line>of the storm without wishing to</line>
+    <line>analyze its causes. Henry said that</line>
+    <line>the Fairies and giants were at</line>
+    <line>war and Elizabeth attempted</line>
+    <line>a picture of it.</line><anchor xml:id="c56-0015.01"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <delSpan rend="vertical_line" spanTo="#c56-0015.02"></delSpan>
+    <line rend="indent1">As I grew older my attempts</line>
+    <line>in science were of a higher nature.</line>
+    <line>I <del rend="strikethrough">endeavou</del> produced little earthquakes</line>
+    <line>and tried every kind of combination</line>
+    <line>of gasses <del rend="strikethrough">to</del> and elements to ascertain</line>
+    <line>the results.</line><anchor xml:id="c56-0015.02"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><delSpan rend="strikethrough" spanTo="#c56-0015.03"></delSpan>As I
+      before mentioned my brothers</line>
+    <line>were much younger than myself.</line>
+    <line>Ernest the second of our family was five</line><anchor xml:id="c56-0015.03"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Another task <mod>
+        <del rend="strikethrough">soon</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">also</add>
+      </mod> devolved upon</line>
+    <line>me when I became the instructor</line>
+    <line>of my brothers. Ernest was five years</line>
+    <line>younger than myself, and was my</line>
+    <line>principal pupil. He had been aflicted</line>
+    <line>with ill health from his infancy <mod>
+        <del rend="strikethrough">&amp;</del>
+        <add hand="#pbs" place="superlinear">thro which</add>
+      </mod></line>
+    <line>Elizabeth and I had been his constant</line>
+    <line><del rend="strikethrough">m</del> nurses <del rend="strikethrough">I</del> his disposition
+      was gentle but</line>
+    <line>he was incapable any severe appli</line>
+    <line>cation. William the younge<mod>
+        <del rend="overwritten">er</del>
+        <add hand="#pbs" place="intralinear">st</add>
+      </mod> of our</line>
+    <line>family was quite a child and the</line>
+    <line>most beautiful little fellow in the</line>
+    <line>world, his lively blue eyes dimpled cheeks</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="6v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0016.xml" xml:id="ox-ms_abinger_c56-0016">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0016.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>46</line></zone>
+  <zone type="main">
+    <line>and <del rend="strikethrough">affectionate</del> endearing manners</line>
+    <line>inspired the tenderest affection. Such</line>
+    <line>was our domestic circle from which</line>
+    <line>care and pain seemed for ever banish</line>
+    <line>ed. <del rend="strikethrough">f</del> My father directed our studies</line>
+    <line>and my mother partook of our</line>
+    <line>enjoyments. <mod>
+        <del rend="strikethrough">we were all equal</del>
+        <anchor xml:id="c56-0016.01"></anchor>
+      </mod> the</line>
+    <line>voice of command was never heard</line>
+    <line>among us but mutual affection</line>
+    <line>engaged us all to comply with<add hand="#pbs" place="intralinear">,</add> &amp; <add hand="#pbs" place="intralinear">to</add></line>
+    <line>obey the slightest desire of each</line>
+    <line>other.</line>
+  </zone>
+  <zone corresp="#c56-0016.01" type="left_margin">
+    <addSpan spanTo="#c56-0016.02"></addSpan>
+    <line><mod>
+        <del rend="strikethrough">we none</del>
+        <add place="superlinear">neither</add>
+      </mod> of</line>
+    <line>us possessed</line>
+    <line>an envied</line>
+    <line>preheminence</line>
+    <line>over the other</line>
+    <anchor xml:id="c56-0016.02"></anchor></zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="7r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0017.xml" xml:id="ox-ms_abinger_c56-0017">
+    <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0017.jp2"></graphic>
+    <zone rend="#bordered" type="pagination"><line>47</line></zone>
+    
+    <zone type="library"><line>7</line></zone>
+    <zone type="main">
+        <line rend="center"><milestone spanTo="#c56-0017.04" unit="tei:head"></milestone>Chapter <mod><del rend="overwritten">2</del><add place="intralinear">3</add></mod><anchor xml:id="c56-0017.04"></anchor></line>
+        <milestone unit="tei:p"></milestone>
+        <line rend="indent1">When I had attained the age of</line>
+        <line>seventeen my <mod>
+                <del rend="strikethrough">father</del>
+                <add place="superlinear">parents</add>
+            </mod> resolved that</line>
+        <line>I should <mod>
+                <del rend="strikethrough">go</del>
+                <del rend="strikethrough"> to</del>
+                <anchor xml:id="c56-0017.01"></anchor>
+                <add hand="#pbs" place="superlinear">at</add>
+            </mod> the university of In-</line>
+        <line>golstadt. I had hitherto attended the</line>
+        <line>schools of Geneva, but my father thought</line>
+        <line>it necessary for the completion of my</line>
+        <line>education <del rend="strikethrough">that</del> that I should be</line>
+        <line><anchor xml:id="c56-0017.02"></anchor>acquainted with other customs <mod>
+                <del rend="strikethrough">besides</del>
+                <add hand="#pbs" place="superlinear">than</add>
+            </mod></line>
+        <line>those of my native country. My depar</line>
+        <line>ture was therefore fixed <del rend="strikethrough">for</del> at an</line>
+        <line>early <mod>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear">date.</add>
+            </mod> But before the day resolved</line>
+        <line>upon could arrive the first mis</line>
+        <line>fortune of my life occurred: <del rend="strikethrough">as if</del> an</line>
+        <line>omen <add hand="#pbs" place="superlinear">as it were</add> of my future misery
+                <delSpan rend="strikethrough" spanTo="#c56-0017.03"></delSpan>if</line>
+        <line>I should prosecute my journey.<anchor xml:id="c56-0017.03"></anchor></line>
+        <milestone unit="tei:p"></milestone>
+        <line rend="indent2">&gt;Elizabeth had caught the scar</line>
+        <line>let fever but <del rend="strikethrough"><unclear extent="1" unit="chars"></unclear></del> her
+            illness was</line>
+        <line>not severe and she quickly recovered.</line>
+        <line>During her confinement <mod>
+                <del rend="strikethrough">mady</del>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear"><del rend="strikethrough"><unclear>made</unclear></del>
+                    many</add>
+            </mod> ar</line>
+        <line>guments had been urged to persuade</line>
+        <line>my mother <mod>
+                <del rend="strikethrough">not</del>
+                <del rend="strikethrough">a</del>
+                <add hand="#pbs" place="superlinear">to refrain from</add>
+            </mod> to attend upon</line>
+        <line>her. She had yielded <mod>
+                <del rend="strikethrough">the</del>
+                <del rend="strikethrough">to these</del>
+                <add hand="#pbs" place="superlinear">to our entreaties,</add>
+            </mod> but</line>
+        <line>when she <del rend="strikethrough">ha</del> heard that her</line>
+        <line>favourite was recovering, she <mod>
+                <del rend="overwritten">w</del>
+                <add hand="#pbs" place="intralinear">c</add>
+            </mod>ould</line>
+        <line>no longer debar herself from her</line>
+        <line>society, and entered her sick cham</line>
+        <line>ber long before <mod>
+                <del rend="strikethrough">it was safe</del>
+                <add hand="#pbs" place="superlinear">the danger of infection was past</add>
+            </mod>. The</line>
+    </zone>
+    <zone corresp="#c56-0017.01" type="left_margin">
+        <line><add hand="#pbs">become a student </add></line>
+    </zone>
+    <zone corresp="#c56-0017.02" type="left_margin">
+        <line><add hand="#pbs">made </add></line>
+    </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="7v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0018.xml" xml:id="ox-ms_abinger_c56-0018">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0018.jp2"></graphic>
+
+  <zone rend="bordered" type="pagination"><line>48</line></zone>
+
+  <zone type="main">
+    <line>consequences of this imprudence were</line>
+    <line>fatal: on the third day my mother</line>
+    <line>sickened. Her fever was <del rend="strikethrough">very</del> malig-</line>
+    <line>nant, <del rend="strikethrough">tr</del> and the looks of her atten</line>
+    <line>dants prognosticated the <del rend="strikethrough">wort</del> worst</line>
+    <line>evil. On her death bed the forti</line>
+    <line>tude and benignity <del rend="strikethrough">di</del> of <mod>
+        <del rend="strikethrough">my mother</del>
+        <add hand="#pbs" place="superlinear">this admirable woman</add>
+      </mod></line>
+    <line>did not desert her. She joined the</line>
+    <line>hands of Elizabeth and myself. "My</line>
+    <line>"children said she it was on your</line>
+    <line>"union that my firmest hopes of</line>
+    <line>"future happiness were placed. It</line>
+    <line>"will now be the consolation of</line>
+    <line>"your <del rend="strikethrough">fathor</del> father.<del rend="strikethrough"><add hand="#pbs" place="superlinear">alone</add></del> Elizabeth, my</line>
+    <line>"love, supply my place to <del rend="strikethrough">the other</del></line>
+    <line>"your young <del rend="strikethrough">cons</del> cousins. Alas! I</line>
+    <line>"<del rend="strikethrough">almost</del> regret <mod>
+        <del rend="strikethrough">being</del>
+        <add hand="#pbs" place="superlinear">than I am</add>
+      </mod> taken from you,</line>
+    <line>"<del rend="strikethrough">h</del> and happy and beloved, as I am</line>
+    <line>"is it not hard to quit you all? But</line>
+    <line>"these are not thoughts befitting me</line>
+    <line>"I <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">will endeavour to</add>
+      </mod> resign myself <del rend="strikethrough">to</del> cheerfully to</line>
+    <line>"death and will indulge a hope <del next="#c56-0018.01" rend="strikethrough">my</del></line>
+    <line>"<del rend="strikethrough" xml:id="c56-0018.01">beloved</del>
+      <del rend="strikethrough">creatures</del> of meeting you</line>
+    <line>"in another world."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">She died calmly and her features</line>
+    <line>expressed <del rend="strikethrough"><unclear>lov</unclear></del> affection even in
+      death.</line>
+    <line>I need not describe the feelings of those</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="8r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0019.xml" xml:id="ox-ms_abinger_c56-0019">
+    <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0019.jp2"></graphic>
+
+    <zone rend="#bordered" type="pagination"><line>49</line></zone>
+    <zone type="library"><line>8</line></zone>
+
+    <zone type="main">
+        <line>whose dearest ties are rent by that</line>
+        <line>most irreperable evil; the <del rend="strikethrough">bla</del> void</line>
+        <line>that every where presents itself to</line>
+        <line><mod>
+                <del rend="strikethrough">their</del>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <del rend="strikethrough">minds</del>
+                <add place="superlinear">the soul</add>
+            </mod> and the despair that</line>
+        <line>is exhibited on the countenance.</line>
+        <line>It is so long before the mind can</line>
+        <line>persuade itself that she, whom</line>
+        <line>they saw every day, and whose very</line>
+        <line>existence appeared a part of theirs,</line>
+        <line>can have departed for ever: <mod>
+                <del rend="overwritten">T</del>
+                <add>t</add>
+            </mod>hat</line>
+        <line>the brightness of a loved eye can have</line>
+        <line><mod>
+                <del rend="strikethrough">faded</del>
+                <add hand="#pbs" place="superlinear">been extinguished,</add>
+            </mod> and the sound of a voice <del rend="strikethrough">never</del></line>
+        <line>so familiar and dear to the ear</line>
+        <line>can be hushed, never more to be</line>
+        <line>heard. These are the reflections of the</line>
+        <line>first days. But when the lapse of</line>
+        <line>time proves the reality of the evil</line>
+        <line>then the <mod>
+                <del rend="strikethrough">true</del>
+                <del rend="strikethrough">despair</del>
+                <add place="superlinear">bitterness of grief</add>
+            </mod> commences<add hand="#pbs" place="intralinear"><unclear>,</unclear></add></line>
+        <line><del rend="strikethrough">Then the survivors dare not turn</del></line>
+        <line><mod>
+                <del rend="strikethrough">But</del>
+                <add hand="#pbs" place="superlinear">Yet, from whom</add>
+            </mod> who has not <delSpan rend="strikethrough" spanTo="#c56-0019.01"></delSpan>had some
+            dear</line>
+        <line>connection rent away by<anchor xml:id="c56-0019.01"></anchor> that rude hand <anchor xml:id="c56-0019.02"></anchor></line>
+        <line><unclear extent="2" unit="chars"></unclear> and why <mod>
+                <del rend="strikethrough">need</del>
+                <add hand="#pbs" place="superlinear">should</add>
+            </mod> I describe a sorrow</line>
+        <line>which all have felt, and must</line>
+        <line>feel? <del rend="strikethrough">But</del>
+            <mod>
+                <del rend="overwritten">t</del>
+                <add hand="#pbs" place="intralinear">T</add>
+            </mod>he time at length arrives</line>
+        <line>when grief is rather an indulgence</line>
+        <line><del rend="strikethrough">a</del> than a necessity and the smile</line>
+        <line>that plays on the lips, although</line>
+        <line>it is deemed sacriledge, is not Ba</line>
+        <line>nished.– My mother <mod spanTo="#c56-0019.04"></mod><del next="#c56-0019.05" rend="strikethrough">was gone</del><add place="superlinear"><unclear>lost</unclear></add>
+            <del next="#c56-0019.06" rend="strikethrough" xml:id="c56-0019.05">had be</del><del rend="unmarked">en</del></line>
+        <line><del next="#c56-0019.07" rend="strikethrough" xml:id="c56-0019.06">taken</del><add place="sublinear"><metamark function="insert">^</metamark></add>
+            <del rend="strikethrough" xml:id="c56-0019.07">away</del><add place="superlinear">was
+                dead</add><anchor xml:id="c56-0019.04"></anchor> but we had still</line>
+    </zone>
+
+    <zone corresp="#c56-0019.02" type="left_margin">
+        <addSpan hand="#pbs" spanTo="#c56-0019.03"></addSpan>
+        <line>rent away some</line>
+        <line>dear connection,</line><anchor xml:id="c56-0019.03"></anchor>
+    </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="8v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0020.xml" xml:id="ox-ms_abinger_c56-0020">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0020.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>50</line></zone>
+  <zone type="main">
+    <line>duties which we ought to perform</line>
+    <line>we must continue our course with</line>
+    <line>the rest <mod spanTo="#c56-0020.01"></mod><del rend="strikethrough">&amp; bless God if
+        nothing</del>
+      <mod>
+        <del rend="strikethrough">else</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">worse</add></del>
+      </mod><delSpan rend="strikethrough" spanTo="#c56-0020.02"></delSpan>hap</line>
+    <line>pens<anchor xml:id="c56-0020.02"></anchor><del rend="unmarked">.</del>
+      <del rend="strikethrough"><add next="#c56-0020.03" place="superlinear">and the idleness
+          generated by grief would</add></del><del rend="strikethrough"><add place="intralinear" xml:id="c56-0020.03">become a bad habit if further indulged</add></del><add><anchor xml:id="c56-0020.04"></anchor></add><anchor xml:id="c56-0020.01"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">My journey to Ingolstadt which had</line>
+    <line>been deferred by these events was now</line>
+    <line>again determined upon, <del rend="strikethrough">and all that</del></line>
+    <line>I <del rend="strikethrough">could</del> obtain<add hand="#pbs" place="intralinear">ed</add> from my father <mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">a</add>
+      </mod></line>
+    <line>respite of some weeks. This time</line>
+    <line>was spent sadly. My mothers death</line>
+    <line>and my speedy departure depressed</line>
+    <line>our spirits but Elizabeth endeavour</line>
+    <line>ed to <mod>
+        <del rend="strikethrough">spr</del>
+        <del rend="strikethrough">renew</del>
+        <del rend="strikethrough">the spirit</del>
+        <del rend="strikethrough"><add place="superlinear">cast a<space extent="5" unit="chars"></space>a
+            gleam</add></del>
+        <add hand="#pbs" place="sublinear">renew the spirit</add>
+      </mod> of cheer</line>
+    <line>fullness in our little society. Since</line>
+    <line>the death of her aunt her mind</line>
+    <line><anchor xml:id="c56-0020.07"></anchor>acquired new <del rend="strikethrough">firmess</del> firmness and</line>
+    <line>vigour. She determined to fulfil her</line>
+    <line>duties with the greatest exactitude</line>
+    <line>and <mod>
+        <del rend="strikethrough">her</del>
+        <add hand="#pbs" place="superlinear">she felt that the</add>
+      </mod> most imperious duty <mod spanTo="#c56-0020.08"></mod><del next="#c56-0020.09" rend="strikethrough">was</del><add hand="#pbs" place="superlinear">of</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0020.09">to</del> render<add hand="#pbs" place="intralinear">ing</add><anchor xml:id="c56-0020.08"></anchor> her uncle and cousins hap</line>
+    <line>py.<anchor xml:id="c56-0020.10"></anchor> She consoled me, amused her uncle,</line>
+    <line><del rend="strikethrough">and</del> instructed my brothers and I never</line>
+    <line>beheld her so enchanting as at this</line>
+    <line>time when she <mod spanTo="#c56-0020.12"></mod><delSpan rend="strikethrough" spanTo="#c56-0020.13"></delSpan>sar sacrifised every</line>
+    <line>minut<anchor xml:id="c56-0020.13"></anchor><del rend="unmarked">e</del>
+      <del rend="strikethrough">of her time</del>
+      <del rend="strikethrough">to others</del><mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">was</add>
+      </mod><anchor xml:id="c56-0020.12"></anchor> continual</line>
+    <line>ly endeavouring to contribute to the</line>
+    <line>happiness of others entirely forgetful</line>
+  </zone>
+  <zone corresp="#c56-0020.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0020.05"></addSpan>
+    <line>and learn</line>
+    <line>to think our</line>
+    <line>-selves fortu</line>
+    <line>nate, <delSpan rend="strikethrough" spanTo="#c56-0020.06"></delSpan>if no</line>
+    <line>more<anchor xml:id="c56-0020.06"></anchor> whilst</line>
+    <line>one remains</line>
+    <line>whom the</line>
+    <line>spoiler has</line>
+    <line>not seized.</line><anchor xml:id="c56-0020.05"></anchor>
+  </zone>
+  <zone corresp="#c56-0020.07" type="left_margin">
+    <add>had </add>
+  </zone>
+  <zone corresp="#c56-0020.10" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0020.11"></addSpan>
+    <line> had devolved</line>
+    <line>on her.</line>
+    <anchor xml:id="c56-0020.11"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="9r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0021.xml" xml:id="ox-ms_abinger_c56-0021">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0021.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>51</line></zone>
+  <zone type="library"><line>9</line></zone>
+  <zone type="main">
+    <line>of <del rend="strikethrough">hels</del> herself.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The day of my departure at lenghth</line>
+    <line>arrived – I had taken leave of all</line>
+    <line>my friends excepting Clerval, who spent</line>
+    <line>the last evening with us. He bitterly la</line>
+    <line>mented that he was <mod>
+        <del rend="strikethrough">not able</del>
+        <add hand="#pbs" place="superlinear">unable</add>
+      </mod> to</line>
+    <line>accompany me But his father</line>
+    <line>could not <mod>
+        <del rend="strikethrough">bear</del>
+        <add hand="#pbs" place="superlinear">be persuaded</add>
+      </mod> to part with him</line>
+    <line><del rend="strikethrough">besides</del>
+      <del rend="strikethrough">as</del>
+      <del rend="strikethrough">he</del> intend<mod>
+        <del rend="overwritten">ed</del>
+        <add hand="#pbs" place="intralinear">ing</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">him to</del>
+        <add hand="#pbs" place="superlinear">that he should</add>
+      </mod> be-</line>
+    <line>come a partner with him in</line>
+    <line>his business, and <mod spanTo="#c56-0021.09"></mod><del next="#c56-0021.03" rend="strikethrough">he said he did not</del><anchor xml:id="c56-0021.01"></anchor></line>
+    <line><del next="#c56-0021.04" rend="strikethrough" xml:id="c56-0021.03">see</del>
+      <mod>
+        <del rend="unmarked"><add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">of</add></del>
+      </mod>
+      <del next="#c56-0021.05" rend="strikethrough" xml:id="c56-002201.04">what use learning</del>
+      <mod>
+        <del next="#c56-0021.06" rend="strikethrough" xml:id="c56-0021.05">was</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">could be</add></del>
+      </mod>
+      <del next="#c56-0021.07" rend="strikethrough" xml:id="c56-0021.06">to a</del></line>
+    <line><del rend="strikethrough" xml:id="c56-0021.07">merchant.</del><anchor xml:id="c56-0021.09"></anchor> Henry had a refined mind</line>
+    <line><del rend="strikethrough">and a</del> he <mod>
+        <del rend="strikethrough">did not wish</del>
+        <add hand="#pbs" place="superlinear">had no desire</add>
+      </mod> to be idle</line>
+    <line>and was well pleased to become <delSpan rend="strikethrough" spanTo="#c56-0021.08"></delSpan>the</line>
+    <line>partner<anchor xml:id="c56-0021.08"></anchor>
+      <del rend="strikethrough">of</del> his father's <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">partner</add>
+      </mod>but he believed</line>
+    <line>that a man might be a very good</line>
+    <line>trader and yet <mod>
+        <del rend="strikethrough">have</del>
+        <add hand="#pbs" place="superlinear">posess</add>
+      </mod> a cultivated</line>
+    <line><mod>
+        <del rend="strikethrough">mind.</del>
+        <add place="intralinear">understanding.</add>
+      </mod></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We sate late listening to his com</line>
+    <line>plaints, and <del rend="strikethrough">I</del> making many little</line>
+    <line>arrangements for the future. <del rend="strikethrough">and</del>
+      <mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">T</add>
+      </mod>he</line>
+    <line>next morning early I departed. Tears</line>
+    <line>gushed from the eyes of Elizabeth</line>
+    <line>they proceeded partly from sorrow</line>
+    <line>at my departure, and partly because</line>
+    <line>she reflected that the same journey</line>
+    <line>was to have taken place three</line>
+    <line>months before when a mothers</line>
+    <line>blessing would have accompanied me</line>
+  </zone>
+
+  <zone corresp="#c56-0021.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0021.02"></addSpan>
+    <line><del rend="strikethrough">and</del> in</line>
+    <line>compliance</line>
+    <line>with his favou</line>
+    <line>rite theory,</line>
+    <line>that <del rend="strikethrough">the</del> learning</line>
+    <line>was superflous</line>
+    <line>in the com-</line>
+    <line>-merce of ordi</line>
+    <line>nary life.</line>
+    <anchor xml:id="c56-0021.02"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="9v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0022.xml" xml:id="ox-ms_abinger_c56-0022">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0022.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>53</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">I threw myself into the chaise</line>
+    <line>that was to convey me away and in</line>
+    <line>dulged in the most melancholy reflec</line>
+    <line>tions. I who had ever been surrounded</line>
+    <line>by amiable companions, continually</line>
+    <line>engaged in <del rend="strikethrough">ed</del> endeavouring to give</line>
+    <line>mutual pleasure; I was now alone.</line>
+    <line>In the university <del rend="strikethrough">wi</del> whither I was</line>
+    <line>going I must form my own friends</line>
+    <line>and be my own <mod>
+        <del rend="strikethrough">introduction</del>
+        <del rend="unmarked">.</del>
+        <add hand="#pbs" place="superlinear">protector.</add>
+      </mod> My</line>
+    <line>life had hitherto been remarkably retired</line>
+    <line>and domestic and this had given me</line>
+    <line>an invincible repugnance to new <del rend="strikethrough">faces</del></line>
+    <line>countenances. I loved my brothers Eliza-</line>
+    <line>beth and Clerval these were "old</line>
+    <line>familiar faces" but I believed my</line>
+    <line>self totally unfitted for the compa-</line>
+    <line>ny of strangers. Such were my reflec-</line>
+    <line>tions as I commenced my journey But</line>
+    <line>as I proceeded my spirits and hopes</line>
+    <line>rose. I ardently desired knowledge</line>
+    <line><mod>
+        <del rend="strikethrough">and I</del>
+        <anchor xml:id="c56-0022.01"></anchor>
+      </mod> often when at home</line>
+    <line>thought <mod>
+        <del rend="strikethrough">how</del>
+        <add hand="#pbs" place="superlinear">it</add>
+      </mod> hard <del rend="strikethrough">it was</del> to remain</line>
+    <line><anchor xml:id="c56-0022.02"></anchor> cooped up in one place <delSpan rend="strikethrough" spanTo="#c56-0022.03"></delSpan>all my</line>
+    <line>life<anchor xml:id="c56-0022.03"></anchor> and <add hand="#pbs" place="superlinear">had</add>
+      longed to enter into the</line>
+    <line><del rend="strikethrough">worth</del> world and take my <mod spanTo="#c56-0022.04"></mod><del next="#c56-0022.05" rend="strikethrough">place</del></line>
+    <line><del rend="strikethrough" xml:id="c56-0022.05">with</del><anchor xml:id="c56-0022.07"></anchor><add place="superlinear" xml:id="c56-0022.06">among</add><anchor xml:id="c56-0022.04"></anchor> other human beings. <del rend="strikethrough">And</del></line>
+    <line>now my desires were <del rend="strikethrough">cop</del> complyed</line>
+    <line>with <add place="intralinear">&amp;</add> it would <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">indeed</add>
+        <add hand="#pbs" place="superlinear">have</add>
+        <del rend="strikethrough">be</del>
+        <del rend="strikethrough">indeed</del>
+      </mod> be<add hand="#pbs" place="intralinear">en</add> folly to</line>
+    <line>repent.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I had <mod>
+        <del rend="strikethrough">plenty of</del>
+        <add hand="#pbs" place="superlinear">sufficient</add>
+      </mod> leisure for these</line>
+  </zone>
+  <zone corresp="#c56-0022.01" type="left_margin">
+    <line><add hand="#pbs">I had</add></line>
+  </zone>
+  <zone corresp="#c56-0022.02" type="left_margin">
+    <line><add>during my youth</add></line>
+  </zone>
+  <zone corresp="#c56-0022.07" type="left_margin">
+    <line><add next="#c56-0022.06">station </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="10r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0023.xml" xml:id="ox-ms_abinger_c56-0023">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0023.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>54</line></zone>
+  <zone type="library"><line>10</line></zone>
+  <zone type="main">
+    <line>and many other reflections during</line>
+    <line>my journey to Ingolstadt which was</line>
+    <line>long and fatiguing – at length the</line>
+    <line>steeples of the town met my eyes. I</line>
+    <line>alighted and was conducted to my</line>
+    <line>solitary apartment to spend the</line>
+    <line>evening as I pleased.</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="10v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0024.xml" xml:id="ox-ms_abinger_c56-0024">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0024.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>55</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0024.04" unit="tei:head"></milestone>Chap. 4<anchor xml:id="c56-0024.04"></anchor></line>
+    <line>The next morning I delivered my</line>
+    <line>letters of introduction and paid a</line>
+    <line>visit to some of the principal</line>
+    <line>professors. and among others to M. <mod>
+        <del rend="strikethrough">K</del>
+        <del rend="unmarked">—</del>
+        <anchor xml:id="c56-0024.01"></anchor>
+      </mod></line>
+    <line>Professor of <del rend="strikethrough">&amp; Lecturer</del>
+      <del rend="strikethrough">upon</del> Natural</line>
+    <line>philosophy. He received me with</line>
+    <line>politeness, and asked me several</line>
+    <line>questions concerning my progress</line>
+    <line>in the <del rend="strikethrough">sciences</del> different branches</line>
+    <line>of science appertaining to natural</line>
+    <line>philosophy. I mentioned, it is true</line>
+    <line>with fear and trembling, the only</line>
+    <line>authors I had <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">ever</add>
+      </mod> read upon those</line>
+    <line>subjects. The professor stared. <delSpan rend="strikethrough" spanTo="#c56-0024.02"></delSpan>I
+      said</line>
+    <line>that I did not mention these<anchor xml:id="c56-0024.02"></anchor></line>
+    <line>"Have you really" said<del rend="smear">"</del> he "spent</line>
+    <line>"your time in studying such</line>
+    <line>"nonsence?" I replied in the affir</line>
+    <line>mative.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Every minute"– continued M. <mod>
+        <del rend="strikethrough">K</del>
+        <del rend="unmarked">—</del>
+        <anchor xml:id="c56-0024.03"></anchor>
+      </mod></line>
+    <line>with warmth," every instant that</line>
+    <line>"you have wasted upon those</line>
+    <line>"books is utterly and entirely lost.</line>
+    <line>"You have burdened your <del rend="strikethrough">bur</del></line>
+    <line>"<del rend="strikethrough">memor</del> memory with exploded</line>
+    <line>"systems and useless names. Good</line>
+    <line>"God <mod>
+        <del rend="strikethrough">where must you</del>
+        <add place="superlinear">in what desart land</add>
+      </mod> have you</line>
+    <line>"lived where no one was kind</line>
+    <line>"enough to <del rend="strikethrough">enfor</del> inform you</line>
+    <line>"that these fancies which <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">you</add>
+      </mod> have</line>
+  </zone>
+  <zone corresp="#c56-0024.01" type="left_margin">
+    <line><add><mod>
+          <del rend="strikethrough">Krempe</del>
+          <add place="sublinear">Krempe</add>
+        </mod></add></line>
+  </zone>
+  <zone corresp="#c56-0024.03" type="left_margin">
+    <line><add>Krempe</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="11r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0025.xml" xml:id="ox-ms_abinger_c56-0025">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0025.jp2"></graphic>
+  <zone rend="#bordered" type="pagination"><line>56</line></zone>
+  <zone type="library"><line>11</line></zone>
+  <zone type="main">
+    <line>"so greedily imbibed are <del rend="strikethrough">at le</del> a </line>
+    <line>"thousand years old and as musty as</line>
+    <line>"<del rend="strikethrough">your</del> they are ancient. I little expected</line>
+    <line>"in this enlightened and scientific age</line>
+    <line>"to find a disciple of Albertus Mag</line>
+    <line>"nus and Paracelsus. My dear sir</line>
+    <line>"you must begin your studies entire</line>
+    <line>"ly anew." So saying he ste<mod>
+        <del rend="overwritten">ss</del>
+        <add hand="#pbs" place="intralinear">pp</add>
+      </mod>ed aside, and</line>
+    
+    <line><del rend="strikethrough">wh</del> wrote down a list of several</line>
+    <line>books <del rend="strikethrough"><unclear>u</unclear></del> upon natural philosophy</line>
+    <line>which he desired me to procure</line>
+    <line>and dismissed me after mentioning</line>
+    <line>that <del rend="strikethrough">he intended</del>
+      <del rend="strikethrough">to commen</del> in</line>
+    <line>the beginning of the next week</line>
+    <line>he intended to commence a course</line>
+    <line>of lectures upon natural philosophy <mod>
+        <add place="sublinear"><metamark function="displacement" xml:id="c56-0025.01">X</metamark></add>
+      </mod></line>
+    <line>and that M. W.<mod>
+        <del rend="unmarked">—</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">aldham</add>
+      </mod> a fellow professor</line>
+    <line>would lecture upon chemistry</line>
+    <line>the alternate days which he missed.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">I returned home not dissapointed</line>
+    <line>for I had long considered the au-</line>
+    <line>thors useless which the professor</line>
+    <line>had so strongly reprobated – but I</line>
+    <line>did not feel very much enclined</line>
+    <line>to <del rend="strikethrough">bu</del> study those books which at</line>
+    <line>his <del rend="strikethrough">recon</del> recommondation I had</line>
+    <line>procured. M. K<mod>
+        <del rend="unmarked">—</del>
+        <add place="superlinear">rempe</add>
+      </mod> was a little squat</line>
+    <line>man with a gruff voice and repul</line>
+    <line>sive countenance and the teacher</line>
+    <line>did not prepossess me in favour</line>
+  </zone>
+  <zone corresp="#c56-0025.01" type="left_margin">
+    <line><add hand="#pbs"><metamark function="displacement">X</metamark> in its general
+        relations;</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="11v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0026.xml" xml:id="ox-ms_abinger_c56-0026">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0026.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>57</line></zone>
+
+  <zone type="main">
+    <line>of his <mod>
+        <del rend="strikethrough">science</del><del rend="unmarked">.</del>
+        <add hand="#pbs" place="superlinear">doctrine.</add>
+      </mod>
+      <del rend="strikethrough">But when the ne</del> Be-</line>
+    <line>sides I had a contempt for the uses</line>
+    <line>of modern <mod>
+        <del rend="strikethrough">chemistry</del>
+        <add place="superlinear">natural philosophy</add>
+      </mod>. It was very</line>
+    <line><del rend="strikethrough">when</del> different when the<del rend="strikethrough">n</del>
+      masters</line>
+    <line>of the science sought immortality</line>
+    <line>and <mod>
+        <del rend="strikethrough">wealth</del>
+        <add hand="#pbs" place="superlinear">power</add>
+      </mod>;– such views although</line>
+    <line>futile were grand; but now <mod>
+        <del rend="strikethrough">it</del>
+        <add hand="#pbs" place="superlinear">the scene</add>
+      </mod> was</line>
+    <line><del rend="strikethrough">all</del> changed.<mod spanTo="#c56-0026.06"></mod><delSpan rend="vertical_line" spanTo="#c56-0026.07"></delSpan>
+      <del rend="strikethrough">t and the expulsion</del></line>
+    <line>of chimera overthrew at the same</line>
+    <line>time all <mod>
+        <del rend="strikethrough">greatness in the science</del>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">those</add></del>
+      </mod>
+      <anchor xml:id="c56-0026.07"></anchor><anchor xml:id="c56-0026.01"></anchor>
+        <anchor xml:id="c56-0026.04"></anchor>
+      <anchor xml:id="c56-0026.06"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">Such were my reflections during</line>
+    <line><del rend="strikethrough">tw</del> two or three days <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">spent</add>
+      </mod> almost <mod>
+        <add place="intralinear">in</add>
+        <del rend="strikethrough">solitary</del>
+        <anchor xml:id="c56-0026.03"></anchor>
+      </mod></line>
+    <line> but <del rend="strikethrough">at</del> as the ensueing week</line>
+    <line>commenced I thought of the infor</line>
+    <line>mation M<hi rend="sup">r</hi>. K.<mod>
+        <del rend="unmarked">—</del>
+        <add place="superlinear">rempe</add>
+      </mod> had given me</line>
+    <line>concerning the lectures, and although</line>
+    <line>I could not consent to go and hear</line>
+    <line>that little conceited fellow deliver</line>
+    <line>sentences <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">out of a pulpit</add>
+      </mod> I recollected what he had</line>
+    <line>said of M<hi rend="sup">r</hi>. Waldham, whom I had</line>
+    <line>never seen <del rend="strikethrough">and</del> as he had been</line>
+    <line>hitherto out of town.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2"><mod>
+        <del rend="strikethrough">Half out of</del>
+        <add place="superlinear">Partly from</add>
+      </mod> curiosity and partly from</line>
+    <line>idleness I went into the lecturing room</line>
+    <line>which M<hi rend="sup">r</hi>. Waldham entered shortly</line>
+    <line>after. This Professor was a very dif</line>
+    <line>ferent man from <mod>
+        <del rend="strikethrough">the other</del>
+        <add place="superlinear">his colleague</add>
+      </mod>. He</line>
+    <line>was about fifty but with aspect ex-</line>
+    <line>pressive of the greatest benevolence</line>
+    <line>a few grey <del rend="strikethrough">hars</del> hairs covered his temples</line>
+  </zone>
+
+  <zone corresp="#c56-0026.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0026.02"></addSpan>
+    <line>the <del rend="strikethrough">utmost</del></line>
+    <line>ambition of</line>
+    <line>enquirer seemed</line>
+    <line>to limit itself</line>
+    <line>to the annihi</line>
+    <line>lation of those</line>
+    <line>visions on which </line>
+    <anchor xml:id="c56-0026.02"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0026.03" type="left_margin">
+    <line><add>solitude:</add></line>
+  </zone>
+
+  <zone corresp="#c56-0026.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0026.05"></addSpan>
+    <line>my interest in science</line>
+    <line>was chiefly founded.</line>
+    <line>I was required</line>
+    <line>to exchange</line>
+    <line>chimeras of</line>
+    <line>boundless grandeur,</line>
+    <line>for realities of</line>
+    <line>little worth.</line>
+    <anchor xml:id="c56-0026.05"></anchor>
+  </zone>
+
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="12r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0027.xml" xml:id="ox-ms_abinger_c56-0027">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0027.jp2"></graphic>
+
+  <zone rend="#bordered" type="pagination"><line>58</line></zone>
+  <zone type="library"><line>12</line></zone>
+
+  <zone type="main">
+    <line>but those at the back of his head</line>
+    <line>were nearly black. He was short in</line>
+    <line>person but remarkably erect <del rend="strikethrough">ha</del> and</line>
+    <line>his voice the sweetest I had ever</line>
+    <line>heard. He began his lecture with a</line>
+    <line><mod>
+        <del rend="strikethrough">kind</del>
+        <del rend="strikethrough">of</del>
+        <anchor xml:id="c56-0027.01"></anchor>
+      </mod> history of chemistry and <delSpan rend="strikethrough" spanTo="#c56-0027.03"></delSpan>remark-</line>
+    <line>ed<anchor xml:id="c56-0027.03"></anchor> the various improvements <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">&amp; discoveries</add></del>
+      </mod>
+      <delSpan rend="strikethrough" spanTo="#c56-0027.04"></delSpan>diffe</line>
+    <line>rent<anchor xml:id="c56-0027.04"></anchor><anchor xml:id="c56-0027.05"></anchor> men <mod>
+        <del rend="strikethrough">had made</del>
+        <add place="superlinear">of learning</add>
+      </mod> pronoucing</line>
+    <line>the names of the greatest discoverers</line>
+    <line><mod>
+        <del rend="strikethrough">with great warmth</del>
+        <anchor xml:id="c56-0027.06"></anchor>
+      </mod>. He then took</line>
+    <line>a cursory view of the present state</line>
+    <line>of <mod>
+        <del rend="strikethrough">chemistry</del>
+        <add hand="#pbs" place="superlinear">the science,</add>
+      </mod> and explained many</line>
+    <line>of its <del rend="strikethrough">termes</del> terms. <mod>
+        <del rend="strikethrough">made</del>
+        <add hand="#pbs" place="superlinear">After making</add>
+      </mod> a few</line>
+    <line>preparatory experiments <mod>
+        <del rend="strikethrough">and</del>
+        <add hand="#pbs" place="superlinear">he</add>
+      </mod> conclu</line>
+    <line>ded with a panegyric upon <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">modern</add>
+      </mod> chemist</line>
+    <line>ry the words of which I shall never</line>
+    <line>forget.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"The ancient teachers of this science"</line>
+    <line>said he, "promised impossibilities</line>
+    <line>"and performed nothing. The modern</line>
+    <line>"masters promise very little. They</line>
+    <line>"<del rend="strikethrough">no</del> know that metals cannot be</line>
+    <line>"transmuted and that the elixir</line>
+    <line>"<mod>
+        <del rend="strikethrough">vitæ</del>
+        <anchor xml:id="c56-0027.07"></anchor>
+      </mod> is a <del rend="strikethrough">mere</del> chimæra. But</line>
+    <line>"these philosophers whose <del rend="strikethrough">eyes</del> hands</line>
+    <line>"appear only made to dabble in</line>
+    <line>"dirt and their eyes to pore over</line>
+    <line>"the microscope or cruscible,</line>
+    <line>"have indeed performed miracles.</line>
+    <line>"They penetrate into the recesses of</line>
+    <line>"nature and show how she works</line>
+  </zone>
+  <zone corresp="#c56-0027.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0027.02"></addSpan><line>by a recapitu</line>
+    <line>lation of the</line><anchor xml:id="c56-0027.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0027.05" type="left_margin">
+    <add>made by various</add>
+  </zone>
+  <zone corresp="#c56-0027.06" type="left_margin">
+    <add>with fervour</add>
+  </zone>
+  <zone corresp="#c56-0027.07" type="left_margin">
+    <add>of life</add>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="12v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0028.xml" xml:id="ox-ms_abinger_c56-0028">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0028.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>58</line></zone>
+  <zone type="main">
+    <line>"in her hiding places. They ascend into</line>
+    <line>"the heavens<add hand="#pbs" place="intralinear">;</add>– they have discoverd
+      how</line>
+    <line>"the blood circulates, and the nature</line>
+    <line>"of the air we breathe. <del rend="strikethrough">New</del> They have</line>
+    <line>"acquired new and almost unlimi</line>
+    <line>ted powers<mod>
+        <del rend="overwritten">,</del>
+        <add hand="#pbs" place="intralinear">;</add>
+      </mod>– The<add place="intralinear">y</add> can command the</line>
+    <line>"thunders of heaven, mimick the</line>
+    <line>"earthquake, and even mock the</line>
+    <line>"invisible world with its own</line>
+    <line>"shadows."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I departed highly pleased with</line>
+    <line>the professor and his lecture &amp;</line>
+    <line>paid him a visit the same evening.</line>
+    <line>His manners in private were even</line>
+    <line>more mild <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">&amp; attractive</add>
+      </mod> than in public. For</line>
+    <line>there was a certain dignity in his</line>
+    <line>manner during his lectures which</line>
+    <line>was replaced by the greatest <del rend="strikethrough">affabity</del></line>
+    <line>affability and kindness in his own</line>
+    <line>house. He heard <mod>
+        <del rend="strikethrough">by</del>
+        <add place="superlinear">my</add>
+      </mod> little narration</line>
+    <line>concerning my studies with attention</line>
+    <line>smiled at the names of Cornelius</line>
+    <line>Agrippa and Paracelsus<add place="superlinear"><metamark>X</metamark></add> but
+      without</line>
+    <line>the contempt that Mr Krempe had</line>
+    <line><del rend="strikethrough">Ex</del>
+      <mod>
+        <del rend="strikethrough">exhibited</del>
+        <add hand="#pbs" place="superlinear">expressed to them</add>
+      </mod>. <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <anchor xml:id="c56-0028.01"></anchor>
+      </mod>
+      <del rend="strikethrough">I ended by saying</del> that</line>
+    <line>his lecture had removed my prejudice</line>
+    <line>against modern chemists and I request-</line>
+    <line>ed at the same time his advice</line>
+    <line>concerning the books I ought to procure</line>
+  </zone>
+
+  <zone corresp="#c56-0028.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0028.02"></addSpan>
+    <line><retrace cause="fix" hand="#mws" spanTo="#c56-0028.04"></retrace><metamark function="displacement">^</metamark></line>
+    <line>He said that</line>
+    <line>these were</line>
+    <line>men to whose</line>
+    <line>indefatigable zeal</line>
+    <line>modern<anchor xml:id="c56-0028.04"></anchor>
+      <mod>
+        <del rend="strikethrough">chem</del>
+        <add place="superlinear">natural</add>
+      </mod></line>
+    <line><retrace cause="fix" hand="#mws" spanTo="#c56-0028.05"></retrace>philosophers were</line>
+    <line>indebted for most</line>
+    <line>of the foundations</line>
+    <line>of their knowledge<anchor xml:id="c56-0028.05"></anchor></line>
+    <line><delSpan rend="strikethrough" spanTo="#c56-0028.03"></delSpan>it is not a meaner</line>
+    <line>task<anchor xml:id="c56-0028.03"></anchor>
+      <retrace cause="fix" hand="#mws">They</retrace>
+      <mod>
+        <add hand="#mws" place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#mws" place="superlinear">had</add>
+      </mod>
+      <retrace cause="fix" hand="#mws" spanTo="#c56-0028.06"></retrace>left to</line>
+    <line>us, as an easier</line>
+    <line>task to give new</line>
+    <line>names, &amp; arrange</line>
+    <line>in conected classi</line>
+    <line>fications the</line>
+    <line>facts which they</line>
+    <line>to a great degree</line>
+    <line>ha<mod>
+        <del rend="overwritten">v</del>
+        <add hand="#mws" place="intralinear">d</add>
+        <del rend="strikethrough">e</del>
+      </mod> been the</line>
+    <line>instruments of</line>
+    <line>bringing to light.</line>
+    <line>The labours of</line>
+    <line>men of genius</line>
+    <line>however erroneously</line>
+    <line>directed scarce</line>
+    <line>ly ever failed.<anchor xml:id="c56-0028.06"></anchor><anchor xml:id="c56-0028.02"></anchor></line><anchor xml:id="c56-0029.01"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="13r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0029.xml" xml:id="ox-ms_abinger_c56-0029">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0029.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>59</line></zone>
+  <zone type="library"><line>13</line></zone>
+
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"I am happy" said M<hi rend="sup">r</hi>. Waldham,
+      "To</line>
+    <line>"have gained a <del rend="strikethrough">desci</del> desciple and if if your</line>
+    <line>"<del rend="strikethrough">appil</del> application equals your ability</line>
+    <line>"I have no doubt of your success. Che</line>
+    <line>"mistry is that branch of natural</line>
+    <line>"philosophy in which the greatest im-</line>
+    <line>"provements have <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">been</add>
+      </mod> &amp; may be made.</line>
+    <line>"It is on that account<del rend="strikethrough">s</del> that I
+      <unclear>sl</unclear></line>
+    <line>"chose it for my peculiar study. But</line>
+    <line>"at the same <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">time</add>
+      </mod> I did not neglect the</line>
+    <line>"other sciences. A man would make</line>
+    <line>"a very sorry chemist if he atteneded</line>
+    <line>to that department alone. <unclear extent="1" unit="chars"></unclear> If</line>
+    <line>"your wish is really to become a</line>
+    <line>"man of science and not merely</line>
+    <line>"a pretty experimentalist I should</line>
+    <line>"advi<mod xml:space="preserve"><del rend="overwritten">c</del><add hand="#pbs" place="intralinear">s</add></mod>e you to apply to every</line>
+    <line>"branch of natural philosophy <del rend="strikethrough">and</del><anchor xml:id="c56-0029.05"></anchor></line>
+    <line>"Mathematics."</line>
+    <milestone unit="tei:p"></milestone>
+    <delSpan rend="vertical_line" spanTo="#c56-0029.07"></delSpan><line rend="indent1">He
+      then gave me the list</line>
+    <line>I had requested and mentioned a few</line>
+    <line>machines that I ought to procure</line>
+    <line>and promising that when I should</line>
+    <line>have</line><anchor xml:id="c56-0029.07"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">He then took me into his</line>
+    <line><mod>
+        <del rend="strikethrough">workroom</del>
+        <add place="superlinear">laboratory</add>
+      </mod> and <del rend="strikethrough">shewed a</del><del rend="unmarked">nd</del>
+      explain</line>
+    <line>ed to me <add hand="#pbs" place="superlinear">the use of</add> his various machines
+        <mod spanTo="#c56-0029.08"></mod><delSpan rend="strikethrough" spanTo="#c56-0029.09"></delSpan>tel</line>
+    <line>ling me<anchor xml:id="c56-0029.09"></anchor><anchor xml:id="c56-0029.06"></anchor><anchor xml:id="c56-0029.08"></anchor> what I <mod spanTo="#c56-0029.10"></mod><del next="#c56-0029.11" rend="strikethrough">should</del>
+      <del next="c56-0029.12" rend="strikethrough" xml:id="c56-0029.11">procure</del><add place="superlinear">ought to procure</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0029.12">for my priva</del><anchor xml:id="c56-0029.10"></anchor> and promising me</line>
+    <line><del rend="strikethrough">a lone</del> the use of his <add hand="#pbs" place="superlinear">own</add> when I should</line>
+    <line>have advanced far<del rend="strikethrough">e</del> enough in</line>
+    <line>the study not to <damage agent="ink_blot">des</damage>
+      <del rend="strikethrough">der</del> derange</line>
+  </zone>
+  <zone corresp="#c56-0029.01" type="left_margin">
+    <addSpan spanTo="#c56-0029.02"></addSpan>
+    <line><addSpan hand="#pbs" spanTo="#c56-0029.03"></addSpan>in ultimately</line>
+    <line>turning to the</line>
+    <line>solid advantage of</line>
+    <line>mankind.<anchor xml:id="c56-0029.03"></anchor>
+      <addSpan spanTo="#c56-0029.04"></addSpan>I listen</line>
+    <line>ed to his state</line>
+    <line>ment which</line>
+    <line>was delivered</line>
+    <line>without any</line>
+    <line>presumption</line>
+    <line>&amp; then added<anchor xml:id="c56-0029.04"></anchor></line><anchor xml:id="c56-0029.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0029.05" type="left_margin">
+    <line><retrace cause="fix" hand="#mws"><add hand="#pbs">including</add></retrace></line></zone>
+
+  <zone corresp="#c56-0029.06" type="left_margin">
+    <line><add hand="#pbs">instructing me as to</add></line></zone>
+
+  
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="13v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0030.xml" xml:id="ox-ms_abinger_c56-0030">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0030.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>60</line></zone>
+  <zone type="main">
+    <line>the<mod>
+        <del rend="overwritten">m</del>
+        <add place="intralinear">ir</add>
+      </mod>.<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">mechanism.</add>
+      </mod> He also gave me the list of</line>
+    <line>books which I had requested and</line>
+    <line>I took my leave.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Thus ended a day memorable</line>
+    <line><mod>
+        <del rend="strikethrough">in a my life</del>
+        <add place="superlinear">to me</add>
+      </mod> for it decided my</line>
+    <line>destiny.</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="14r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0031.xml" xml:id="ox-ms_abinger_c56-0031">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0031.jp2"></graphic>
+  
+  <zone rend="bordered" type="pagination"><line>61</line></zone>
+  <zone type="library"><line>14</line></zone>
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0031.07" unit="tei:head"></milestone>Chap. 5<anchor xml:id="c56-0031.07"></anchor></line>
+    <line>From this day natural philosophy and parti</line>
+    <line>cularly chemistry became <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">nearly</add>
+      </mod> my sole <del rend="strikethrough">appli</del></line>
+    <line>study. I read with ardour <del rend="strikethrough">m</del> those books</line>
+    <line>so full of genius and discrimination</line>
+    <line><mod>
+        <del rend="unmarked">th</del>
+        <del rend="strikethrough">at have been written</del>
+        <anchor xml:id="c56-0031.01"></anchor>
+      </mod> on these sub-</line>
+    <line>jects. I attended the lectures, and culti</line>
+    <line>vated the acquaintance of the men</line>
+    <line>of science of the university; and I found</line>
+    <line>even in M<hi rend="underline"><hi rend="sup">r</hi></hi> Krempe a great deal</line>
+    <line>of sound sense &amp; real information</line>
+    <line>combined it is true with a repulsive</line>
+    <line>phisiognomy &amp; manners, but not on</line>
+    <line>that account the less valuable.</line>
+    <line>In M. Waldman I found a true friend.</line>
+    <line>His gentleness was never tinged by <del rend="strikethrough">dg</del></line>
+    <line>dogmatism and his instructions were</line>
+    <line>given with an air of frankness and</line>
+    <line>good nature that banished ever<add hand="#pbs" place="intralinear">y</add> idea</line>
+    <line>of <del rend="strikethrough">pedantl</del> pedantry. It was perhaps the</line>
+    <line>amiable character of this man that</line>
+    <line>enclined me more to the study of that</line>
+    <line>branch of <mod>
+        <del rend="strikethrough">science</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">natural philosophy which he professed</add>
+      </mod> than an intrinsic</line>
+    <line>love for the science itself. But this</line>
+    <line><mod>
+      <add place="intralinear"><metamark function="displacement" xml:id="c56-0031.03">X</metamark></add>
+        <del rend="strikethrough">was</del></mod> only in the first steps towards</line> the <line>knowledge; <mod>
+        <del rend="strikethrough">as</del>
+        <add hand="#pbs" place="superlinear">the more fully</add>
+      </mod> I entered <del rend="strikethrough">more fully</del> into</line>
+    <line><mod>
+        <del rend="strikethrough">the</del>
+        <del rend="strikethrough">philosophy</del>
+        <add hand="#pbs" place="superlinear">science </add>
+      </mod> the more I <mod>
+        <del rend="strikethrough">studied</del>
+        <del rend="strikethrough"><add place="superlinear">s</add></del>
+        <add hand="#pbs" place="superlinear"> pursued</add>
+      </mod> it</line>
+    <line>for its own sake. That application</line>
+    <line>which at first had been a matter</line>
+    <line>of <del rend="strikethrough">ch</del> duty <add place="sublinear"><metamark function="insert">^</metamark></add><add hand="#pbs" place="superlinear">&amp;
+        resolution,</add> now became so ardent</line>
+    <line>and eager that the stars often</line>
+    <line>dissapeared <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add><anchor xml:id="c56-0031.05"></anchor>
+      </mod> while I was yet <mod>
+        <del rend="strikethrough">labouring</del>
+        <add hand="#pbs" place="sublinear">engaged</add>
+      </mod></line>
+    <line>in my labrotary.</line>
+  </zone>
+  <zone corresp="#c56-0031.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0031.02"></addSpan>
+    <line>which modern</line>
+    <line>enquirers</line>
+    <anchor xml:id="c56-0031.02"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0031.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0031.04"></addSpan><line></line>
+    <line><del rend="strikethrough">circumstance</del></line>
+    <line><del rend="strikethrough"><unclear>of</unclear></del>
+      <del rend="strikethrough">was had</del></line>
+    <line>state of mind had</line>
+    <line>place <metamark function="displacement">X</metamark></line><anchor xml:id="c56-0031.04"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0031.05" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0031.06"></addSpan>
+    <line>in the light of</line>
+    <line>morning</line>
+    <anchor xml:id="c56-0031.06"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="14v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0032.xml" xml:id="ox-ms_abinger_c56-0032">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0032.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>62</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">As I applied so closely, it may be</line>
+    <line>easily conceived that I improved rapid</line>
+    <line>ly. <del rend="strikethrough">It</del> My ardour was indeed the astonish</line>
+    <line>ment of the students, and my proficiency</line>
+    <line>that of the master. <del rend="strikethrough">and</del> Professor Krempe</line>
+    <line>often asked me with a sly smile</line>
+    <line>how Cornelius Agrippa went on<mod>
+        <add hand="#pbs" place="intralinear">;</add>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <anchor xml:id="c-56.0032.01"></anchor>
+      </mod> Two</line>
+    <line>years passed in this manner during</line>
+    <line>which I paid no visit to Geneva, but</line>
+    <line><del rend="strikethrough">ws</del> was engaged heart and soul in the</line>
+    <line>pursuit of some discoveries which I</line>
+    <line>hoped to make. <del rend="strikethrough">No one</del> None but those</line>
+    <line>who have experienced it can conceive</line>
+    <line>of the enticements of science–<del rend="strikethrough">especially</del> In</line>
+    <line>other studies you go as far as others have</line>
+    <line><mod>
+        <del rend="overwritten">d</del>
+        <add hand="#pbs" place="intralinear">g</add>
+      </mod>one before you and there is nothing</line>
+    <line>more to <mod>
+        <del rend="strikethrough">learn</del>
+        <del rend="unmarked">,</del>
+        <add hand="#pbs" place="superlinear">know,</add>
+      </mod> learn, but in a scientific</line>
+    <line>pursuit <del rend="strikethrough">their</del> there is continual</line>
+    <line>food for discovery and wonder. A mind</line>
+    <line>of <del rend="strikethrough">even</del> moderate capacity who closely pursues</line>
+    <line>one study must infallibly arrive at</line>
+    <line>great proficiency in th<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">at</add>
+      </mod> study—And I</line>
+    <line>who <del rend="strikethrough">was</del> continually <mod>
+        <del rend="strikethrough">applied to</del>
+        <add hand="#pbs" place="superlinear">sought  the attainment
+          of</add>
+      </mod> one</line>
+    <line><mod>
+        <del rend="strikethrough">thing</del>
+        <add hand="#pbs" place="superlinear">object </add><anchor xml:id="c-56.0032.03"></anchor>
+      </mod> and <add hand="#pbs" place="superlinear">was</add> wra<mod>
+        <del rend="overwritten"><unclear extent="2" unit="chars"></unclear></del>
+        <add hand="#pbs" place="intralinear">pt</add>
+      </mod> up <del rend="strikethrough">as I was</del> in this <add hand="#pbs" place="intralinear">sole</add></line>
+    <line><del rend="strikethrough">I</del> improved so rapidly that at the end</line>
+    <line>of the two years I made <mod spanTo="#c56-0032.06"></mod><del next="#c-56.0032.07" rend="strikethrough">one or two</del>
+      <add hand="#pbs" place="intralinear">some</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0032.07">trifling</del><anchor xml:id="c56-0032.06"></anchor> discoveries in the improvement</line>
+    <line>of some chemical <mod>
+        <del rend="strikethrough">machines</del>
+        <add hand="#pbs" place="superlinear">instruments</add>
+      </mod> which pro</line>
+    <line>cured me great esteem and admiration</line>
+    <line>at the university. When I arrived at</line>
+    <line>this <add place="sublinear"><metamark function="insert">^</metamark></add>point, <anchor xml:id="c-56.0032.04"></anchor><del rend="strikethrough">that</del> m<mod>
+        <del rend="overwritten"><unclear extent="1" unit="chars"></unclear></del>
+        <add place="intralinear">y</add>
+      </mod> residence <del rend="strikethrough">at In</del></line>
+  </zone>
+  <zone corresp="#c-56.0032.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c-56.0032.02"></addSpan>
+    <line>while M. Waldham</line>
+    <line>expressed the most</line>
+    <line>heartfelt exultation</line>
+    <line>in my progress.</line>
+    <anchor xml:id="c-56.0032.02"></anchor>
+  </zone>
+  <zone corresp="#c-56.0032.03" type="left_margin">
+    <line><add hand="#pbs">pursuit</add></line>
+  </zone>
+  <zone corresp="#c-56.0032.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c-56.0032.05"></addSpan>
+    <line>and ha<mod xml:space="preserve"><del rend="overwritten">v</del><add place="intralinear">d</add><del rend="unmarked">ng</del></mod> learned</line>
+    <line>all the professors</line>
+    <line>at Ingolstadt were</line>
+    <line>qualified to teach</line>
+    <anchor xml:id="c-56.0032.05"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="15r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0033.xml" xml:id="ox-ms_abinger_c56-0033">
+    <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0033.jp2"></graphic>
+    <zone rend="bordered" type="pagination"><line>63</line></zone>
+    <zone type="library"><line>15</line></zone>
+    <zone type="main">
+        <line><del rend="strikethrough">golstadt was</del><anchor xml:id="c56-0033.01"></anchor> no
+            longer conducive to</line>
+        <line>my improvement, I thought of returning</line>
+        <line>to my friends and to my native town,</line>
+        <line>when an incident happened that</line>
+        <line>protracted my stay.</line>
+        <milestone unit="tei:p"></milestone>
+        <line rend="indent1">One of those phænonoma which</line>
+        <line>had <mod>
+                <del rend="strikethrough">mo<del rend="overwritten">re</del><add hand="#pbs" place="intralinear">st</add></del>
+            </mod> peculiarly attracted my atten</line>
+        <line>tion was the structure of the human</line>
+        <line>frame; and indeed that of any animal</line>
+        <line>endued with life. Whence I often asked</line>
+        <line>myself did this principle of life proceed.</line>
+        <line>It was a bold question, and one <mod>
+                <del rend="strikethrough">that</del>
+                <anchor xml:id="c56-0033.02"></anchor>
+            </mod></line>
+        <line>has ever been considered as a mystery.</line>
+        <line>Yet how many things are we on the</line>
+        <line>brink of becoming acquainted with</line>
+        <line>if cowardice or carelessness did</line>
+        <line>not restrain <mod>
+                <del rend="strikethrough">us</del>
+                <add hand="#pbs" place="superlinear">our enquiries?</add>
+            </mod>. I revolved these circum</line>
+        <line>stances in my mind and determined</line>
+        <line>from thenceforth to apply myself more</line>
+        <line>particularly to th<mod>
+                <del rend="overwritten">at</del>
+                <add hand="#pbs" place="intralinear">ose</add>
+            </mod> branch<add hand="#pbs" place="intralinear">es</add> of natural</line>
+        <line>philosophy which <mod>
+                <del rend="strikethrough">treats</del>
+                <del rend="strikethrough">of</del>
+                <add hand="#pbs" place="superlinear">relate to</add>
+            </mod> phisiology.</line>
+        <line>Unless I had been animated by an al-</line>
+        <line>most supernatural enthusiasm, my</line>
+        <line>application to this study would have</line>
+        <line>been irksome and almost intolerable.</line>
+        <line>To examine the causes of life <del rend="strikethrough"><unclear>de</unclear></del> we
+            must</line>
+        <line>first have <del rend="strikethrough">recou</del> recourse to death.</line>
+        <line><del rend="strikethrough">No is ano anatomy</del> I became acquainted</line>
+        <line>with the science of anatomy but this</line>
+        <line>was not sufficient. I must also observe</line>
+        <line>the natural decay &amp; corruption of the</line>
+        <line>human body. In my education</line>
+    </zone>
+    <zone corresp="#c56-0033.01" type="left_margin">
+        <line><add hand="#pbs">there being</add></line>
+    </zone>
+    <zone corresp="#c56-0033.02" type="left_margin">
+        <line><add hand="#pbs">which</add></line>
+    </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="15v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0034.xml" xml:id="ox-ms_abinger_c56-0034">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0034.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>64</line></zone>
+  <zone type="main">
+    <line>my father had taken the greatest</line>
+    <line>precautions that my mind should</line>
+    <line><del rend="strikethrough">not</del> be impressed by <mod>
+        <add place="sublinear">^</add>
+        <add hand="#pbs" place="superlinear">no</add>
+      </mod> supernatural</line>
+    <line>horrors. I do not ever remember</line>
+    <line>having trembled at <mod>
+        <del rend="strikethrough">a ghost story</del>
+        <add hand="#pbs" place="superlinear">tale of superstition</add>
+      </mod> or</line>
+    <line>to have feared the apparition of <add hand="#pbs" place="superlinear">a</add>
+      spirit</line>
+    <line><del rend="strikethrough">Ligh</del> Darkness had no effect upon my</line>
+    <line>fancy and a churchyard was to</line>
+    <line>me merely <mod>
+        <add place="superlinear">^</add>
+        <add hand="#pbs" place="superlinear">as</add>
+      </mod> the receptacle of <del rend="strikethrough">rotten b</del></line>
+    <line>bodies deprived of life and <mod>
+        <del rend="strikethrough">becoming</del>
+        <add hand="#pbs" place="superlinear">which</add>
+      </mod></line>
+    <line>from being the seat of beauty &amp;</line>
+    <line>strength <mod>
+        <add place="sublinear">^</add>
+        <add hand="#pbs" place="superlinear">become</add>
+      </mod> food for the worm. <del rend="strikethrough">But</del></line>
+    <line><del rend="strikethrough">I </del>
+      <del rend="strikethrough">A loathsome</del>
+      <unclear>c</unclear>
+      <del rend="strikethrough">But</del> now I was</line>
+    <line><mod>
+        <del rend="strikethrough">obliged</del>
+        <add hand="#pbs" place="superlinear">led</add>
+      </mod> to examine the <mod>
+        <del rend="strikethrough">cause</del>
+        <add place="superlinear">cause</add>
+      </mod> &amp; progress</line>
+    <line>of this decay and forced to spend days</line>
+    <line>and nights in vau<retrace cause="unclear" hand="#pbs">l</retrace>ts and Charnel</line>
+    <line>houses. I <del rend="strikethrough">was obliged</del> My attention was</line>
+    <line>fixed upon every <mod>
+        <del rend="strikethrough">horror of whic</del>
+        <del rend="unmarked">h</del>
+        <add hand="#pbs" next="#c56-0034.01" place="superlinear">object <del rend="strikethrough">calculated to</del></add>
+        <add hand="#pbs" place="sublinear" xml:id="c56-0034.01">the most insupportable to the
+          delicacy of</add>
+      </mod></line>
+    <line>the human feelings. <del rend="strikethrough">are suscept</del><del rend="unmarked">able</del>–</line>
+    
+    <line>I saw how the fine form of <del rend="strikethrough">a</del> man</line>
+    <line><mod>
+        <del rend="strikethrough">was</del>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">became</add></del>
+        <anchor xml:id="c56-0034.02"></anchor>
+      </mod> degraded and wasted. I beheld the</line>
+    <line>corruption of death succeed to the bloom</line>
+    <line>-ing cheek of life – <add hand="#pbs" place="superlinear">I saw</add> how the worm
+        <mod spanTo="#c56-0034.06"></mod><delSpan rend="strikethrough" spanTo="#c56-0034.03"></delSpan>suc</line>
+    <line>ceeded to<anchor xml:id="c56-0034.03"></anchor><add hand="#pbs" place="superlinear">inherited</add><anchor xml:id="c56-0034.06"></anchor> the wonders of the eye and</line>
+    <line>brain. I paused, examin<mod xml:space="preserve"><del rend="overwritten">ed</del><add hand="#pbs" place="intralinear">ing</add></mod> and anal<mod xml:space="preserve"><del rend="overwritten">yzed</del><add hand="#pbs" place="intralinear">yzing</add></mod></line>
+    <line><mod>
+        <del rend="strikethrough">every</del>
+        <del rend="strikethrough">minutiæ</del>
+        <del rend="unmarked"> of </del>
+        <del rend="strikethrough">causation</del>
+        <anchor xml:id="c56-0034.04"></anchor>
+      </mod> untill</line>
+    <line>from the midst of this darkness</line>
+    <line>a sudden light broke in upon me.</line>
+    <line>A light so brilliant &amp; wondrous yet</line>
+  </zone>
+
+  <zone corresp="#c56-0034.02" type="left_margin">
+    <line><add hand="#pbs">was</add></line>
+  </zone>
+  <zone corresp="#c56-0034.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0034.05"></addSpan>
+    <line>all the minutiæ</line>
+    <line>of causation</line>
+    <line>as exemplified in</line>
+    <line>the change from</line>
+    <line>life to death, &amp;</line>
+    <line>death to life,</line>
+    <anchor xml:id="c56-0034.05"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="16r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0035.xml" xml:id="ox-ms_abinger_c56-0035">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0035.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>65</line></zone>
+  <zone type="library"><line>16</line></zone>
+  <zone type="main">
+    <line>so simple that while <mod spanTo="#c56-0035.01"></mod><delSpan rend="strikethrough" spanTo="#c56-0035.02"></delSpan>it intoxica</line>
+    <line>ted me<anchor xml:id="c56-0035.02"></anchor><anchor xml:id="c56-0035.03"></anchor><anchor xml:id="c56-0035.01"></anchor> I was surprised that I</line>
+    <line><del rend="strikethrough">was</del> among so many men of genius</line>
+    <line>who had applied to the same science</line>
+    <line>that I alone should discover</line>
+    <line>this astonishing secret.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Remember I am <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">not</add>
+      </mod> recording the</line>
+    <line><del rend="strikethrough">no</del> vision <del rend="strikethrough">of</del> of a madman
+      – the</line>
+    <line>sun does not more certainly shine</line>
+    <line>in the heavens than that wh<mod xml:space="preserve"><del rend="overwritten">at</del><add hand="#pbs" place="intralinear">ich</add></mod></line>
+    <line>I now <mod>
+        <del rend="strikethrough">record</del>
+        <add hand="#pbs" place="superlinear">affirm,</add>
+      </mod> is true. Some miracle</line>
+    <line>might have produced it. But the</line>
+    <line>stages of discovery were distinct</line>
+    <line>and probable. After days and nights</line>
+    <line>of incredible <mod>
+        <del rend="strikethrough">toil</del>
+        <add hand="#pbs" place="superlinear">labour</add>
+      </mod> and fatigue</line>
+    <line>I succeeded in discovering the</line>
+    <line>cause of generation &amp; life. Nay</line>
+    <line>more, I <mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">became</add>
+      </mod> myself capable of</line>
+    <line>bestowing animation upon lifeless</line>
+    <line>matter.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del rend="strikethrough">My</del> The surprise <mod>
+        <del rend="strikethrough">that</del>
+        <add hand="#pbs" place="superlinear">which</add>
+      </mod> I <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">at first</add>
+      </mod>experienced</line>
+    <line>on this discovery soon gave place to</line>
+    <line>delight and rapture. <mod spanTo="#c56-0035.05"></mod><delSpan rend="strikethrough" spanTo="#c56-0035.08"></delSpan>After such</line>
+    <line>painful labour<anchor xml:id="c56-0035.08"></anchor><add place="sublinear"><metamark function="insert" xml:id="c56-0035.06">^</metamark></add><anchor xml:id="c56-0035.05"></anchor>
+      <mod>
+        <del rend="strikethrough">come</del>
+        <add place="superlinear">to arrive</add>
+      </mod> at onece</line>
+    <line>at the <mod>
+        <del rend="strikethrough">obj ect</del>
+        <del rend="strikethrough">object</del>
+        <add place="superlinear">summit</add>
+      </mod> of my desires</line>
+    <line>was the most gratifying circumstance</line>
+    <line>that could have occurred. But this</line>
+    <line>discovery was so great and overwhelm</line>
+    <line>ing that <del rend="strikethrough">the</del>
+      <del>reflection</del> all the</line>
+  </zone>
+  <zone corresp="#c56-0035.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0035.04"></addSpan>
+    <line>I became dizzy</line>
+    <line>with the immen</line>
+    <line>sity of the prospect</line>
+    <line>which it illus</line>
+    <line>trated,</line><anchor xml:id="c56-0035.04"></anchor>
+  </zone>
+  <zone corresp="#c56-0035.06" type="left_margin">
+    <addSpan spanTo="#c56-0035.07"></addSpan>
+    <line>After so much</line>
+    <line><hi rend="sup"><metamark function="displacement">^</metamark></hi>time spent in</line>
+    <line>painful labour</line><anchor xml:id="c56-0035.07"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="16v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0036.xml" xml:id="ox-ms_abinger_c56-0036">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0036.jp2"></graphic>
+
+  <zone rend="bordered" type="pagination"><line>66</line></zone>
+
+  <zone type="main">
+    <line>steps <mod>
+        <del rend="strikethrough">that</del>
+        <add hand="#pbs" place="superlinear">by which I had been</add>
+      </mod>progressively led to it were</line>
+    <line>obliterated. <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">and</add>
+      </mod>I <mod>
+        <del rend="strikethrough">saw</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">beheld</add>
+      </mod> only the result. What</line>
+    <line>had been the study and desire of the</line>
+    <line><del rend="strikethrough">m</del> wisest men since the creation of</line>
+    <line>the world was now <mod>
+        <del rend="strikethrough">in</del>
+        <add hand="#pbs" place="superlinear">within</add>
+      </mod> my <mod>
+        <del rend="strikethrough">hands.</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">grasp;</add>
+      </mod> Not</line>
+    <line>that, like a magic <del rend="strikethrough"><unclear>sceen</unclear></del> scene
+      it</line>
+    <line>all opened upon me at on<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">c</add>
+      </mod>e<mod>
+        <del rend="overwritten"><unclear>;</unclear></del>
+        <add place="intralinear">.</add>
+      </mod>
+      <delSpan rend="strikethrough" spanTo="#c56-0036.01"></delSpan>on</line>
+    <line>the contrary<anchor xml:id="c56-0036.01"></anchor>
+      <mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">T</add>
+      </mod>he <del rend="strikethrough"><unclear>big</unclear></del> information</line>
+    <line>I had obtained was <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">of a nature</add>
+      </mod> rather <mod spanTo="#c56-0036.02"></mod><delSpan rend="strikethrough" spanTo="#c56-0036.03"></delSpan>one that</line>
+    <line>would<anchor xml:id="c56-0036.03"></anchor><add place="sublinear"><metamark function="insert">^</metamark></add>
+      <add hand="#pbs" place="superlinear">to</add><anchor xml:id="c56-0036.02"></anchor> direct my
+      endeavours. <mod spanTo="#c56-0036.04"></mod><add place="sublinear"><metamark function="insert">^</metamark></add>
+      <delSpan rend="strikethough" spanTo="#c56-0036.05"></delSpan>that</line>
+    <line>than show me the prospect with</line>
+    <line>any precise certainty.<anchor xml:id="c56-0036.05"></anchor><anchor xml:id="c56-0036.06"></anchor><anchor xml:id="c56-0036.04"></anchor> I was like the</line>
+    <line>Arabian<del rend="strikethrough">,</del> who had been buried with</line>
+    <line>the dead, and found a passage to life</line>
+    <line>aided only by one glimmering and seem</line>
+    <line>ingly ineffectual light.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I see by your eargerness and the</line>
+    <line>wonder and hope which your eyes</line>
+    <line>express, my friend, that you expect to</line>
+    <line>be informed of the <del rend="strikethrough">scret</del> secret with</line>
+    <line>which I am acquainted<mod>
+        <del rend="overwritten">,</del>
+        <add hand="#pbs" place="intralinear">;</add>
+      </mod>
+      <mod spanTo="#c56-0036.08"></mod><del next="#c56-0036.09" rend="strikethrough">but you
+        are</del><add hand="#pbs" place="superlinear">that cannot be.</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0036.09">mistaken</del><del rend="unmarked">.</del><anchor xml:id="c56-0036.08"></anchor> Listen patiently to the end</line>
+    <line>of my story and you will easily</line>
+    <line>perceive why <add place="intralinear">I</add> am reserved upon that</line>
+    <line>subject.— <del rend="strikethrough">For why shoul</del><del rend="unmarked">d</del>
+      I <add place="superlinear">will not</add> lead you</line>
+    <line>on, <del rend="strikethrough">as</del> unguarded and ardent as I then</line>
+    <line>was, to your <del rend="strikethrough">destruct</del> destruction &amp;</line>
+  </zone>
+  <zone corresp="#c56-0036.06" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0036.07"></addSpan><line><metamark function="displacement">^</metamark>so soon as I</line>
+    <line>should point</line>
+    <line>them towards</line>
+    <line>the object of</line>
+    <line>my search,</line>
+    <line>than to exhi</line>
+    <line>bit that ob-</line>
+    <line>ject already</line>
+    <line>accomplished.</line><anchor xml:id="c56-0036.07"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="17r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0037.xml" xml:id="ox-ms_abinger_c56-0037">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0037.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>67</line></zone>
+  <zone type="library">17</zone>
+  <zone type="main">
+    <line>infallible misery. Learn from me, if</line>
+    <line>not by my precepts at least by my exam</line>
+    <line>ple, how dangerous is the acquirement</line>
+    <line>of knowledge and how much happier</line>
+    <line>that man is who believes his native</line>
+    <line>town the world, than he <del rend="strikethrough">who<unclear>nto</unclear></del></line>
+    <line>aspires to become greater than his</line>
+    <line>nature <del rend="strikethrough">allows.</del> will allow.</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="17v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0038.xml" xml:id="ox-ms_abinger_c56-0038">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0038.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>68</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0038.18" unit="tei:head"></milestone>Chapter 6.<anchor xml:id="c56-0038.18"></anchor></line>
+    <line>When I found <mod>
+        <del rend="strikethrough">this</del>
+        <add hand="#pbs" place="superlinear">so</add>
+      </mod> astonishing<add hand="#pbs" place="superlinear">a</add> power</line>
+    <line>placed <mod>
+        <del rend="strikethrough">in</del>
+        <add hand="#pbs" place="superlinear">within</add>
+      </mod> my hands<add hand="#pbs" place="intralinear">,</add> I hesitated a long time</line>
+    <line>concerning the <mod>
+        <del rend="strikethrough">use</del>
+        <add hand="#pbs" place="superlinear">manner in which</add>
+      </mod> I should <mod>
+        <del rend="strikethrough">make of</del>
+        <add hand="#pbs" place="superlinear">employ</add>
+      </mod> it.</line>
+    <line>Although I <del rend="strikethrough">conceived myself capable of</del> possessed</line>
+    <line>the capacity of bestowing animation yet</line>
+    <line><del rend="strikethrough">my</del> to <mod>
+        <del rend="strikethrough">create</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">prepare</add>
+      </mod> a <mod>
+        <del rend="strikethrough">creature</del>
+        <add hand="#pbs" place="superlinear">frame</add>
+      </mod>
+      <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">for the <mod>
+            <del rend="strikethrough">receiving i</del>
+            <add place="superlinear">reception of</add>
+          </mod><mod>
+            <del rend="overwritten">t</del>
+            <add place="intralinear">it</add>
+          </mod></add>
+      </mod> with all its intri</line>
+    <line>cacies of fibres muscles &amp; veins <mod>
+        <del rend="strikethrough">must be</del>
+        <anchor xml:id="c56-0038.01"></anchor>
+      </mod></line>
+    <line>a work of inconceivable <milestone spanTo="#c56-0038.21" unit="tei:seg" xml:id="c56-0038.19"></milestone>labour<anchor xml:id="c56-0038.21"></anchor><add hand="#pbs" place="superlinear"><metamark function="transpose" target="#c56-0038.19">2</metamark></add> &amp; <add hand="#pbs" place="superlinear"><metamark function="transpose" target="#c56-0038.20">1</metamark></add><milestone spanTo="#c56-0038.22" unit="tei:seg" xml:id="c56-0038.20"></milestone>diffi</line>
+    <line>culty<anchor xml:id="c56-0038.22"></anchor>. I doubted at first whether I should<listTranspose><transpose><ptr target="#c56-0038.20"></ptr><ptr target="#c56-0038.19"></ptr></transpose></listTranspose></line>
+    <line>attempt the creation of a <mod>
+        <del rend="strikethrough">creature</del>
+        <add hand="#pbs" place="superlinear">being</add>
+      </mod></line>
+    <line>like <del rend="strikethrough">unto</del> myself or one of simpler</line>
+    <line>organization; <del rend="strikethrough">b</del> but my imagination</line>
+    <line>was too much exalted by my first success</line>
+    <line>to permit me to doubt of my <del rend="strikethrough">capacity</del></line>
+    <line>ability to <mod>
+        <del rend="strikethrough">create</del>
+        <add hand="#pbs" place="superlinear">give life</add>
+        <del rend="strikethrough">a</del>
+        <add hand="#pbs" place="superlinear">to</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">creature</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear"><del rend="strikethrough">being</del> an animal</add>
+      </mod> as complex</line>
+    <line>and wonderful as man. <mod spanTo="#c56-0038.02"></mod><mod>
+        <del next="#c56-0038.03" rend="strikethrough"><del rend="overwritten"><unclear>but</unclear></del><add place="intralinear">Yet</add></del>
+        <del rend="strikethrough"><add place="superlinear">But</add></del>
+      </mod>
+      <del next="#c56-0038.04" rend="strikethrough" xml:id="c56-0038.03">when I</del></line>
+    <line><del rend="strikethrough" xml:id="c56-0038.04">when</del>
+      <del rend="strikethrough">I</del>
+      <mod>
+        <del rend="strikethrough">looked around for</del>
+        <del rend="strikethrough"><add place="superlinear">considered</add></del>
+      </mod>
+      <del rend="strikethrough">my</del>
+      <del rend="strikethrough">materials</del></line>
+    <line><del rend="strikethrough">they</del>
+      <anchor xml:id="c56-0038.05"></anchor><add hand="#pbs" place="superlinear" xml:id="c56-0038.07">my command</add><anchor xml:id="c56-0038.02"></anchor> hardly
+      appeared adequate to so ardous</line>
+    <line>an undertaking; <mod>
+        <del rend="strikethrough">but I did not despai</del>
+        <del rend="unmarked">r.</del>
+        <add hand="#pbs" next="#c56-0038.11" place="superlinear">but I doubted not that I should
+          ul</add>
+        <add hand="#pbs" place="sublinear" xml:id="c56-0038.11">-timately succeed.</add>
+      </mod></line>
+    <line><mod spanTo="#c56-0038.12"></mod><delSpan rend="vertical_line" spanTo="#c56-0038.13"></delSpan>I
+      allowed that my first attempts might</line>
+    <line>be futile, my operations fail or my work</line>
+    <line>be imperfect,<anchor xml:id="c56-0038.13"></anchor>
+      <del rend="strikethrough">but I looked around on</del><anchor xml:id="c56-0038.08"></anchor><anchor xml:id="c56-0038.12"></anchor></line>
+    <line>the improvement <mod>
+        <del rend="strikethrough">that</del>
+        <add place="superlinear">which</add>
+      </mod> every day</line>
+    <line>takes place in science and <add hand="#pbs" place="intralinear">mechanics</add></line>
+    <line><mod spanTo="#c56-0038.14"></mod><del next="#c56-0038.15" rend="strikethrough">and m my
+        attempt was so much grande</del><del rend="unmarked">r</del><add hand="#pbs" place="superlinear">I was encouraged to hope</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0038.15">and</del>
+      <delSpan rend="strikethrough" spanTo="#c56-0038.16"></delSpan>And altho although I could not
+      hope</line>
+    <line>that<anchor xml:id="c56-0038.16"></anchor><anchor xml:id="c56-0038.14"></anchor> my <add hand="#pbs" place="superlinear">present</add> attempts would <mod spanTo="#c56-0038.17"></mod><del rend="strikethrough"><unclear>s</unclear></del><del rend="strikethrough"><add hand="#pbs" place="superlinear">at le</add></del>
+      <del rend="strikethrough">be in every</del></line>
+    <line><add hand="#pbs">at least <mod>
+          <add place="sublinear"><metamark function="insert">^</metamark></add>
+          <add place="superlinear">lay</add>
+        </mod> the foundations of future success</add><anchor xml:id="c56-0038.17"></anchor></line>
+  </zone>
+
+  <zone corresp="#c56-0038.01" type="left_margin">
+    <line><add hand="#pbs">still remained</add></line>
+  </zone>
+
+  <zone corresp="#c56-0038.05" type="left_margin">
+    <addSpan hand="#pbs" next="#c56-0038.07" spanTo="#c56-0038.06"></addSpan>
+    <line>The materials</line>
+    <line>at present within </line><anchor xml:id="c56-0038.06"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0038.08" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0038.09"></addSpan>
+    <line>I prepared myself</line>
+    <line>for a multitude</line>
+    <line>of reverses, my</line>
+    <line>operations <del rend="strikethrough">might</del></line>
+    <line>be baffled <del rend="strikethrough">ever</del></line>
+    <line>incessantly, &amp; at</line>
+    <line>last my work be</line>
+    <line>but imperfect,</line>
+    <line>yet, when I con</line>
+    <line>sidered</line>
+    <anchor xml:id="c56-0038.09"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="18r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0039.xml" xml:id="ox-ms_abinger_c56-0039">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0039.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line><mod><del rend="overwritten"><unclear>7</unclear></del><add place="intralinear">6</add></mod>9</line></zone>
+  <zone type="library"><line>18</line></zone>
+  <zone type="main">
+    <line><del rend="strikethrough">way perfect<mod>
+          <del rend="strikethrough"> yet</del>
+          <del rend="strikethrough"><add place="superlinear">but</add></del>
+        </mod></del><anchor xml:id="c56-0039.01"></anchor>
+      I did not think that</line>
+    <line>the magnitude and <mod>
+        <del rend="strikethrough">grandeur</del>
+        <add hand="#pbs" place="superlinear">complexity</add>
+      </mod> of my plan</line>
+    <line><del rend="strikethrough">w</del>as any argument of its impracticabi</line>
+    <line>lity. <mod>
+        <del rend="strikethrough">And</del>
+        <del rend="overwritten">i</del>
+        <add hand="#pbs" place="intralinear">I</add>
+      </mod>t was with these feelings <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">that</add>
+      </mod>I</line>
+    <line>began the creation of a human being.</line>
+    <line>As the <mod>
+        <del rend="strikethrough">smallness</del>
+        <add hand="#pbs" place="superlinear">minuteness</add>
+      </mod> of the parts <mod>
+        <del rend="strikethrough">were</del>
+        <add hand="#pbs" place="superlinear">formed</add>
+      </mod> a</line>
+    <line>great hindrance to my speed I resolved,</line>
+    <line>contrary to my first intention, to make</line>
+    <line><mod>
+        <del rend="strikethrough">him</del>
+        <anchor xml:id="c56-0039.03"></anchor>
+      </mod>
+      <del rend="strikethrough">of</del> of a gigantic stature; that</line>
+    <line>is to say about <mod>
+        <del rend="strikethrough">7</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">seven</add>
+      </mod> or eight feet in</line>
+    <line>height, and proportionably large. <del rend="strikethrough">And</del></line>
+    <line>after having formed this determination</line>
+    <line>and having spent some months in</line>
+    <line><mod>
+        <del rend="strikethrough">collecting</del>
+        <del rend="strikethrough">of</del>
+        <anchor xml:id="c56-0039.04"></anchor>
+      </mod> my materials, I began.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">No one can conceive <del rend="strikethrough">my</del> the
+      variety</line>
+    <line>of feelings which pressed upon me</line>
+    <line>during this time. When success raised</line>
+    <line>me <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">to</add>
+      </mod>enthusiasm life and death appear</line>
+    <line>ed to me ideal bounds, which I</line>
+    <line>should first break <add hand="#pbs" place="superlinear">thro,</add> and pour a</line>
+    <line>torrent of light into our dark world.</line>
+    <line>A new <mod>
+        <del rend="strikethrough">creation</del>
+        <add hand="#pbs" place="superlinear">existence</add>
+      </mod> would bless me as its</line>
+    <line><mod>
+        <del rend="strikethrough">maker</del>
+        <anchor xml:id="c56-0039.06"></anchor>
+      </mod> and source; many happy and</line>
+    <line>excellent <mod>
+        <del rend="strikethrough">creatures</del>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">beings</add></del>
+        <add hand="#pbs" place="sublinear">natures</add>
+      </mod> would owe their</line>
+    <line><mod>
+        <del rend="strikethrough">existence</del>
+        <del rend="strikethrough">in</del>
+        <add hand="#pbs" place="superlinear">being</add>
+      </mod> to me. <del rend="strikethrough">in manner</del></line>
+    <line><del rend="strikethrough">in a manner</del> no father could claim</line>
+    <line>the gratitude of his child <mod>
+        <add place="sublinear"><metamark function="displacement" xml:id="c56-0039.07">^</metamark></add>
+      </mod>
+      <del rend="strikethrough">And</del> pur</line>
+    <line>sueing <mod>
+        <del rend="strikethrough">my</del>
+        <add hand="#pbs" place="superlinear">these</add>
+      </mod> reflections <del rend="strikethrough">if</del> I thought</line>
+    <line>that if I could bestow <mod>
+        <del rend="strikethrough">life</del>
+        <add place="superlinear">animation</add>
+      </mod> upon</line>
+    <line><del rend="strikethrough">upon</del> lifeless matter I might in</line>
+    <line>process of time (although I now found</line>
+  </zone>
+  <zone corresp="#c56-0039.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0039.02"></addSpan>
+    <line>Nor, could I</line>
+    <line>consider</line>
+    <anchor xml:id="c56-0039.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0039.03" type="left_margin">
+    <line><add hand="#pbs">the being</add></line>
+  </zone>
+  <zone corresp="#c56-0039.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0039.05"></addSpan>
+    <line>successfully</line>
+    <line>collecting &amp;</line>
+    <line>arranging</line><anchor xml:id="c56-0039.05"></anchor>
+  </zone>
+  <zone corresp="#c56-0039.06" type="left_margin">
+    <line><add>creator</add></line>
+  </zone>
+  <zone corresp="#c56-0039.07" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0039.08"></addSpan>
+    <line>so completely as</line>
+    <line>I should deserve</line>
+    <line>thiers</line>
+    <anchor xml:id="c56-0039.08"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="18v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0040.xml" xml:id="ox-ms_abinger_c56-0040">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0040.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>70</line></zone>
+  <zone type="main">
+    <line>it impossible) renew life where</line>
+    <line>death had apparently devoted the</line>
+    <line>body to corruption.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">These thoughts supported my</line>
+    <line>spirits while I pursued my <mod>
+        <del rend="strikethrough">labours</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">undertaking</add>
+      </mod></line>
+    <line>with unremitting <mod>
+        <del rend="strikethrough">eagerness</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">ardour</add>
+      </mod>. My cheek</line>
+    <line><mod>
+        <del rend="strikethrough">was</del>
+        <anchor xml:id="c56-0040.01"></anchor>
+      </mod> pale with study, and <del rend="strikethrough">pe</del> my person</line>
+    <line><anchor xml:id="c56-0040.02"></anchor>emaciated by confinement. sometimes</line>
+    <line>on the very brink of certainty I faild</line>
+    <line>yet I still clung to the hope which</line>
+    <line>the next day or the <del rend="strikethrough">nexhour</del> next</line>
+    <line>hour might realize. One secret</line>
+    <line>which I alone <mod>
+        <del rend="strikethrough">knew</del>
+        <add place="superlinear">possessed</add>
+      </mod> was the hope</line>
+    <line>to which I clung and the moon</line>
+    <line>gazed on my midnight labours</line>
+    <line>while with unrelaxed &amp; breathless</line>
+    <line>eagerness I pursued nature to her</line>
+    <line>most secret hiding places<del rend="strikethrough">. But</del></line>
+    <line>who shall <mod>
+        <del rend="strikethrough">know</del>
+        <del rend="strikethrough">my</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">concieve the horrors of my</add>
+      </mod> secret <mod>
+        <del rend="strikethrough">operatio</del>
+        <del rend="unmarked">ns</del>
+        <add hand="#pbs" place="superlinear">toil</add>
+      </mod></line>
+    <line>as I dabbled among the unhallowed</line>
+    <line>damps of the grave, or tortured the</line>
+    <line>living <del rend="strikethrough">animate to ani</del> animal to</line>
+    <line>animate <mod>
+        <del rend="strikethrough">my</del>
+        <add hand="#pbs" place="superlinear">the</add>
+      </mod> lifeless clay? <del rend="strikethrough">Now</del> my limbs</line>
+    <line><anchor xml:id="c56-0040.03"></anchor> tremble and my eyes swim with the</line>
+    <line>rememberance, but then a resistless</line>
+    <line>and <del rend="strikethrough">all</del> almost frantic<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">impulse</add>
+      </mod> urged me</line>
+    <line><mod>
+        <del rend="strikethrough">on</del>
+        <anchor xml:id="c56-0040.04"></anchor>
+      </mod>; I seemed to have lost all</line>
+    <line>soul or sensation but for one</line>
+    <line>pursuit. It was indeed a passing trance</line>
+    <line>that only made me feel with renew</line>
+  </zone>
+  <zone corresp="#c56-0040.01" type="left_margin">
+    <line><add hand="#pbs">had grown</add></line>
+  </zone>
+  <zone corresp="#c56-0040.02" type="left_margin">
+    <line><add hand="#pbs">became</add></line>
+  </zone>
+  <zone corresp="#c56-0040.03" type="left_margin">
+    <line><add hand="#pbs">now</add></line>
+  </zone>
+  <zone corresp="#c56-0040.04" type="left_margin">
+    <line><add hand="#pbs">forward</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="19r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0041.xml" xml:id="ox-ms_abinger_c56-0041">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0041.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>71</line></zone>
+  <zone type="library"><line>19</line></zone>
+  <zone type="main">
+    <line>ed acuteness <mod>
+        <del rend="strikethrough">when</del>
+        <add hand="#pbs" place="superlinear">so soon as</add>
+      </mod> the unnatural sti</line>
+    <line>mulus ceas<mod>
+        <del rend="overwritten">ed</del>
+        <add hand="#pbs" place="intralinear">ing</add>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">had</add></del>
+      </mod> to operate, and I had return</line>
+    <line>ed to my old habits. I collected bones from</line>
+    <line>Charnel houses and with profane fingers</line>
+    <line>meddled with the secrets of the human</line>
+    <line>frame. In a solitary chamber–or rather</line>
+    <line>cell at the top of the house and seperated</line>
+    <line>from all other appartments by a gallery</line>
+    <line>and staircase I <del rend="strikethrough">h</del> kept my workshop</line>
+    <line>of filthy creation; my eyeballs were</line>
+    <line>starting from their sockets in at-</line>
+    <line>tending to the minutiæ of <del rend="strikethrough">the</del> my</line>
+    <line>employment. The dissecting room and</line>
+    <line>the slaughter house furnished many</line>
+    <line>of my materials, and often did my</line>
+    <line>human nature turn from my</line>
+    <line>occupation <mod>
+        <del rend="strikethrough">but</del>
+        <del rend="overwritten">I</del>
+        <add hand="#pbs" place="superlinear">whilst</add>
+        <del rend="strikethrough">wal</del>
+        <del rend="strikethrough">was</del>
+      </mod> still urged</line>
+    <line>on by an eagerness which <add hand="#pbs" place="superlinear">perpetually</add> encreased,</line>
+    <line><mod>
+        <del rend="strikethrough">as</del>
+        <anchor xml:id="c56-0041.01"></anchor>
+      </mod> my work <del rend="strikethrough">drew</del> near <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">to</add>
+      </mod> a conclusion.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The <del rend="strikethrough">sums</del> Summer
+      months</line>
+    <line>passed while I was thus <mod>
+        <del rend="strikethrough">employed</del>
+        <add hand="#pbs" place="superlinear">engaged,</add>
+      </mod></line>
+    <line>heart and soul, in one pursuit. It</line>
+    <line>was a most beautiful season: never</line>
+    <line>did the fields bestow a more plentiful</line>
+    <line>harvest, or the vines yeild a more</line>
+    <line>luxuriant vintage. But my eyes were</line>
+    <line><mod>
+        <del rend="unmarked">s</del>
+        <del rend="strikethrough">hut</del>
+        <anchor xml:id="c56-0041.02"></anchor>
+      </mod> to the charms of nature &amp; the</line>
+    <line>same feelings which <mod>
+        <del rend="strikethrough">caused</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">made</add>
+      </mod> me <del rend="strikethrough">to</del></line>
+    <line>neglect the scenes around me caused</line>
+    <line>me also to forget those friends who</line>
+    <line>were so many miles absent and whom</line>
+    <line>I had not seen for so long a time.</line>
+  </zone>
+  <zone corresp="#c56-0041.01" type="left_margin">
+    <line><add hand="#pbs">I brought</add></line>
+  </zone>
+  <zone corresp="#c56-0041.02" type="left_margin">
+    <line><add hand="#pbs">insensible</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="19v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0042.xml" xml:id="ox-ms_abinger_c56-0042">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0042.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>72</line></zone>
+  <zone type="main">
+    <line>I knew that my silence disquieted</line>
+    <line>them and I well remembered the</line>
+    <line>words of my father. "I know that while</line>
+    <line>"you are pleased with yourself you</line>
+    <line>"will <del rend="strikethrough">thing</del> think of us with affection</line>
+    <line>"and we shall hear regularly from</line>
+    <line>"you. And you must pardon me</line>
+    <line>"if I regard <del rend="strikethrough">you</del> any interruption</line>
+    <line>"in your corespondence, as a proof</line>
+    <line>"that your other <mod>
+        <del rend="strikethrough">studies</del>
+        <add hand="#pbs" place="superlinear">duties</add>
+      </mod> are equal-</line>
+    <line>"ly neglected" I <del rend="strikethrough">rembered</del> knew well</line>
+    <line>therefore what his <del rend="strikethrough">opinion</del> would</line>
+    <line>be <add hand="#pbs" place="superlinear">his feelings</add> but I could not tear my
+      thoughts</line>
+    <line>from my occupation loathsome in</line>
+    <line>itself but which had taken a<add place="intralinear">n</add></line>
+    <line><mod>
+        <del rend="strikethrough">strong</del>
+        <anchor xml:id="c56-0042.02"></anchor>
+      </mod> hold of my <del rend="strikethrough">imagni</del> imagination.</line>
+    <line>I wished as it were to <del rend="strikethrough">procr</del> procras</line>
+    <line>tinate <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">all that related to</add>
+      </mod> my feelings of affection, untill</line>
+    <line>the great object <mod>
+        <del rend="strikethrough">of my affection</del>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="sublinear">which swallowed up every habit</add>
+        <anchor xml:id="c56-0042.04"></anchor>
+      </mod></line>
+    <line>compleated.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I then thought that my father</line>
+    <line>would be <del rend="strikethrough">in</del> unjust <mod>
+        <del rend="strikethrough">to</del>
+        <add place="superlinear">if he</add>
+      </mod> ascribe<add place="intralinear">d</add> my</line>
+    <line>neglect to vice or faultiness on my</line>
+    <line>part; but I am now convinced</line>
+    <line>that <mod>
+        <del rend="strikethrough">I</del>
+        <del rend="strikethrough">am</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">he was</add>
+        <add place="superlinear"><metamark function="displacement">X</metamark></add>
+        <del rend="strikethrough">in the right</del>
+        <del rend="strikethrough"><add place="superlinear">in <unclear>co</unclear>
+          conceive</add></del>
+        <anchor xml:id="c56-0042.05"></anchor>
+      </mod>. A human</line>
+    <line>being in perfection ough<add place="intralinear">t</add> always to</line>
+    <line>preserve a <del rend="strikethrough">cl</del> calm and peaceful</line>
+    <line>mind and never to allow passion</line>
+  </zone>
+  <zone corresp="#c56-0042.02" type="left_margin">
+    <line><add>irresistible</add></line>
+  </zone>
+  <zone corresp="#c56-0042.04" type="left_margin">
+    <line><add xml:id="c56-0042.03"> of my nature should be</add></line>
+  </zone>
+  <zone corresp="#c56-0042.05" type="left_margin">
+    <addSpan spanTo="#c56-0042.06"></addSpan>
+    <line><metamark>X</metamark> he was in the</line>
+    <line>right in conceiv</line>
+    <line>ing that I</line>
+    <line>should not be</line>
+    <line>altogether free</line>
+    <line>from blame.</line>
+    <anchor xml:id="c56-0042.06"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="20r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0043.xml" xml:id="ox-ms_abinger_c56-0043">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0043.jp2"></graphic>
+  <zone type="pagination"><line>73</line></zone>
+  <zone type="library"><line>20</line></zone>
+  <zone type="main">
+    <line>or <mod>
+        <add place="sublinear">^</add>
+        <add place="superlinear">a</add>
+      </mod> transitory desire to disturb his</line>
+    <line>tranquillity. I do not think that the pursuit</line>
+    <line>of knowledge is any exception to this rule.</line>
+    <line>If the study to which you apply yourself</line>
+    <line>has a <del rend="strikethrough">d</del> tendency to weaken your affections</line>
+    <line>and to destroy your taste for those simple</line>
+    <line>pleasures in which no alloy can possibly</line>
+    <line>mix then that study is certainly unlawful</line>
+    <line>that <del rend="strikethrough">it</del> is to say <del rend="strikethrough">on that</del>
+      not befitting <del rend="strikethrough">to</del> the</line>
+    <line>human mind. If this <del rend="strikethrough">rul</del> rule <mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">were</add>
+      </mod> al</line>
+    <line>ways observed; if no man allowed any</line>
+    <line>pursuit whatsoever to interfere with</line>
+    <line>his tranquillity and <add hand="#pbs" place="superlinear">his</add> domestic
+      affections</line>
+    <line>Greece had never been enslaved, Cæsar</line>
+    <line>would have spared his country, America</line>
+    <line>would have been discovered more gradua<add place="intralinear">l</add></line>
+    <line>ly, and the Empires of Mexico &amp; Peru had</line>
+    <line>not been destroyed.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">But I forget that I am moralizing</line>
+    <line>in the most interresting part of my</line>
+    <line>tale; and your looks remind me to</line>
+    <line>proceed.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">My father made no reproach in his</line>
+    <line>letters, <del rend="strikethrough">an</del> and only took notice of my</line>
+    <line>silence by enquiring more particularly</line>
+    <line>than before what my <del rend="strikethrough">co</del> occupations</line>
+    <line><del rend="strikethrough">wer</del> were. Winter spring and summer</line>
+    <line>passed away during my <mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">l</add>
+      </mod>abours but</line>
+    <line>I did not watch the blossom or the</line>
+    <line>expanding leaves – sights which before</line>
+    <line>had alway yeilded me supreme delight<unclear>.</unclear></line>
+    <line>so <mod>
+        <del rend="strikethrough">much</del>
+        <add hand="#pbs" place="superlinear">deeply</add>
+      </mod> was I <mod>
+        <del rend="strikethrough">taken up with</del>
+        <add hand="#pbs" place="superlinear">engrossed in</add>
+      </mod> my</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="20v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0044.xml" xml:id="ox-ms_abinger_c56-0044">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0044.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>74</line></zone>
+  <zone type="main">
+    <line>occupation. The leaves of that year</line>
+    <line>were withered before my work drew</line>
+    <line>near a close. And now every day shewed</line>
+    <line>me more plainly how well I had suc</line>
+    <line>ceeded. But my enthusiasm was</line>
+    <line>checked by my <del rend="strikethrough">am</del> anxiety and I appeared</line>
+    <line>rather like one doomed by slavery</line>
+    <line>to toil in the mines or any other</line>
+    <line>unwholsome trade than an artist</line>
+    <line>occupied in his favourite employment.</line>
+    <line>Every <del rend="strikethrough">nigh</del> night a slow fever oppressed</line>
+    <line>me and I became <mod>
+        <del rend="strikethrough">nevous</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">nervous</add>
+      </mod> to a <del rend="strikethrough">degre</del></line>
+    <line>most painful degree; a <del rend="strikethrough">fever</del> a dis-</line>
+    <line>ease I regretted <add hand="#pbs" place="superlinear">the</add> more because I had</line>
+    <line>hitherto enjoyed excellent health &amp;</line>
+    <line><del rend="strikethrough">my nerves</del>
+      <del rend="strikethrough">were fi</del> had always</line>
+    <line>boasted of <mod>
+        <del rend="strikethrough">my</del>
+        <add hand="#pbs" place="superlinear">the</add>
+      </mod> firm<add hand="#pbs" place="intralinear">ness</add>
+      <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">of my</add>
+      </mod> nerves. But I</line>
+    <line>believed that exercise and amusement</line>
+    <line>would soon <del rend="strikethrough">driv</del> drive away <mod>
+        <del rend="strikethrough">these</del>
+        <add hand="#pbs" place="superlinear">such</add>
+      </mod> sym-</line>
+    <line><del rend="strikethrough">p</del>-toms and I promised myself both</line>
+    <line>of these when my creation should be</line>
+    <line>comple<mod>
+        <del rend="overwritten">et</del>
+        <add hand="#pbs" place="intralinear">te</add>
+        <del rend="strikethrough">ed</del>
+      </mod>. <delSpan rend="strikethrough" spanTo="#c56-0044.01"></delSpan>I had<add place="superlinear">had
+        t</add> then determined to</line>
+    <line>go to Geneva as soon as this should be</line>
+    <line>done and a in the midst of my</line>
+    <line>family find eve</line><anchor xml:id="c56-0044.01"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="3847" lry="5342" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="21r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0045.xml" xml:id="ox-ms_abinger_c56-0045">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0045.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>75</line></zone>
+  <zone type="library"><line>21</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0045.04" unit="tei:head"></milestone>Chapter 7<hi rend="sup"><hi rend="underline">th</hi></hi><anchor xml:id="c56-0045.04"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">It was on a dreary night of November</line>
+    <line>that I beheld <del rend="strikethrough"><add hand="#pbs" place="superlinear">the frame on
+          whic</add></del> my man comple<mod>
+        <del rend="overwritten">at</del>
+        <add place="intralinear">te</add>
+        <add>ed</add>
+      </mod><add hand="#pbs" place="intralinear">,</add>. <del rend="strikethrough">And</del></line>
+    <line>with an anxiety that almost amount</line>
+    <line>ed to agony I collected instruments of life</line>
+    <line>around me <mod>
+        <del rend="strikethrough">and endeavour to</del>
+        <add place="superlinear">that I might</add>
+      </mod>
+      <mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">i</add>
+      </mod>nfuse a</line>
+    <line>spark of being into the lifeless thin<mod>
+        <del rend="overwritten">k</del>
+        <add place="intralinear">g</add>
+      </mod></line>
+    <line>that lay at my feet. It was already</line>
+    <line>one in the morning, the rain pattered</line>
+    <line>dismally against the window panes, &amp;</line>
+    <line>my candle was nearly burnt out, when</line>
+    <line>by the glimmer of the half extinguish-</line>
+    <line>ed light I saw the dull yellow eye of</line>
+    <line>the creature open.—It breathed hard,</line>
+    <line>and a convulsive motion agitated</line>
+    <line>its limbs.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del rend="strikethrough">But how</del> How can I describe
+      my</line>
+    <line>emotion at this catastrophe; or how deli</line>
+    <line>neate the wretch whom with such</line>
+    <line>infinite pains and care I had endeavoured</line>
+    <line>to form. His limbs were in proportion</line>
+    <line>and I had selected his features <del rend="strikethrough">h</del> as</line>
+    <line><mod>
+        <del rend="strikethrough">handsome</del>
+        <del rend="unmarked">.</del>
+        <anchor xml:id="c56-0045.01"></anchor>
+      </mod>
+      <mod>
+        <del rend="strikethrough">Handsome</del>
+        <add hand="#pbs" place="superlinear">Beautiful</add>
+      </mod>; Great God! His</line>
+    <line><mod>
+        <del rend="strikethrough">dun</del>
+        <anchor xml:id="c56-0045.02"></anchor>
+      </mod> skin scarcely covered the work of</line>
+    <line>muscles and arteries beneath; his hair</line>
+    <line>was<mod>
+      <add place="sublinear"><metamark function="displacement" xml:id="c56-0045.03">^</metamark></add>
+        </mod> flowing and his teeth of a pearly white</line>
+    <line>ness but these luxurianc<add place="intralinear">i</add>es only <del rend="strikethrough">fomed</del></line>
+    <line>formed a more horrid contrast with</line>
+    <line>his watry eyes that seemed almost of</line>
+    <line>the same colour as the dun white</line>
+    <line>sockets in which they were set,</line>
+  </zone>
+
+  <zone corresp="#c56-0045.01" type="left_margin">
+    <line><add><mod>
+          <del rend="strikethrough">handsome</del>
+          <add hand="#pbs" place="superlinear">beautiful.</add>
+        </mod></add></line>
+  </zone>
+
+  <zone corresp="#c56-0045.02" type="left_margin">
+    <line><add>yellow</add></line>
+  </zone>
+
+  <zone corresp="#c56-0045.03" type="left_margin">
+    <line><add hand="#pbs">of a lustrous black &amp;</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="3844" lry="5404" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="21v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0046.xml" xml:id="ox-ms_abinger_c56-0046">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0046.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>76</line></zone>
+  <zone type="main">
+    <line>his shrivelled complexion and strait</line>
+    <line>black lips.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The different accidents of life are</line>
+    <line>not so changeable as the feelings of hu</line>
+    <line>man nature. I had worked hard for</line>
+    <line>nearly two years for the sole purpose</line>
+    <line>of infusing <del rend="strikethrough">f</del> life into an inanimate</line>
+    <line>body. For this I had deprived m<retrace cause="unclear">y</retrace>self of</line>
+    <line>rest and <del rend="strikethrough">heath</del> health. I had desired</line>
+    <line>it with an ardour that far exceed<add hand="#pbs" place="intralinear">ed</add></line>
+    <line>moderation; but now that I had succeed</line>
+    <line>ed these dreams vanished and breathless</line>
+    <line>horror and disgust filled my heart.</line>
+    <line>Unable <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">to endure</add>
+      </mod> the aspect of the <mod>
+        <del rend="strikethrough">creature</del>
+        <add hand="#pbs" place="superlinear">being</add>
+      </mod> I</line>
+    <line>had created, I rushed out of the room and</line>
+    <line><mod>
+        <del rend="strikethrough">remained</del>
+        <add hand="#pbs" place="superlinear">continued</add>
+      </mod> a long time traversing my</line>
+    <line>bed chamber unable to compose my</line>
+    <line>mind to sleep. At lenght <mod>
+        <del rend="overwritten"><unclear>s</unclear></del>
+        <add place="intralinear">l</add>
+      </mod>assitude</line>
+    <line>succeeded to the tumult I had before</line>
+    <line>endured, and I threw myself on my</line>
+    <line>bed in my clothes endeavouring to seek</line>
+    <line>a <del rend="strikethrough">feew</del> few moments of forgetfullness.</line>
+    <line>But it was in vain; I slept indeed but</line>
+    <line><damage type="inkblot">I</damage> was disturbed by the wildest dreams–</line>
+    <line>I saw Elizabeth <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">in the bloom of health</add>
+      </mod> walking in the streets of</line>
+    <line>Ingolstadt; delighted &amp; surprised I embraced</line>
+    <line>her but as I imprinted the first kiss</line>
+    <line>on her lips they became lurid with</line>
+    <line>the hue of death; her features appeared</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="22r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0047.xml" xml:id="ox-ms_abinger_c56-0047">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0047.jp2"></graphic>
+  <zone type="pagination"><line>77</line></zone>
+  <zone type="library"><line>22</line></zone>
+  <zone type="main">
+    <line>to change and I thought that I held</line>
+    <line>the corpse of my dead mother in my arms<mod>
+        <del rend="overwritten">,</del>
+        <add hand="#pbs" place="intralinear">:</add>
+      </mod></line>
+    <line><mod>
+        <del rend="overwritten">a</del>
+        <add place="intralinear">A</add>
+      </mod> shroud envolepped her form &amp; I saw</line>
+    <line>the grave worms crawling in the folds of</line>
+    <line>the flannel; I started <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">from my sleep</add>
+      </mod> with horror, a</line>
+    <line><del rend="strikethrough">when I saw</del> cold dew covered my forehead</line>
+    <line>my teeth <del rend="strikethrough">ah</del> chattered and every limb</line>
+    <line><mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">became</add>
+      </mod> convul<mod>
+        <del rend="overwritten"><unclear extent="1" unit="chars"></unclear></del>
+        <add place="intralinear">s</add>
+      </mod>ed, when, by the dim and</line>
+    <line>yellow light of the moon as it forced</line>
+    <line>its way through the window shutters, I</line>
+    <line>beheld the wretch — the miserable</line>
+    <line>monster whom I had created; he hel<mod>
+        <del rend="overwritten"><unclear extent="1" unit="chars"></unclear></del>
+        <add place="intralinear">d</add>
+      </mod></line>
+    <line>up the curtain, and his eyes<add hand="#pbs" place="superlinear">—</add>; if
+      eyes</line>
+    <line>they may be called,<add place="superlinear">—</add> were fixed on
+      me–His</line>
+    
+    <line>jaws opened and he muttered <del rend="strikethrough"><add hand="#pbs" place="superlinear">in</add></del> some <mod>
+        <del rend="strikethrough">words</del>
+        <anchor xml:id="c56-0047.01"></anchor>
+      </mod></line>
+    <line>while a grin wrinkled his cheeks. He</line>
+    <line>might have spoken but I did not</line>
+    <line>hear — one <del rend="strikethrough">had</del> hand was stretched out</line>
+    <line>to detain me but I escaped and <del rend="strikethrough">ran</del></line>
+    <line>rushed down <mod>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">the</add></del>
+      </mod> stair<mod>
+        <retrace cause="fix" hand="#pbs">s</retrace>
+        <del rend="strikethrough"><add hand="#pbs" place="intralinear">case</add></del>
+      </mod> I took refuge in</line>
+    <line>a court-yard belonging to the house</line>
+    <line>which I inhabited; where I remained</line>
+    <line><anchor xml:id="c56-0047.03"></anchor>the rest of the night walking up and</line>
+    <line>down in the greatest agitation; listen</line>
+    <line>ing attentively, catching and fearing each</line>
+    <line>sound as if it were to announce the</line>
+    <line>arrival of the demoniacal corpse to</line>
+    <line>which I had so miserabl<mod>
+        <del rend="overwritten">e</del>
+        <add hand="#pbs" place="intralinear">y</add>
+      </mod> given life.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Oh! no mortal could support</line>
+    <line>the horror of that countenance. A</line>
+    <line>mummy <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">again</add>
+      </mod> endued with <mod>
+        <del rend="strikethrough">life</del>
+        <add hand="#pbs" place="superlinear">animation</add>
+      </mod> could not be</line>
+  </zone>
+  <zone corresp="#c56-0047.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0047.02"></addSpan>
+    <line>inarticulate</line>
+    <line>sounds</line><anchor xml:id="c56-0047.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0047.03" type="left_margin">
+    <line><add hand="#pbs">during </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="22v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0048.xml" xml:id="ox-ms_abinger_c56-0048">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0048.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>78</line></zone>
+  <zone type="main">
+    <line>so hideous as <hi rend="double-underline">He</hi>. I had gazed on him</line>
+    <line>while unfinished; <del rend="strikethrough">and I thought</del> he</line>
+    <line>was ugly then. But when those muscles</line>
+    <line>and joints were endued with motion</line>
+    <line>it became a thing <del rend="strikethrough">to</del> such as even Dante</line>
+    <line>could never have conceived.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I passed the night wretchedly–</line>
+    <line>sometimes my pulse<add place="intralinear">s</add> beat so quickly <mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">a</add>
+      </mod>nd</line>
+    <line>ha<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">r</add>
+      </mod>dly that I felt the palpitation of</line>
+    <line>every artery: At others I nearly sunk</line>
+    <line>to the ground <mod>
+        <del rend="strikethrough">with</del>
+        <add hand="#pbs" place="superlinear">thro</add>
+      </mod> languor and ex-</line>
+    <line>treme weakness. <mod spanTo="#c56-0048.04"></mod><del next="#c56-0048.05" rend="strikethrough">Surely so wretched a</del></line>
+    <line><add place="superlinear"><metamark function="displacement" xml:id="c56-0048.01">X</metamark></add><del rend="strikethrough" xml:id="c56-0048.05">creature as I never before existed.</del><anchor xml:id="c56-0048.04"></anchor></line>
+    <line>Dreams that had been my food and</line>
+    <line>rest for so long a space were now</line>
+    <line>become a hell to me– <del rend="strikethrough">I</del> and the</line>
+    <line>change was so rapid, the overthrow</line>
+    <line>so complete.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Morning — dismal and wet — at leng<mod>
+        <del rend="overwritten">ht</del>
+        <add place="intralinear">th</add>
+      </mod></line>
+    <line>dawned, and <del rend="strikethrough">to</del> discovered to my sleepless</line>
+    <line>and aching eyes the church of Ingols-</line>
+    <line>stadt its white steeple &amp; <add place="superlinear"><del rend="strikethrough">the</del> its</add> clock which</line>
+    <line>pointed to the sixth<del rend="strikethrough">e</del> hour. The porter</line>
+    <line>opened the gates of the court which had</line>
+    <line>that night been my assylum and I</line>
+    <line>issued into the streets, pacing <add hand="#pbs" place="superlinear">them</add>
+      with</line>
+    <line>quick steps as if I <del rend="strikethrough">ough</del> sought to</line>
+    <line><anchor xml:id="c56-0048.03"></anchor>the wretch whom I feared every turn-</line>
+    <line>ing in the street would present to</line>
+  </zone>
+
+  <zone corresp="#c56-0048.01" type="left_margin">
+    <addSpan spanTo="#c56-0048.02"></addSpan>
+    <line><metamark function="displacement">X</metamark></line>
+    <line>and mingled</line>
+    <line>with this hor</line>
+    <line>ror I felt the</line>
+    <line>bitterness of</line>
+    <line><del rend="strikethrough">disapp</del></line>
+    <line>disappointment:</line><anchor xml:id="c56-0048.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0048.03" type="left_margin">
+    <line><add hand="#pbs">avoid </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="23r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0049.xml" xml:id="ox-ms_abinger_c56-0049">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0049.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>79</line></zone>
+  <zone type="library"><line>23</line></zone>
+  <zone type="main">
+    <line>my view. I did not dare <del rend="strikethrough">to</del> return</line>
+    <line>to the appartment <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">which</add>
+      </mod> I inhabited but</line>
+    <line>felt impelled to hurry on although</line>
+    <line>wetted by the <del rend="strikethrough">drizzling</del> rain which poured</line>
+    <line>from a black and comfortless sky.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I continued walking in this manner</line>
+    <line>for some time endeavouring by bodily</line>
+    <line>exercise to ease the load that weighed</line>
+    <line>upon my mind. I traversed the streets</line>
+    <line>without any clear conception of where</line>
+    <line>I was or what I was doing: my heart</line>
+    <line>palpitated <mod>
+        <del rend="strikethrough">with</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">in the sickness of</add>
+      </mod> fear and I hurried</line>
+    <line>on with irregular steps not daring</line>
+    <line>to look about me,</line>
+    <milestone spanTo="#c56-0049.01" unit="tei:lg"></milestone>
+    <line><space extent="7" unit="chars"></space>"Like one who on a lon<mod>
+        <del rend="overwritten">s</del>
+        <add place="intralinear">es</add>
+      </mod>ome road</line>
+    <milestone spanTo="#a" unit="tei:l"></milestone>
+    <line rend="indent2">"doth walk in fear and dread</line>
+    <anchor xml:id="a"></anchor>
+    <line rend="indent2">"and having once turned round</line>
+    <line rend="right"><metamark>L</metamark>walks on</line>
+    <line rend="indent2">"<del rend="smear">wal</del>And turns no more his
+      head</line>
+    <line rend="indent2">"Because he knows a frightful</line>
+    <line rend="right"><metamark>L</metamark>fiend</line>
+    <line rend="indent2">"doth close behind him tread."<metamark>*</metamark></line>
+    <anchor xml:id="c56-0049.01"></anchor>
+    <line>Continueing thus, I came at lenght</line>
+    <line><mod>
+        <del rend="strikethrough">opposite</del>
+        <add hand="#pbs" place="superlinear">opposite to</add>
+      </mod> the Inn at which the dili</line>
+    <line>-gences and carriages usually stopped. Here</line>
+    <line>I paused I knew not why but remained</line>
+    <line>some minutes with my eyes fixed on</line>
+    <line>a coach that was coming towards me</line>
+    <line>from the other end of the street.</line>
+    <line>As <mod>
+        <del rend="strikethrough">I</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">it</add>
+      </mod> drew nearer I observed that it</line>
+    <line>was the Swiss diligence; it stopped</line>
+    <line>just where I was standing, and on</line>
+  </zone>
+  <zone type="left_margin">
+    <line><metamark>_______________</metamark></line>
+    <milestone spanTo="#c56-0049.03" unit="tei:note"></milestone>
+      <line><metamark>*</metamark>Coleridge's</line>
+      <line>"Ancient Mariner."</line>
+    <anchor xml:id="c56-0049.03"></anchor>
+    
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="23v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0050.xml" xml:id="ox-ms_abinger_c56-0050">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0050.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>80</line></zone>
+  <zone type="main">
+    <line>the doors being opened I perceived Henry</line>
+    <line>Clerval, who on <del><unclear>seee</unclear></del> seeing me instantly</line>
+    <line>sprung out.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"My dear Frankenstien," exclaimed
+      he</line>
+    <line>"How glad I am to see you; how</line>
+    <line>"fortunate <add hand="#pbs" place="superlinear">that</add> you should be here at</line>
+    <line>the <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">very</add>
+      </mod> moment of my alighting."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Nothing could equal my delight</line>
+    <line>on <del rend="strikethrough">see</del> seing Clerval: his presence</line>
+    <line>brought back to my thoughts my fa-</line>
+    <line>ther, Elizabeth and all those scenes</line>
+    <line>of home so dear to my recollection.</line>
+    <line>I grasped his hand, and in a moment</line>
+    <line>forgot my horror and misfortune.</line>
+    <line>I felt<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">suddenly, and</add>
+      </mod> for the first time <mod>
+        <del rend="strikethrough">for</del>
+        <add hand="#pbs" place="superlinear">during</add>
+      </mod>for</line>
+    <line>many months<add hand="#pbs">,</add> calm and serene</line>
+    <line>joy. I welcomed my friend therefore</line>
+    <line>in the most cordial manner &amp;</line>
+    <line>we walked towards my colledge.</line>
+    <line>Clerval <del rend="strikethrough">ran on</del>
+      <del rend="strikethrough">talked</del> continued</line>
+    <line>talking for some time about <mod>
+        <del rend="strikethrough">my</del>
+        <add hand="#pbs" place="superlinear">our mutual</add>
+      </mod></line>
+    <line>friends and his <add hand="#pbs" place="superlinear">own</add>good fortune in</line>
+    <line>being allowed to come to Ingolstadt.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"You may believe," said he, <del rend="strikethrough">"that</del></line>
+    <line>"it was not with<del rend="strikethrough">out</del> considerable</line>
+    <line>"trouble that I persuaded my</line>
+    <line>"father that it is not absolutely</line>
+    <line>"necessary for a merchant to</line>
+    <line>"know nothing except bookeeping</line>
+  </zone>
+  
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="24r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0051.xml" xml:id="ox-ms_abinger_c56-0051">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0051.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>81</line></zone>
+  <zone type="library"><line>24</line></zone>
+  <zone type="main">
+    <line>"and indeed I believe I left him</line>
+    <line>"incredulous to the last for his con</line>
+    <line>"stant answer to my applications</line>
+    <line>"was the same as <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">that of</add>
+      </mod>the dutch school</line>
+    <line>"master in the Vicar of Wakefield–</line>
+    <line><delSpan rend="strikethrough" spanTo="#c56-0051.01"></delSpan>'I live very well yet I do not
+      know</line>
+    <line>"Greek<anchor xml:id="c56-0051.01"></anchor> " I have ten thousand florins– <anchor xml:id="c56-0051.02"></anchor></line>
+    <line>"But his affection for me at</line>
+    <line>"length overcame his dislike for</line>
+    <line>"learning, and he permitted me</line>
+    <line>"to <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">under</add>
+      </mod>take a voyage <add hand="#pbs" place="superlinear">of discovery</add>to the land
+      of</line>
+    <line>"knowledge."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"And my father, brothers &amp; Eliza</line>
+    <line>beth" said I</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Very well &amp; very happy" replied</line>
+    <line>he "only a little uneasy that <del rend="strikethrough">yo</del></line>
+    <line>"they hear from you so seldom, &amp;</line>
+    <line>"by the bye, I mean to lecture you</line>
+    <line>"a little upon their account</line>
+    <line>"myself– But my dear Frankenstein"</line>
+    <line>continued he stopping short &amp; gazing </line>
+    <line>"full in my face "I did not before</line>
+    <line>"remark how very ill you are. So thin</line>
+    <line>"and pale; you appear as if you had</line>
+    <line>"been watching for several nights."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"You have guessed right" I replied</line>
+    <line>"I have lately been so engaged in</line>
+    <line>"<mod>
+        <del rend="strikethrough">several</del>
+        <add hand="#pbs" place="superlinear"><del rend="strikethrough">studious</del> one</add>
+      </mod> occupation<del rend="strikethrough">s</del> that I <mod>
+        <del rend="strikethrough">did</del>
+        <anchor xml:id="c56-0051.04"></anchor>
+      </mod></line>
+    <line>"not allow<mod>
+        <add hand="#pbs" place="intralinear">ed</add>
+      </mod><mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">myself</add>
+      </mod> sufficient rest as you</line>
+  </zone>
+  
+  <zone corresp="#c56-0051.02" type="left_margin">
+    <addSpan spanTo="#c56-0051.03"></addSpan>
+    <line>"<mod><restore type="smear_strikethrough"><del rend="strikethrough">a year</del></restore></mod><del rend="smear"><add place="superlinear">y<hi rend="sup">r</hi>.</add></del> with</line>
+    <line>"out greek –I</line>
+    <line>"eat heartily</line>
+    <line>"without greek</line>
+    <line><unclear>of-</unclear></line>
+    <anchor xml:id="c56-0051.03"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0051.04" type="left_margin">
+    <line><add hand="#pbs">have</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="24v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0052.xml" xml:id="ox-ms_abinger_c56-0052">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0052.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>82</line></zone>
+  <zone type="main">
+    <line>"see<add hand="#pbs" place="intralinear">;</add> but I hope<add hand="#pbs" place="intralinear">,</add> I sincerely hope all those</line>
+    <line>"occupations are at an end—I am free</line>
+    <line>"now I hope."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I trembled excessively: I could not</line>
+    <line>bear to think of<add hand="#pbs" place="intralinear">,</add> &amp; far less to
+      allude</line>
+    <line>to the occurences of the prece<del rend="strikethrough">e</del>ding</line>
+    <line>night. <del rend="strikethrough">I continued to walk</del>
+      <del rend="strikethrough">theire</del> I</line>
+    <line>walked therefore with a quick pace,</line>
+    <line>and we soon arrived at my colledge.</line>
+    <line>I then reflected – and the thought made</line>
+    <line>me shiver that the creature whom</line>
+    <line>I had left in my appartment might</line>
+    <line>be still there—alive and walking</line>
+    <line>about. I dreaded to see him but I</line>
+    <line>dreaded still more that Henry should</line>
+    <line>behold the monst<del rend="strikethrough">h</del>er. <del rend="strikethrough">I
+        therefore</del></line>
+    <line>entreat<mod>
+        <del rend="overwritten">ed</del>
+        <add hand="#pbs" place="intralinear">ing</add>
+      </mod> him <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">therefore</add>
+      </mod>to remain a few</line>
+    <line>minute<add hand="#pbs" place="intralinear">s</add> at the bottom of the</line>
+    <line>stairs, <del rend="strikethrough">while</del> I darted up towards</line>
+    <line>my own room. My hand was already</line>
+    <line>on the lock before I recovered</line>
+    <line>myself, when I paused and a cold</line>
+    <line>shivering came over me. I threw</line>
+    <line>the door open as children are accus</line>
+    <line>tomed to do when they expect</line>
+    <line>a spectre to stand in waiting for</line>
+    <line>them on the other side. But</line>
+    <line>nothing appeared. I stepped fearfully</line>
+    <line><damage type="ink_blot">in –</damage> the appartment was empty, and</line>
+    <line>my bedroon was also freed from its</line>
+    <line>hideous guest. I could hardly <del rend="strikethrough">belief</del></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="25r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0053.xml" xml:id="ox-ms_abinger_c56-0053">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0053.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>83</line></zone>
+  <zone type="library"><line>25</line></zone>
+  <zone type="main">
+    <line>believe that so great a good fortune</line>
+    <line>could have befallen me; but when</line>
+    <line>I <mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">became</add>
+      </mod> assured that my enemy had</line>
+    <line>indeed fled, I clapped my hands for</line>
+    <line>joy and ran down to Henr<retrace cause="unclear" hand="#pbs">y</retrace>.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We ascended into my room &amp; present</line>
+    <line>ly the servant brought breakfast:</line>
+    <line>but I was unable to contain my-</line>
+    <line>self. It was not joy only that possess-</line>
+    <line>-ed me,–I felt my flesh tingle with</line>
+    <line>the excess of sensitiveness and my</line>
+    <line>pulse beat rapidly. I was unable to</line>
+    <line>remain for a single instant in</line>
+    <line>the same place — I jumped over</line>
+    <line>the chairs, clapped my hand<add place="intralinear">s</add> &amp; laughed</line>
+    <line>aloud. Clerval at first attributed</line>
+    <line>my unusual spirits to joy <mod>
+        <del rend="strikethrough">at</del>
+        <add place="superlinear">on</add>
+      </mod> his</line>
+    <line>arrival– but when <del rend="strikethrough">saw</del> he observed</line>
+    <line>me <add place="sublinear"><metamark function="insert">^</metamark></add><add hand="#pbs" place="superlinear">more attentively</add>he saw a wildness in my eyes for</line>
+    <line>which he could not account and</line>
+    <line>my loud unrestrained heartless laugh</line>
+    <line>-ter frightened and astonished him.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">My dear Frankenstein," cried he "What</line>
+    <line>for God's sake is the matter <del rend="strikethrough">for</del> do not</line>
+    <line>laugh so – <del rend="strikethrough">What has</del> How ill you are!</line>
+    <line>What is the cause of all this?</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Do not ask me cried I, putting my</line>
+    <line>hand<add place="intralinear">s</add>
+      <del rend="strikethrough">fef</del> before my eyes, for I thought</line>
+    <line>I saw <hi rend="underline">the spectre</hi> glide into the</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="25v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0054.xml" xml:id="ox-ms_abinger_c56-0054">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0054.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>84</line></zone>
+  <zone type="main">
+    <line>room – <del rend="strikethrough">Wh</del> He can tell! Oh save me</line>
+    <line>save <del rend="strikethrough">I</del> me"– I imagined that the</line>
+    <line>monster seized me I struggled furious</line>
+    <line>ly &amp; fell down in a fit.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Poor Clerval! What must have been</line>
+    <line>his feelings. A <del rend="strikethrough">joy</del>
+      <del rend="strikethrough">meti</del> meeting which</line>
+    <line>he had anticipated with such joy so</line>
+    <line>strangely turned to bitterness. But I</line>
+    <line>did not witness his grief for I was</line>
+    <line><mod>
+        <del rend="strikethrough">senseless</del>
+        <add place="superlinear">lifeless</add>
+      </mod> and did not recover my</line>
+    <line>senses for <del rend="strikethrough">several</del> a long, long time.</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="26r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0055.xml" xml:id="ox-ms_abinger_c56-0055">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0055.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>85</line></zone>
+  <zone type="library"><line>26</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0055.02" unit="tei:head"></milestone>Chap. 7<anchor xml:id="c56-0055.02"></anchor></line>
+    <line>This was the commencement of a nervous</line>
+    <line>fever which confined me for several</line>
+    <line> months. <del rend="strikethrough">And</del> during all this time Henry was</line>
+    <line>my only nurse. I afterwards learned that</line>
+    <line><del rend="strikethrough">kn</del> knowing my fathers advanced age</line>
+    <line>and unfitness for so long a journey &amp;</line>
+    <line>wretched Elizabeth would be he</line>
+    <line>had spared them this <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">grief</add>
+      </mod> by <del rend="strikethrough">partly</del> conceal</line>
+    <line>ing the extent of my disorder. He knew</line>
+    <line>that I could not have a more kind</line>
+    <line>&amp; attentive nurse than himself, and</line>
+    <line>firm in the hope he had of my recovery</line>
+    <line>he did not doubt that instead of doing</line>
+    <line>harm he performed the kindest action</line>
+    <line>that he could towards them.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">But I was in reality very ill &amp;</line>
+    <line>surely nothing but the unbounded</line>
+    <line><del rend="strikethrough">affection</del> &amp; unremitting attentions of</line>
+    <line>my friend could have restored me to</line>
+    <line>life. The form of the mo<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">n</add>
+      </mod>ster on whom</line>
+    <line>I had bestowed life was for ever before</line>
+    <line><add hand="#pbs" place="superlinear">my</add>eyes, and I raved <del rend="strikethrough">incessant</del> incessantly</line>
+    <line>concerning him. <add place="superlinear">Doubtless</add>My words <del rend="strikethrough">no</del>
+      <del rend="strikethrough">doubt</del></line>
+    <line>surprised Henry – he at first believed</line>
+    <line>them the wanderings of my disordered</line>
+    <line>imagination but the <delSpan rend="strikethrough" spanTo="#c56-0055.01"></delSpan>continuance</line>
+    <line>and<anchor xml:id="c56-0055.01"></anchor> per<mod>
+        <del rend="overwritten">n</del>
+        <add hand="#pbs" place="intralinear">t</add>
+      </mod>inacity with which I conti</line>
+    <line>nually recurred to the same subject</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="26v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0056.xml" xml:id="ox-ms_abinger_c56-0056">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0056.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>86</line></zone>
+  <zone type="main">
+    <line><del rend="strikethrough">astonished him.</del><add hand="#pbs" next="#c56-0056.01" place="intralinear"><del rend="strikethrough">sta</del> persuaded him that my</add><anchor xml:id="c56-0056.02"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del rend="strikethrough">It was</del> by very slow
+      degrees and with</line>
+    <line>frequent relapses that alarmed &amp;</line>
+    <line>grieved my friend <del rend="strikethrough">that</del> I recovered. I remember</line>
+    <line>that the first time I was capable of</line>
+    <line>observing outward objects with any kind</line>
+    <line>of pleasure<add hand="#pbs" place="intralinear">,</add> I perceived that the</line>
+    <line>fallen leaves had disappeared and that</line>
+    <line>young buds were shooting forth from</line>
+    <line>the trees. It was a divine spring &amp; the</line>
+    <line>season no doubt contributed greatly</line>
+    <line>to my convalescence. I felt also senti</line>
+    <line>ments of joy and affection revive</line>
+    <line>in <add hand="#pbs" place="superlinear">my</add> bosom<add hand="#pbs" place="intralinear">,</add> my gloom disappeared and</line>
+    <line>in a short time I became as cheerful</line>
+    <line>as before I was attacked by the fatal</line>
+    <line>passion <del rend="strikethrough">that consumed me</del>.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Dearest Clerval," said I "How kind<add hand="#pbs" place="intralinear">,</add></line>
+    <line>"how very good you are to me. This</line>
+    <line>"whole winter instead of spending it</line>
+    <line>"<del rend="strikethrough">at</del> in study as you promised yourself,</line>
+    <line>"has been consumed in my sick room:</line>
+    <line>"how shall I ever repay you? I feel</line>
+    <line>"the greatest remorse for the disap</line>
+    <line>"pointment I have been the <del rend="strikethrough">c</del>occa</line>
+    <line>"sion of– But you will forgive me."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"You will repay me," replied Henry,</line>
+    <line>"if you do not dis compose yourself;</line>
+  </zone>
+  <zone corresp="#c56-0056.02" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0056.03" xml:id="c56-0056.01"></addSpan>
+    <line> disorder owed</line>
+    <line>its origin to</line>
+    <line>some uncommon</line>
+    <line>&amp; terrible</line>
+    <line>event</line>
+    <anchor xml:id="c56-0056.03"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="27r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0057.xml" xml:id="ox-ms_abinger_c56-0057">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0057.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>87</line></zone>
+  <zone type="library"><line>27</line></zone>
+  <zone type="main">
+    <line>"but get well as fast as you ca<mod>
+        <del rend="overwritten">m</del>
+        <add place="intralinear">n</add>
+      </mod>. And</line>
+    <line>"since you appear in such good</line>
+    <line>"spirits I may speak to you on</line>
+    <line>"one subject; may I not?"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I trembled; one subject! What</line>
+    <line>could it be? Could he allude to<mod>
+        <add place="sublinear"><metamark function="insert"><metamark function="insert">^</metamark></metamark></add>
+        <add place="superlinear">an</add>
+      </mod> object</line>
+    <line><anchor xml:id="c56-0057.01"></anchor>I dared not even think. Do not fright</line>
+    <line>"en yourself," said Clerval, who observed</line>
+    <line>my change of colour," I will not mention</line>
+    <line>"it if it agitates you. But your father</line>
+    <line>"and cousin would be so happy if they</line>
+    <line>"<del rend="strikethrough">rec</del> received a letter from you in</line>
+    <line>"your own hand – They hardly know how</line>
+    <line>"ill you have been<unclear>,</unclear> and are uneasy</line>
+    <line>"at your long silence."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Is that all? "I said smiling</line>
+    <line>"My dear Henry how could you suppose</line>
+    <line>"that my first thoughts would not</line>
+    <line>"fly towards<mod>
+        <del rend="strikethrough">that</del>
+        <add place="sublinear"><metamark function="insert">߶</metamark></add>
+        <add place="superlinear">those</add>
+      </mod> dear, dear friends</line>
+    <line>"whom I love and who are so deserving</line>
+    <line>"of my love."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"If this is your present temper"</line>
+    <line>said Henry "you will be glad perhaps</line>
+    <line>"to see a letter <del rend="strikethrough">here</del> that has been</line>
+    <line>"<del rend="strikethrough">ly</del> lying<del rend="strikethrough">e</del> here some
+        day<add hand="#pbs" place="intralinear">s</add> it is from your</line>
+    <line>"cousin I believe."</line>
+    <line rend="center"><milestone spanTo="#c56-0057.02" unit="tei:head"></milestone><add place="interlinear">Ch V– 113</add><anchor xml:id="c56-0057.02"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">He then put the following letter</line>
+    <line>into my hands.</line>
+    <line rend="indent2">"To V. Frankenstien</line>
+    <line rend="right">Geneva <mod>
+        <del rend="strikethrough">Apri</del>
+        <del rend="unmarked">l</del>
+        <add place="superlinear">March</add>
+      </mod> 18<hi rend="underline"><hi rend="sup">th</hi></hi> 17—</line>
+    <line>"My dear Cousin</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"I cannot describe to you the uneasi</line>
+  </zone>
+
+  <zone corresp="#c56-0057.01" type="left_margin">
+    <line><add>on whom </add></line>
+  </zone>
+
+  </surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="27v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0058.xml" xml:id="ox-ms_abinger_c56-0058">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0058.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>88</line></zone>
+  <zone type="main">
+    <line>ness we have all felt concerning your</line>
+    <line>health<unclear>.</unclear> We cannot help imagining that</line>
+    <line>your friend Clerval conceals the ex</line>
+    <line>tent of your disorder, for it is now</line>
+    <line>several months since we have seen</line>
+    <line>your handwriting and all this time</line>
+    <line>you have been obliged to dictate to</line>
+    <line>Henry – Surely Victor you must have</line>
+    <line>been very ill<mod>
+        <add place="superlinear">and this makes us very wretched as much so <metamark function="displacement" xml:id="c56-0058.01">X</metamark></add></mod>. My father was almost</line>
+    <line>persuaded <mod>
+        <del rend="strikethrough">of this</del>
+        <add hand="#pbs" place="superlinear">that you were indeed dangerously ill,</add>
+      </mod> and could hardly</line>
+    <line><add hand="#pbs" place="superlinear">be</add> re<mod>
+        <del rend="overwritten">f</del>
+        <add place="intralinear">st</add>
+      </mod>rain<add hand="#pbs" place="intralinear">ed</add> from <mod>
+        <add place="sublinear"><metamark function="insert">߶</metamark></add>
+        <add hand="#pbs" place="superlinear">undertaking</add>
+      </mod> a journey to Ingolstadt.</line>
+    <line><del rend="strikethrough">I</del>
+      <del next="#c56-0058.02">but I entreated him not</del><del rend="strikethrough"><add hand="#pbs" place="superlinear">to undertake it</add></del>
+      <del next="#c56-0058.03" rend="strikethrough" xml:id="c56-0058.02">because</del><mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">for</add></del>
+      </mod></line>
+    <line><del rend="strikethrough" xml:id="c56-0058.03">although</del>
+      <delSpan rend="vertical_line" spanTo="#c56-0058.04"></delSpan>his health is better now</line>
+    <line>tha<mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">n</add>
+      </mod> it has been since the death</line>
+    <line>of My beloved Aunt, yet <mod>
+        <del rend="strikethrough">tha</del>
+        <add place="superlinear">the</add>
+      </mod> fatigue</line>
+    <line>might <add hand="#pbs" place="superlinear">have</add><anchor xml:id="c56-0058.04"></anchor>
+      <del rend="strikethrough">make him very ill</del>
+      <del rend="strikethrough">and</del></line>
+    <line>Clerval always wr<mod>
+        <del rend="overwritten">o</del>
+        <add place="intralinear">i</add>
+      </mod>te<add place="intralinear">s</add> that you</line>
+    <line>were getting better <mod>
+        <del rend="strikethrough">and</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough">I</del>
+        <add place="superlinear">I <del rend="strikethrough">arden</del> eagerly</add>
+      </mod> hope you</line>
+    <line>will confirm this<add hand="#pbs" place="superlinear">intelligence</add> soon in your
+      own</line>
+    <line>handwriting for indeed, indeed Victor</line>
+    <line>we are all very <mod>
+        <del rend="strikethrough">uneasy</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">miserable on this account</add>
+      </mod>. Relieve</line>
+    <line>us from this fear and we shall</line>
+    <line>be the happiest creatures in the</line>
+    <line>world.– My uncles health <del rend="strikethrough">impro</del> is</line>
+    <line>now <mod>
+        <del rend="strikethrough">well &amp;</del>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear"><unclear>far</unclear></add></del>
+      </mod> vigorous that he appears</line>
+    <line>ten years younger since last</line>
+    <line>winter. Ernest also is so much im</line>
+    <line>proved, <del rend="strikethrough"><add hand="#pbs" place="intralinear">so</add></del> that
+      you would hardly</line>
+    <line>know him; he is now nearly sixteen</line>
+    <line>you know and has <del rend="strikethrough">quite</del> lost that</line>
+  </zone>
+  <zone corresp="#c56-0058.01" type="left_margin">
+    <addSpan spanTo="#c56-0058.05"></addSpan>
+    <line>nearly as <del rend="strikethrough">t</del></line>
+    <line>after the death</line>
+    <line>of your dear</line>
+    <line>mother</line>
+    <anchor xml:id="c56-0058.05"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="28a recto" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0059.xml" xml:id="ox-ms_abinger_c56-0059">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0059.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>89</line></zone>
+  <zone type="library"><line>28<add>a</add></line></zone>
+  <zone type="main">
+    <line>sickly appearance that he had</line>
+    <line>some years ago – he is quite well &amp; <hi rend="underline">hearty</hi></line>
+    <line>if I <del rend="strikethrough">y</del> may use that term for it is</line>
+    <line>very expressive.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"My uncle and I conversed <del rend="strikethrough">the</del></line>
+    <line>last night a long time about what</line>
+    <line><anchor xml:id="c56-0059.01"></anchor>Ernest <mod>
+        <del rend="strikethrough"><hi rend="underline">should be</hi></del>
+        <add place="superlinear">should follow</add>
+      </mod>. His constant</line>
+    <line>ill health when young has deprived</line>
+    <line><anchor xml:id="c56-0059.02"></anchor>of the habit of application and now</line>
+    <line>that he enjoys good health <del rend="strikethrough">we</del> he</line>
+    <line>is continually in the open air <del rend="strikethrough">on</del></line>
+    <line>climbing the hills or rowing on the</line>
+    <line>lake. I, therefore, proposed that</line>
+    <line>he should<add hand="#pbs" place="superlinear">be</add> a farmer which you</line>
+    <line>know cousin is a favourite scheme</line>
+    <line>of mine –A farmer's is a very healthy</line>
+    <line><del rend="strikethrough">&amp;</del> happy life; and the least hurtful</line>
+    <line>or rather the most benificial <del rend="strikethrough">of any</del></line>
+    <line>profession.<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">of any.</add>
+      </mod> My <del rend="strikethrough">father</del> uncle had an</line>
+    <line>idea of his being<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">educated as</add>
+      </mod> an advocate, <mod>
+        <del rend="overwritten">&amp;</del>
+        <add hand="#pbs" place="intralinear">that</add>
+      </mod> through</line>
+    <line>his interrest<add hand="#pbs" place="superlinear">he might become</add> a judge. But
+      besides that</line>
+    <line>he is not at all fit for such an</line>
+    <line>occupation, it is certainly <mod>
+        <del rend="strikethrough">better</del>
+        <add hand="#pbs" place="superlinear">more <del rend="strikethrough">honourable</del></add>
+        <add hand="#pbs" place="sublinear">creditable</add>
+      </mod> to</line>
+    <line><del rend="strikethrough">to</del> cultivate the earth for the suste</line>
+    <line>nance of man than <del rend="strikethrough">it</del> to be the</line>
+    <line>confid<mod>
+        <del rend="overwritten"><unclear extent="1" unit="chars"></unclear></del>
+        <add hand="#pbs" place="intralinear">a</add>
+      </mod>nt &amp; sometimes <mod>
+        <del rend="strikethrough">a helpmate</del>
+        <add hand="#pbs" place="superlinear">the accomplice</add>
+      </mod> of</line>
+    <line>
+      <mod>
+        <del rend="strikethrough">their</del>
+        <add hand="#pbs" place="superlinear">his</add>
+      </mod> vices; which is the employment<mod>
+        <add place="sublinear"><metamark function="displacement" xml:id="c56-0059.03">^</metamark></add>
+      </mod></line>
+    <line>of a Lawyer. <delSpan rend="strikethrough" spanTo="#c56-0059.05"></delSpan>And if he should
+      become</line>
+    <line>a judge<anchor xml:id="c56-0059.05"></anchor> I said that <mod>
+        <del rend="strikethrough">a</del>
+        <del rend="strikethrough">rich</del>
+        <add hand="#pbs" place="superlinear">the occupation of a prosperous</add>
+      </mod> farmer</line>
+    <line>if it were not a more honourable</line>
+  </zone>
+  <zone corresp="#c56-0059.01" type="left_margin">
+    <line><add> profession</add></line>
+  </zone>
+  <zone corresp="#c56-0059.02" type="left_margin">
+    <line><add> him</add></line>
+  </zone>
+  <zone corresp="#c56-0059.03" type="left_margin">
+    <line><add hand="#pbs">&amp; <unclear extent="5" unit="chars"></unclear></add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="28a verso" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0060.xml" xml:id="ox-ms_abinger_c56-0060">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0060.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>90</line></zone>
+  <zone type="main">
+    <line>it was at least a happier employ</line>
+    <line>ment than that of a judge, whose</line>
+    <line>misfortune it was always to meddle</line>
+    <line>with the dark side of human nature</line>
+    <line>My uncle smiled and said that I</line>
+    <line><del rend="strikethrough">ou<add place="intralinear">g</add>t</del> ought to be an
+      advocate myself;</line>
+    <line>which put an end to the conversation</line>
+    <line>on that subject</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><space extent="4" unit="chars"></space>And now I must tell you a little</line>
+    <line>story that will please you. Do you</line>
+    <line>not remember <del rend="strikethrough">Ju</del> Justine <del rend="strikethrough">Martin</del>?<anchor xml:id="c56-0060.01"></anchor></line>
+    <line>Perhaps you do not I will therefore</line>
+    <line>tell you her story in a few words. Mad.</line>
+    <line>Martin her Mother was a widow with</line>
+    <line>four children of whom <del rend="strikethrough">this</del> Justine</line>
+    <line>was the third. This girl had always been</line>
+    <line>the <del rend="strikethrough">favou</del> favourite of her father</line>
+    <line><mod>
+        <del rend="strikethrough">and</del>
+        <anchor xml:id="c56-0060.02"></anchor>
+        <del rend="strikethrough">by</del>
+        <add hand="#pbs" place="superlinear">thro</add>
+      </mod> an odd perversity her Mother</line>
+    <line><del rend="strikethrough">never</del> could <mod>
+        <del rend="strikethrough">bear</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">not endure</add>
+      </mod> her and after the</line>
+    <line>death of M. <mod>
+        <del rend="strikethrough">Martin</del>
+        <add place="superlinear">Moritz</add>
+      </mod> treated her very ill.</line>
+    <line>My aunt observed this, and when Justine</line>
+    <line>was <del rend="strikethrough">ten</del> twelve years old <unclear>too</unclear>
+      prevailed</line>
+    <line>on her mother to allow her to live</line>
+    <line>at our house.<add place="superlinear"><metamark function="displacement" xml:id="c56-0060.03">X</metamark></add>
+      <del rend="strikethrough">Where</del>
+      <delSpan rend="strikethrough" spanTo="#c56-0060.05"></delSpan>she was taught</line>
+    <line>all the duties of servant &amp; was very</line>
+    <line>kindly treated.<anchor xml:id="c56-0060.05"></anchor> I dare say that you now</line>
+    <line>remember all about it, for Justine</line>
+    <line>was a great favourite of yours, &amp; I</line>
+    <line><mod>
+        <del rend="strikethrough">remember</del>
+        <add hand="#pbs" place="superlinear">recollect</add>
+      </mod> you once said, that</line>
+  </zone>
+
+  <zone corresp="#c56-0060.01" type="left_margin">
+    <line><add></add>Moritz?</line>
+  </zone>
+
+  <zone corresp="#c56-0060.02" type="left_margin">
+    <line><add hand="#pbs"></add>but</line>
+  </zone>
+
+  
+  <zone corresp="#c56-0060.03" type="left_margin">
+    <addSpan hand="#pbs" next="#c56-0061.01" spanTo="#c56-0060.04"></addSpan>
+    <line><metamark function="displacement">X</metamark></line>
+    <line>The republican</line>
+    <line>institutions of our</line>
+    <line><del rend="strikethrough">state</del> country, have</line>
+    <line>produced simpler</line>
+    <line>&amp; happier manners</line>
+    <line>than those which</line>
+    <line>prevail in the</line>
+    <line>great monarchies</line>
+    <line>that surround it.</line>
+    <line><del rend="strikethrough">Ju Whilst</del></line>
+    <line>Hence there</line>
+    <line>is less dis-</line>
+    <anchor xml:id="c56-0060.04"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="28b recto" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0061.xml" xml:id="ox-ms_abinger_c56-0061">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0061.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>91</line></zone>
+  <zone type="library"><line>28b</line></zone>
+  <zone type="main">
+    <line>if you were <del rend="strikethrough">a</del> in an ill humour</line>
+    <line>one glance from Justine, could dissi</line>
+    <line>pate it <mod>
+        <del rend="strikethrough">from</del>
+        <add hand="#pbs" place="superlinear">for</add>
+      </mod> the same reason</line>
+    <line>that Ariosto gave concerning the</line>
+    <line>beauty of Angelica:– she looked so</line>
+    <line>frank hearted and happy. My Aunt</line>
+    <line><mod spanTo="#c56-0061.04"></mod><del rend="strikethrough">was very fond of her which</del>
+      <del next="#c56-0061.05" rend="strikethrough">caused</del>
+      <add hand="#pbs" place="superlinear">concieved an attachment for her, by which she <mod>
+          <add place="sublinear"><metamark function="insert">^</metamark></add>
+          <add hand="#pbs" place="superlinear">was</add>
+        </mod></add>
+      <add place="superlinear">induced</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0061.05">her to</del><mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">to</add>
+      </mod><anchor xml:id="c56-0061.04"></anchor> give her an<del rend="strikethrough">d</del>
+      education</line>
+    <line>superior to that which she <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">had</add>
+      </mod> at</line>
+    <line>first intended<mod>
+        <add hand="#pbs" place="intralinear">.</add>
+        <del rend="strikethrough">and she</del>
+        <add hand="#pbs" place="superlinear">This benefit</add>
+      </mod> was fully</line>
+    <line>repaid; <del rend="strikethrough">for</del> Justine was the most</line>
+    <line>grateful little creature in the</line>
+    <line>world. I do not mean that she</line>
+    <line>made any professions–I never</line>
+    <line>heard one pass her lips <del rend="strikethrough">w</del> but</line>
+    <line>you could see by her eye that</line>
+    <line>she almost adored her protectress.</line>
+    <line>Although very gay, and in many respects</line>
+    <line>inconsiderate, yet she paid the greatest</line>
+    <line>attention to every gesture of my Aunt–</line>
+    <line>she thought her the <mod>
+        <del rend="strikethrough">miracle</del>
+        <add hand="#pbs" place="superlinear">model</add>
+      </mod> of <mod spanTo="#c56-0061.06"></mod><add hand="#pbs" place="intralinear">all</add></line>
+    <line><del rend="strikethrough">perfection</del><add hand="#pbs" place="superlinear">excellence,</add><anchor xml:id="c56-0061.06"></anchor> and endeavoured to imi-</line>
+    <line>tate her words and even her man</line>
+    <line>ners, so that <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">even</add>
+      </mod> now she <del rend="strikethrough">very</del> often <mod>
+        <del rend="strikethrough">puts</del>
+        <anchor xml:id="c56-0061.03"></anchor>
+      </mod></line>
+    <line>me <del rend="strikethrough">in mind</del> of her. <delSpan rend="vertical_line" spanTo="#c56-0061.07"></delSpan><del rend="strikethrough">You did not</del> observe</line>
+    <line>all this, nor did I at the time but</line>
+    <line>it struck me afterwards when I</line>
+    <line>reflected on the subject.<anchor xml:id="c56-0061.07"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">When my dearest Aunt died every</line>
+    <line>one was too much occupied in their</line>
+  </zone>
+  
+  <zone type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0061.02" xml:id="c56-0061.01"></addSpan>
+    <line>-tinction<del rend="strikethrough">s</del> between</line>
+    <line>the classes into</line>
+    <line>which human</line>
+    <line>beings have</line>
+    <line>been divided,</line>
+    <line>&amp; the lower</line>
+    <line>orders being</line>
+    <line>neither so poor</line>
+    <line>nor so despised</line>
+    <line>are more</line>
+    <line>refined &amp; moral.</line>
+    <line>A servant at</line>
+    <line>Geneva does</line>
+    <line>not mean the</line>
+    <line>same thing as</line>
+    <line>a servant in</line>
+    <line>France or England</line>
+    <line>—Justine <del rend="strikethrough"><hi rend="underline">was</hi></del></line>
+    <line>thus recieved into</line>
+    <line>our family to</line>
+    <line>learn the duties</line>
+    <line>of a servant, which</line>
+    <line>in our fortunate</line>
+    <line>country does not</line>
+    <line>include a sacri</line>
+    <line>-fize of the digni</line>
+    <line>-ty of a human</line>
+    <line>being.<anchor xml:id="c56-0061.02"></anchor></line>
+  </zone>
+  <zone corresp="#c56-0061.03" type="left_margin">
+    <line><add hand="#pbs"></add>reminds</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="28b verso" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0062.xml" xml:id="ox-ms_abinger_c56-0062">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0062.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>92</line></zone>
+  <zone type="main">
+    <line>own <del rend="strikethrough">grif</del> grief to notice poor Justine</line>
+    <line>who had attended her during her <del rend="strikethrough">whole</del></line>
+    <line>illness with the greatest affection.</line>
+    <line>Poor Justine was very ill but other</line>
+    <line>tryals were reserved for her.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><space extent="3" unit="chars"></space>One by one her brothers &amp; sister</line>
+    <line>had died and her mother was now</line>
+    <line>with the exception of her neglected</line>
+    <line>daugher <del rend="strikethrough">was</del> left childless. The</line>
+    <line>conscience of the woman was troubled</line>
+    <line>and she began to think that the</line>
+    <line>deaths of her favourites was a judgement</line>
+    <line><add hand="#pbs" place="superlinear">sent</add>from heaven to <mod>
+        <del rend="strikethrough">punish</del>
+        <add hand="#pbs" place="superlinear">chastise</add>
+      </mod> her partialli<mod>
+        <del rend="overwritten">n</del>
+        <add place="intralinear">t</add>
+      </mod>y</line>
+    <line>she was a roman Catholic and I believe</line>
+    <line>her confessor encouraged the idea<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">which she had concieved.</add>
+      </mod>. Accor</line>
+    <line>dingly, a few Months after your depar</line>
+    <line>ture for <mod>
+        <del rend="overwritten">i</del>
+        <add place="intralinear">I</add>
+      </mod>ngolstadt, <del rend="strikethrough">sh</del> Justine was called</line>
+    <line>home by her repentant Mother. Poor</line>
+    <line>girl she wept when she quitted our house</line>
+    <line>she was much altered since the death</line>
+    <line>of my aunt: grief had given soft<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">n</add>
+      </mod>ess</line>
+    <line>and a winning mildness to her manners</line>
+    <line>which had before been remarkable</line>
+    <line>for vivacity. Nor <del rend="strikethrough">did</del> was her residence</line>
+    <line>at her Mothers house of a nature to</line>
+    <line>restore her gaiety. The poor <del rend="strikethrough">fo</del> wo</line>
+    <line>man was very vacillating in her</line>
+    <line>repentance. She sometimes begged</line>
+    <line>Justine to forgive her unkindness</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="29r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0063.xml" xml:id="ox-ms_abinger_c56-0063">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0063.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>93</line></zone>
+  <zone type="library"><line>29</line></zone>
+  <zone type="main">
+    <line>but much oftenor accused her</line>
+    <line>as having caused the deaths of <del rend="strikethrough">h</del> her</line>
+    <line>brothers &amp; sister. Perpetual fretting</line>
+    <line>at last threw Mad. Martin into</line>
+    <line>a decline, which at first encreased</line>
+    <line>her irritability<unclear>,</unclear> but she is now at</line>
+    <line>rest for ever; <del rend="strikethrough">for</del>
+      <del rend="strikethrough"><unclear>S</unclear></del> she <del rend="strikethrough">did</del>
+      died</line>
+    <line>on the first approach of cold at</line>
+    <line>the beginning of th<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">is</add>
+      </mod>
+      <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">last</add>
+      </mod> winter <delSpan rend="strikethrough" spanTo="#c56-0063.01"></delSpan>that</line>
+    <line>has just passed<anchor xml:id="c56-0063.01"></anchor>. Justine has</line>
+    <line>returned to us and I assure you</line>
+    <line>I love her tenderly. She is very clever</line>
+    <line>and extremely mild &amp; pretty and as</line>
+    <line>I mentioned before <del rend="strikethrough">she</del>
+      <del rend="strikethrough">is</del> her <mod>
+        <del rend="strikethrough">air</del>
+        <add hand="#pbs" place="superlinear">mein</add>
+      </mod> and</line>
+    <line><anchor xml:id="c56-0063.02"></anchor>expressions <del rend="strikethrough">are</del> continually
+      remind me</line>
+    <line>of my dear Aunt.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del rend="strikethrough">And</del> I must say a few words
+      to</line>
+    <line>you also, My dear Victor, of little darling</line>
+    <line>William. I wish you could see him. He</line>
+    <line>is very tall of his age with sweet laughing</line>
+    <line>blue eyes <del rend="strikethrough">and</del> dark eyelashes and curling</line>
+    <line>hair When he smiles two little dimples</line>
+    <line>appear on his cheeks which are rosy</line>
+    <line>with health — his chin comes down in</line>
+    <line>a beautiful oval <del rend="strikethrough">a</del> After this descrip</line>
+    <line>tion I can only say what our visitors</line>
+    <line>say a thousand times a day–'He is too</line>
+    <line>pretty for a boy'.<mod>
+        <add place="superlinear"><metamark function="displacement" xml:id="c56-0063.03">X</metamark></add>
+      </mod></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del rend="strikethrough">Miss Mansfeld</del> Now, dear
+      Victor I dare</line>
+  </zone>
+  <zone corresp="#c56-0063.02" type="left_margin">
+    <line><add hand="#pbs">her </add></line>
+  </zone>
+  <zone corresp="#c56-0063.03" type="left_margin">
+    <addSpan spanTo="#c56-0063.04"></addSpan>
+    <line>He has already</line>
+    <line>had one or two</line>
+    <line>little <hi rend="underline">wives</hi></line>
+    <line>but Louisa</line>
+    <line><del rend="strikethrough">M</del>
+      <del rend="strikethrough"><unclear>Caln</unclear></del> Biron</line>
+    <line><add hand="#pbs" place="intralinear">is</add> his favourite–</line>
+    <line>a pretty little</line>
+    <line>girl of five years old <del rend="strikethrough">to</del></line>
+    <anchor xml:id="c56-0063.04"></anchor>
+    
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="29v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0064.xml" xml:id="ox-ms_abinger_c56-0064">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0064.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>94</line></zone>
+  <zone type="main">
+    <line>say <del rend="strikethrough">I</del> you wish to be indulged in a little</line>
+    <line>gossip about your acquaintance. The</line>
+    <line>pretty Miss Mansfeld has already received</line>
+    <line><del rend="strikethrough">on</del>
+      <del rend="strikethrough">her</del> the congratulatory visits on her</line>
+    <line>approaching marriage with a young</line>
+    <line>Englishman, John <del rend="strikethrough">Mebourne</del> Mel-</line>
+    <line>bourne Esq. Her ugly sister Manon</line>
+    <line>married M. Hofland the rich banker last</line>
+    <line>autumn. Your favourite schoolfellow</line>
+    <line>Louis Manoir <del rend="strikethrough">ma</del> has suffered several</line>
+    <line>misfortunes <del rend="strikethrough">d</del> since the departure</line>
+    <line>of Clerval from Geneva <del rend="strikethrough">b</del> But he</line>
+    <line>has <del rend="strikethrough">atready</del> already recovered his spirits</line>
+    <line>and he reported to <del rend="strikethrough">m</del> be on the point</line>
+    <line>of marrying a very lively pretty french</line>
+    <line>woman— Mad. Tavernier –She is a widow</line>
+    <line>and much older than Manoir but</line>
+    <line>she is much <del rend="strikethrough">adv</del> admired and a</line>
+    <line>favourite with every body.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I have written myself into good spi</line>
+    <line>rits, dear Cousin yet I can not conclude</line>
+    <line>without again anxiously enquiring</line>
+    <line>concerning your health— Dear Victor, if</line>
+    <line>you are not very ill write yourself</line>
+    <line>and make your father and all</line>
+    <line>of us happy or— I cannot bear to <anchor xml:id="c56-0064.01"></anchor></line>
+    <line rend="right">Your very affectionate Cousin</line>
+    <line><milestone next="#c56-0064.04" spanTo="#c56-0064.03" unit="tei:seg"></milestone><del rend="strikethrough">dearrest</del> – dearest Victor<metamark function="separate">)</metamark><anchor xml:id="c56-0064.03"></anchor> Elizabeth Lavenza</line>
+    <line><milestone spanTo="#c56-0064.05" unit="tei:seg" xml:id="c56-0064.04"></milestone>write–<anchor xml:id="c56-0064.05"></anchor></line>
+  </zone>
+
+  <zone corresp="#c56-0064.01" type="left_margin">
+    <addSpan spanTo="#c56-0064.02"></addSpan>
+    <line>think <mod>
+        <del rend="strikethrough">of</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">on</add>
+      </mod> the</line>
+    <line>other side</line>
+    <line>of the question</line>
+    <line>my tears al-</line>
+    <line>ready flow</line>
+    <anchor xml:id="c56-0064.02"></anchor>
+  </zone>
+
+
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="30r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0065.xml" xml:id="ox-ms_abinger_c56-0065">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0065.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>95</line></zone>
+  <zone type="library"><line>30</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Dear, dear Elizabeth" I exclaimed</line>
+    <line>when I had read her letter"–I will write</line>
+    <line>instantly and relieve them from the</line>
+    <line>great pain they must feel."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">I wrote, and this exertion greatly</line>
+    <line>fatigued me<add hand="#pbs" place="intralinear">;</add> b<mod>
+        <del rend="overwritten">y</del>
+        <add place="intralinear">ut</add>
+      </mod> my convalescence <mod>
+        <del rend="strikethrough">was</del>
+        <anchor xml:id="c56-0065.01"></anchor>
+      </mod></line>
+    <line>commenced and <mod>
+        <del rend="strikethrough">went <add place="superlinear">on</add></del>
+        <add hand="#pbs" place="superlinear">proceeded</add>
+      </mod> regularly–in</line>
+    <line>another fortnight I was able to</line>
+    <line>leave my chamber.</line>
+    <line><metamark function="separate">______</metamark></line>
+  </zone>
+  <zone corresp="#c56-0065.01" type="left_margin">
+    <line><add>had</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="30v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0066.xml" xml:id="ox-ms_abinger_c56-0066">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0066.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>96</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0066.05" unit="tei:head"></milestone>Chap. 8<hi rend="sup"><hi rend="underline">th</hi></hi><anchor xml:id="c56-0066.05"></anchor></line>
+    <line>one of my first duties on my recovery was</line>
+    <line>to introduce Clerval to the <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">several</add>
+      </mod> professors of</line>
+    <line>the university. And in doing this I under</line>
+    <line>went <del rend="strikethrough">torments</del> a kind of rough usage</line>
+    <line><del rend="strikethrough">that</del> ill <del rend="strikethrough">befitten</del> befitt<mod>
+        <del rend="overwritten">ed</del>
+        <add hand="#pbs" place="intralinear">ing</add>
+      </mod> the wounds <add place="intralinear">that</add></line>
+    <line>my mind had sustained. Ever since the</line>
+    <line>fatal night – the end of my labours &amp;</line>
+    <line>the beginning of my misfortunes <del rend="strikethrough"><unclear>(</unclear></del> I
+      had</line>
+    <line>conceived a violent antipathy even to</line>
+    <line>the name of <mod>
+        <del rend="strikethrough">Ch</del>
+        <del rend="strikethrough">Chemistry</del>
+        <add place="superlinear">Natural Philosophy</add>
+      </mod>. When I was other</line>
+    <line>wise quite restored to health the sight of <add hand="#pbs" place="intralinear">a</add></line>
+    <line>Chemical instrument <mod spanTo="#c56-0066.01"></mod><delSpan rend="strikethrough" spanTo="#c56-0066.02"></delSpan>brought on</line>
+    <line>again<anchor xml:id="c56-0066.02"></anchor><add hand="#pbs" place="superlinear">renewed</add><anchor xml:id="c56-0066.01"></anchor> all <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">the agony of my</add>
+      </mod> my<add place="sublinear"><metamark function="insert">^</metamark></add> nervous
+      symtoms. <del rend="strikethrough">Lo</del></line>
+    <line>Henry saw this and had <mod>
+        <del rend="strikethrough">p</del>
+        <del rend="strikethrough">packed up</del>
+        <add place="superlinear">removed</add>
+      </mod></line>
+    <line>all my <mod>
+        <del rend="strikethrough">machines</del>
+        <del rend="strikethrough">in a chest</del>
+        <add place="superlinear">apparatus from my <del rend="strikethrough">che</del> view</add>
+      </mod> he had also</line>
+    <line>changed my <mod>
+        <del rend="strikethrough">room</del>
+        <add place="superlinear">ap<del rend="vertical_line">p</del>artment,</add>
+      </mod> for he perceived that</line>
+    <line>I had <mod>
+        <del rend="strikethrough">a</del>
+        <add hand="#pbs" place="superlinear">acquired</add>
+      </mod> dislike to the room which had</line>
+    <line>previously been my workshop. But these</line>
+    <line>cares of Clerval were <mod>
+        <del rend="strikethrough">thrown away</del>
+        <add hand="#pbs" place="superlinear">made of no avail</add>
+      </mod> when</line>
+    <line>I visited the professors. even my excellent</line>
+    <line>M. Waldman inflicted torture when</line>
+    <line>he praised with <del rend="strikethrough">the</del> kindness and warmth,</line>
+    <line>the astonishing progress that I had made</line>
+    <line>in the sciences. He soon perceived <mod>
+        <del rend="strikethrough">my</del>
+        <anchor xml:id="c56-0066.03"></anchor>
+      </mod></line>
+    <line> dislike<add hand="#pbs" place="intralinear">d</add>
+      <del rend="strikethrough">of</del> the subject, but not guessing</line>
+    <line>the real cause he attributed <mod>
+        <del rend="strikethrough">to</del>
+        <del rend="strikethrough">it</del>
+        <anchor xml:id="c56-0066.04"></anchor>
+      </mod></line>
+    <line>to modesty <del rend="strikethrough">on hearing myself praised</del></line>
+  </zone>
+  <zone corresp="#c56-0066.03" type="left_margin">
+    <line><add hand="#pbs">that I</add></line>
+  </zone>
+  <zone corresp="#c56-0066.04" type="left_margin">
+    <line><add hand="#pbs">my feelings</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="31r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0067.xml" xml:id="ox-ms_abinger_c56-0067">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0067.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>97</line></zone>
+  <zone type="library"><line>31</line></zone>
+  <zone type="main">
+    <line><del rend="strikethrough">he therefore</del><anchor xml:id="c56-0067.01"></anchor> changed the
+      subject from</line>
+    <line>my improvement, to the science itself,</line>
+    <line>with <del rend="strikethrough">an</del> a desire as I evidently saw</line>
+    <line>of drawing <del rend="strikethrough">friend</del> me out. <del rend="strikethrough">K</del>
+      <delSpan rend="strikethrough" spanTo="#c56-0067.02"></delSpan>Kind</line>
+    <line>friend he tortured me without<anchor xml:id="c56-0067.02"></anchor>
+      <delSpan rend="strikethrough" spanTo="#c56-0067.03"></delSpan>but</line>
+    <line>it<anchor xml:id="c56-0067.03"></anchor>
+      <del rend="strikethrough">How cruel is</del> What could I do?</line>
+    <line>He meant to please <del rend="strikethrough">and</del>
+      <del rend="strikethrough">me</del> &amp; he</line>
+    <line><mod>
+        <del rend="strikethrough">tortured</del>
+        <anchor xml:id="c56-0067.04"></anchor>
+      </mod> me <mod>
+        <del rend="strikethrough">it was</del>
+        <add place="superlinear">I felt</add>
+      </mod> as if he <del rend="strikethrough">had</del></line>
+    <line><anchor xml:id="c56-0067.05"></anchor>carefully one by one <del rend="strikethrough">placed</del>
+      in my</line>
+    <line>view those instruments which were</line>
+    <line><anchor xml:id="c56-0067.06"></anchor>afterwards used in putting me to a</line>
+    <line>slow and cruel <del rend="strikethrough">dre</del> death. I writhed</line>
+    <line>under his words, yet dared not shew</line>
+    <line><del rend="strikethrough">my</del> the pain I felt. Clerval, whose</line>
+    <line>eyes and feelings were always quick</line>
+    <line>in di<add hand="#pbs" place="intralinear">s</add>cerning the sensations of others</line>
+    <line>declined the subject alledging <mod>
+        <del rend="strikethrough">in</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">his</add>
+      </mod></line>
+    <line>ignorance &amp; the conversation took</line>
+    <line>a more general turn. I thanked him</line>
+    <line>from my heart, but I did not speak.</line>
+    <line>I plainly saw that he was surprised,</line>
+    <line>but he never attempted to draw</line>
+    <line>my secret from me, and although</line>
+    <line>I loved him with a mixture of</line>
+    <line><mod>
+        <del rend="strikethrough">love</del>
+        <anchor xml:id="c56-0067.07"></anchor>
+      </mod> and reverence that knew no</line>
+    <line>bounds, yet I could never <del rend="strikethrough"><unclear>pr</unclear></del>
+      persuade</line>
+    <line>myself to confide to him that event</line>
+    <line>which was so often present to my</line>
+    <line>thoughts, but which I feared the detail</line>
+    <line>to another would only impress more deeply.</line>
+  </zone>
+  <zone corresp="#c56-0067.01" type="left_margin">
+    <line><add>and</add></line>
+  </zone>
+  <zone corresp="#c56-0067.04" type="left_margin">
+    <line><add>tormented</add></line>
+  </zone>
+  <zone corresp="#c56-0067.05" type="left_margin">
+    <line><add>placed </add></line>
+  </zone>
+  <zone corresp="#c56-0067.06" type="left_margin">
+    <line><add>to be </add></line>
+  </zone>
+  <zone corresp="#c56-0067.07" type="left_margin">
+    <line><add>affection</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="31v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0068.xml" xml:id="ox-ms_abinger_c56-0068">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0068.jp2"></graphic>
+  <zone type="pagination"><line>98</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">M<hi rend="sup">r</hi>. Krempe was not <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">equally</add>
+      </mod> docile <mod spanTo="#c56-0068.01"></mod><del rend="strikethrough">yet</del><add place="superlinear">&amp;</add>
+      <delSpan rend="strikethrough" spanTo="#c56-0068.02"></delSpan>weak</line>
+    <line>as my illness had made me<anchor xml:id="c56-0068.02"></anchor><anchor xml:id="c56-0068.03"></anchor><anchor xml:id="c56-0068.01"></anchor> his harsh</line>
+    <line>blunt econiums gave me even more</line>
+    <line>pain <del rend="strikethrough">that</del> than the benevolent</line>
+    <line>approbation of M. Waldman —"Dam<mod>
+        <del rend="overwritten">m</del>
+        <add place="intralinear">n</add>
+      </mod></line>
+    <line>"the fellow," cried he "Why M<hi rend="sup">r</hi>. Clerval</line>
+    <line>"I tell you he has <del rend="strikethrough">beaut</del> outstript</line>
+    <line>"us all– ay stare if you please but</line>
+    <line>"it is nevertheless true – A youngster</line>
+    <line>"who but <del rend="strikethrough">two</del> three years ago believed</line>
+    <line>"Cornelius Agrippa <mod>
+        <del rend="strikethrough">to be</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">as firmly as the</add>
+      </mod> gospel has</line>
+    <line>"now set himself at the head of</line>
+    <line>"the university &amp; if he is not soon</line>
+    <line>"pulled down we shall all be out</line>
+    <line>"of countenance.—Aye, Aye, continued</line>
+    <line>"he observing my <mod>
+        <del rend="strikethrough">countenance</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">face</add>
+      </mod> ex</line>
+    <line>"pressive of suffering "Mr. <del rend="strikethrough">f</del> Franken-</line>
+    <line>"stein is modest an excellent quality in</line>
+    <line>"a young man; Young men should be</line>
+    <line>"diffident of themselves you know M<hi rend="sup"><hi rend="underline">r</hi></hi></line>
+    <line>"Clerval; I was myself when young but</line>
+    <line>"one soon grows out of that."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">M<hi rend="sup"><hi rend="underline">r</hi></hi> Krempe
+      had now commenced</line>
+    <line><mod>
+        <del rend="strikethrough">the subject of his own praise</del>
+        <add place="superlinear">an eulogy on himself</add>
+      </mod> and that</line>
+    <line>happily turned the conversation</line>
+    <line>from the subject that was so <mod>
+        <del rend="strikethrough">painful</del>
+        <add hand="#pbs" place="superlinear">agonizing</add>
+      </mod></line>
+    <line>to me.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Clerval was no natural philosopher.</line>
+    <line>His imagination was too vivid for</line>
+  </zone>
+  <zone corresp="#c56-0068.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0068.04"></addSpan>
+    <line>in my then</line>
+    <line>condition of</line>
+    <line>almost in-</line>
+    <line>-supportable</line>
+    <line>sensitiveness</line>
+    <anchor xml:id="c56-0068.04"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="32r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0069.xml" xml:id="ox-ms_abinger_c56-0069">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0069.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>99</line></zone>
+  <zone type="library"><line>32</line></zone>
+  <zone type="main">
+    <line>the minutiæ of science. <del rend="strikethrough">La</del> Lan</line>
+    <line>guages were his <mod>
+        <del rend="strikethrough">chief</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">principal</add>
+      </mod> study for he</line>
+    <line>wished to open a field for <mod>
+        <del rend="strikethrough"><add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">him</add></del>
+      </mod> self-instruc</line>
+    <line>tion on his return – <del rend="strikethrough">Greek</del> Persian</line>
+    <line><del rend="strikethrough">&amp;</del> Arabic &amp; Hebrew gained his atten</line>
+    <line>tion <mod>
+        <del rend="strikethrough">when</del>
+      <add place="superlinear"><metamark function="displacement" xml:id="c56-0069.01">X</metamark></add>
+        
+      </mod> he had become perfect</line>
+    <line>ly master of the Greek &amp; Latin langua</line>
+    <line>ges. For my own part idleness had</line>
+    <line>ever been irksome to me and</line>
+    <line>now that I wished to fly from reflec</line>
+    <line>tion and hated my former studies</line>
+    <line><del rend="strikethrough"><unclear>a</unclear></del> I found great relief in being
+      the</line>
+    <line>fellow pupil <mod>
+        <del rend="strikethrough">of</del>
+        <add place="superlinear">with</add>
+      </mod> my <del rend="strikethrough">fr</del> friend and</line>
+    <line><del rend="strikethrough">I not a only</del> found <mod>
+        <del rend="strikethrough">instruct</del>
+        <add place="superlinear">not only</add>
+      </mod> instruc</line>
+    <line>tion but consolation in the works of</line>
+    <line>the orientalists. <del rend="strikethrough">There is something soothing</del></line>
+    <line>Their melancholy is soothing and their</line>
+    <line>joy elevating to a degree I never before</line>
+    <line>experienced in <mod>
+        <del rend="strikethrough">reading</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">studying</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">any</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">the authors of</add>
+        <add place="superlinear">any</add>
+      </mod> other <mod>
+        <del rend="strikethrough">books.</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">country.</add>
+      </mod></line>
+    <line>When you read<del rend="strikethrough">s</del> their <del rend="strikethrough"><unclear>li</unclear></del> writings life</line>
+    <line>appears to consist in a warm sun</line>
+    <line>and gardens of roses – in the smiles &amp;</line>
+    <line><mod>
+        <del rend="strikethrough">tears</del>
+        <anchor xml:id="c56-0069.02"></anchor>
+      </mod> of a fair enemy and the fire</line>
+    <line>that consumes your own heart</line>
+    <line>How different from the man<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">l</add>
+      </mod>y &amp; <del rend="strikethrough">warlike</del></line>
+    <line><anchor xml:id="c56-0069.03"></anchor>poet<mod>
+        <del rend="overwritten"><unclear>s</unclear></del>
+        <add hand="#pbs" place="intralinear">ry</add>
+      </mod> of Greece &amp; Rome.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">Summer passed away in these</line>
+    <line><mod>
+        <del rend="strikethrough">studies</del>
+        <add><anchor xml:id="c56-0069.04"></anchor></add>
+      </mod> &amp; my return to Geneva was</line>
+    <line>fixed for the latter end of Autum<mod>
+        <del rend="overwritten">m</del>
+        <add place="intralinear">n</add>
+      </mod> but</line>
+  </zone>
+  <zone corresp="#c56-0069.01" type="left_margin">
+    <line><add hand="#pbs">so soon as <metamark function="displacement">X</metamark></add></line>
+  </zone>
+  <zone corresp="#c56-0069.02" type="left_margin">
+    <line><add>frowns</add></line>
+  </zone>
+  <zone corresp="#c56-0069.03" type="left_margin">
+    <line><add hand="#pbs">heroical </add></line>
+  </zone>
+  <zone corresp="#c56-0069.04" type="left_margin">
+    <line><add>occupations</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="32v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0070.xml" xml:id="ox-ms_abinger_c56-0070">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0070.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>100</line></zone>
+  <zone type="main">
+    <line>being delayed by several accidents winter</line>
+    <line>&amp; snow arrived, <del rend="strikethrough">and</del> the roads were</line>
+    <line>deemed impassable and my <mod>
+        <del>return</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">journey</add>
+      </mod></line>
+    <line><mod>
+        <del rend="strikethrough">delayed</del>
+        <anchor xml:id="c56-0070.01"></anchor>
+      </mod> untill the <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">ensuing</add>
+      </mod> spring. I felt this</line>
+    <line>delay very bitterly <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">for</add>
+      </mod> I longed to see my</line>
+    <line>native <mod>
+        <del rend="overwritten">c</del>
+        <add place="intralinear">t</add>
+      </mod>own and my beloved friends</line>
+    <line><del rend="strikethrough">and</del> my return had only been delayed</line>
+    <line>so long from an unwillingness to leave</line>
+    <line>Clerval in a strange town before he</line>
+    <line>had become acquainted with its in</line>
+    <line>habitants. The winter <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">however</add>
+      </mod> was <mod>
+        <del rend="strikethrough">however</del>
+        <add place="superlinear"><del type="strikethrough">s</del> spent</add>
+      </mod></line>
+    <line><del rend="strikethrough">a</del> cheerful<add place="intralinear">ly</add>
+      <del rend="strikethrough">one</del> and although the</line>
+    <line>spring was uncommonly late when</line>
+    <line>it came its beauty compensated</line>
+    <line><del rend="strikethrough">for</del> its dilatoriness. <del rend="strikethrough">Ma</del>
+      The month</line>
+    <line>of May was already <del rend="strikethrough">finis</del>
+      <del rend="strikethrough">end</del> com-</line>
+    <line>pleated, and I expected daily the</line>
+    <line>letter that was to fix the date of</line>
+    <line>my <mod>
+        <del rend="strikethrough">return</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">departure,</add>
+      </mod> When Henry proposed</line>
+    <line>a pedestrian tour in environs of</line>
+    <line>Ingolstadt that I might bid farewell</line>
+    <line>to the country I had so long in</line>
+    <line>habited.– I acceeded with pleasure to</line>
+    <line>this propos<mod>
+        <del rend="strikethrough">al</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">ition</add>
+      </mod>– I was fond of Exercise</line>
+    <line>and Clerval had always been my</line>
+    <line>favourite companion in <mod>
+        <del rend="strikethrough">j</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">the</add>
+      </mod> rambles</line>
+    <line>of this nature that I had taken</line>
+    <line>among the scenes of my native coun</line>
+  </zone>
+  <zone corresp="#c56-0070.01" type="left_margin">
+    <addSpan spanTo="#c56-0070.02"></addSpan>
+    <line>was</line>
+    <line>retarted</line>
+    <anchor xml:id="c56-0070.02"></anchor></zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="33r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0071.xml" xml:id="ox-ms_abinger_c56-0071">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0071.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>101</line></zone>
+  <zone type="library"><line>33</line></zone>
+  <zone type="main">
+    <line>try. We passed a fortnight in these</line>
+    <line>perambulations. My health and spirits had long</line>
+    <line>been restored and they gained add<mod>
+        <del rend="overwritten">i</del>
+        <add place="intralinear">it</add>
+      </mod>ional vigour</line>
+    <line>from the salubrious air<del rend="strikethrough">,<add place="superlinear"><metamark>X</metamark></add></del> I breathed, <mod>
+        <add place="superlinear"><metamark function="displacement" xml:id="c56-0071.01">X</metamark></add>
+      </mod> and the</line>
+    <line>conversation of my friend. Study had before</line>
+    <line>rendered me unsocia<mod>
+        <del rend="overwritten">ble</del>
+        <add hand="#pbs" place="intralinear">l,</add>
+      </mod> –I<add hand="#pbs" place="superlinear">had</add> shunned the <del rend="strikethrough">face</del></line>
+    <line>company of my fellow beings But Clerval</line>
+    <line>called forth the better feelings of my heart.</line>
+    <line>he again taught me to love the aspect</line>
+    <line>of nature and the cheerful faces of chil-</line>
+    <line>dren. Excellent Friend! How sincerely did you</line>
+    <line>love me and endeavour to elevate my</line>
+    <line>mind untill it was on a level with</line>
+    <line>your own. A selfish persuit<del rend="strikethrough">e</del> had cramp-</line>
+    <line>ed and narrowed <mod>
+        <del rend="strikethrough">it</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">me</add>
+      </mod> untill your gentle</line>
+    <line>ness &amp; affection warmed &amp; opened <mod>
+        <del rend="strikethrough">it</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">my senses</add>
+      </mod>. <delSpan spanTo="#c56-0071.03"></delSpan>and</line>
+    <line>now<anchor xml:id="c56-0071.03"></anchor> I <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">now</add></del>
+      </mod> became the same happy creature</line>
+    <line>who a few years ago, loving &amp; beloved by</line>
+    <line>all, had no sorrow or care – <del rend="strikethrough">I</del>
+      <del rend="strikethrough">and</del> when</line>
+    <line>happy <mod>
+        <del rend="strikethrough">so</del>
+        <del rend="strikethrough"><add place="superlinear">no</add></del>
+      </mod>
+      <delSpan spanTo="#c56-0071.04"></delSpan>soul was more fitted than mine</line>
+    <line>for feeling delight<anchor xml:id="c56-0071.04"></anchor>
+      <del rend="strikethrough">in</del> inanimate nature <add place="superlinear"><metamark function="displacement" xml:id="c56-0071.05">X</metamark></add> —</line>
+    <line>A serene sky <del rend="strikethrough">filled</del> and verdant<del rend="strikethrough">s</del> fields</line>
+    <line>filled me with extasy.–<mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">T</add>
+      </mod>he <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">present</add>
+      </mod> season was indeed</line>
+    <line>divine – the flowers of spring <mod>
+        <del rend="strikethrough">blossomed</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">bloomed</add>
+      </mod> in the</line>
+    <line>hedges while those of summer were al</line>
+    <line>ready in bud– I <del rend="strikethrough">dis</del> was not disturbed by</line>
+    <line>thoughts that during the preceeding</line>
+    <line>year pressed upon me not withstand-</line>
+    <line>ing my endeavours to throw them off<add hand="#pbs" place="sublinear">with an invincible
+        burthen.</add></line>
+    <line>Henry <del rend="strikethrough">a</del> rejoiced <del rend="strikethrough">im</del> in my
+      gaiety and</line>
+    <line>sincerely sympathized in my <mod>
+        <del rend="strikethrough">joy</del>
+        <add place="superlinear">feelings</add>
+      </mod> – he exer</line>
+  </zone>
+  <zone corresp="#c56-0071.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0071.02"></addSpan>
+    <line>the natural</line>
+    <line>incidents of</line>
+    <line>our progress<metamark>X</metamark></line>
+    <anchor xml:id="c56-0071.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0071.05" type="left_margin">
+    <addSpan spanTo="#c56-0071.06"></addSpan>
+    <line><metamark function="displacement">X</metamark>had the</line>
+    <line>power of bes</line>
+    <line><del rend="strikethrough">bo</del> towing on</line>
+    <line>me the most</line>
+    <line>delightful</line>
+    <line>sensations</line>
+    <anchor xml:id="c56-0071.06"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="33v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0072.xml" xml:id="ox-ms_abinger_c56-0072">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0072.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>102</line>
+  </zone>
+  <zone type="main">
+    <line>ted himself to amuse me, while he expressed</line>
+    <line>the feelings that <del rend="strikethrough">al</del> filled his <mod>
+        <del rend="strikethrough">mind</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">soul</add>
+      </mod>. The</line>
+    <line>resources of his mind on this occasion</line>
+    <line>were truly astonishing. <delSpan rend="strikethrough" spanTo="#c56-0072.01"></delSpan>As we rested
+      during</line>
+    <line>the sultry heat of noon he invented<anchor xml:id="c56-0072.01"></anchor></line>
+    <line>his conversation was full of imagination</line>
+    <line>and very often, in imitation of the persi</line>
+    <line>an &amp; Arabic writers, he invented tales</line>
+    <line>of <mod>
+        <del rend="strikethrough">great</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">wonderful</add>
+      </mod> fancy and interrest. At other</line>
+    <line>times he repeated my favourite poems</line>
+    <line>or drew me out into arguments which</line>
+    <line>he supported with great ingenuity.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">We returned <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">to our colledge</add>
+      </mod> on a sunday – the pea</line>
+    <line>sants were dancing and every one we</line>
+    <line>met appeared joyful and happy – my</line>
+    <line>own spirits were high and I bounded</line>
+    <line>along with <del rend="strikethrough">a</del> feelings of <mod spanTo="#c56-0072.02"></mod><del rend="strikethrough">hilarity</del>
+      <delSpan rend="strikethrough" spanTo="#c56-0072.03"></delSpan>unbound</line>
+    <line>ed<anchor xml:id="c56-0072.03"></anchor><anchor xml:id="c56-0072.04"></anchor><anchor xml:id="c56-0072.02"></anchor> joy and hilarity.</line>
+    
+    <line><add><metamark function="count">20</metamark></add></line>
+    <line><add><metamark function="count">15</metamark></add></line>
+  </zone>
+
+  <zone corresp="#c56-0072.04" type="left_margin">
+    <line><add>unbridled </add></line>
+  </zone>
+
+  
+    
+  
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="34r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0073.xml" xml:id="ox-ms_abinger_c56-0073">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0073.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>103</line></zone>
+  <zone type="library"><line>34</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0073.05" unit="tei:head"></milestone>Chap. 9<hi rend="sup"><hi rend="underline">th</hi></hi><anchor xml:id="c56-0073.05"></anchor></line>
+    <line>On my return I found the following letter</line>
+    <line>from my father.</line>
+    
+    <line rend="indent2">To V.–Frankenstein</line>
+    <line rend="right">Geneva – June 2<hi rend="sup"><hi rend="underline">n</hi>d</hi>– 17—</line>
+    <line>My dear Victor</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">You have probably waited impati-</line>
+    <line>ently <del rend="strikethrough">the</del> for <mod>
+        <del rend="strikethrough">the</del>
+        <add place="superlinear">a</add>
+      </mod> letter <del rend="strikethrough">which was</del> to fix</line>
+    <line><anchor xml:id="c56-0073.01"></anchor>your return and I was at first tempted</line>
+    <line>to write a few lines <mod spanTo="#c56-0073.02"></mod><del rend="strikethrough">only</del>
+      <del rend="unmarked">to</del>
+      <del rend="strikethrough">fix</del>
+      <del rend="strikethrough">that</del><add place="superlinear">merely mentioning the
+      day</add></line>
+    <line><del rend="strikethrough">date</del><anchor xml:id="c56-0073.03"></anchor><anchor xml:id="c56-0073.02"></anchor> – but that would be <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">a</add>
+        <del rend="strikethrough">very</del>
+      </mod> cruel <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">kindness</add>
+      </mod></line>
+    <line>and I dare not do it. What would <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">be</add>
+      </mod> your</line>
+    <line>surprise <del rend="strikethrough">be</del>, my son<del rend="strikethrough">e</del>, when
+      your ex</line>
+    <line>pected a happy and gay welcome to <del rend="strikethrough">heho</del></line>
+    <line>beh<mod>
+        <del rend="overwritten">o</del>
+        <add place="intralinear">e</add>
+      </mod>ld on the contrary tears and wretched</line>
+    <line>ness. And how, Victor, can I relate our</line>
+    <line>misfortune<mod>
+        <del rend="overwritten"><unclear>;</unclear></del>
+        <add place="intralinear">?</add>
+      </mod> absence cannot have rendered</line>
+    <line>you callous to our joys and griefs and how</line>
+    <line>can I inflict pain on an absent child.?</line>
+    <line>I wish to prepare you for the woeful</line>
+    <line>news but I know it is impossible; even</line>
+    <line>now your eye skims over the page to</line>
+    <line>seek the words which are to convey to</line>
+    <line>you the horrible tidings.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">William is dead! That sweet child</line>
+    <line>whose smiles delighted &amp; warmed me</line>
+    <line>who was so gentle yet so gay, Victor, he</line>
+    <line>is Murdered!</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I will not attempt to <del rend="strikethrough">o</del>
+      console you</line>
+    <line>but will simply relate the circumstances</line>
+    <line>of the transaction.</line>
+  </zone>
+  <zone corresp="#c56-0073.01" type="left_margin">
+    <line><add>the date of </add></line>
+  </zone>
+  <zone corresp="#c56-0073.03" type="left_margin">
+    <addSpan spanTo="#c56-0073.04"></addSpan>
+    <line>on which</line>
+    <line>I should</line>
+    <line>expect you</line>
+    <anchor xml:id="c56-0073.04"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="34v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0074.xml" xml:id="ox-ms_abinger_c56-0074">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0074.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>104</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Last thurday (May <del rend="strikethrough">26</del> 28<hi rend="underline">th</hi>) I; <mod>
+        <del rend="strikethrough">your<add place="superlinear">my</add></del>
+      </mod>
+      <del rend="strikethrough">cousin</del></line>
+    <line>my niece and your two brothers went to</line>
+    <line>walk in Plainpalais. The evening was</line>
+    <line>warm and serene, and we prolonged our</line>
+    <line>walk <del rend="strikethrough">fat</del> farther than usual. It was</line>
+    <line><del rend="strikethrough"><hi rend="underline">ale</hi></del> already dusk before we
+      thought of</line>
+    <line>returning <mod>
+        <del rend="strikethrough">When</del>
+        <add place="superlinear">and then</add>
+      </mod> we <mod>
+        <del rend="strikethrough">found</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">discovered</add>
+      </mod> that Ernest</line>
+    <line>and William who had gone on before,</line>
+    <line>were not to be found. We accordingly</line>
+    <line>rested on a seat untill they should</line>
+    <line>return. Presently Ernest came <del rend="strikethrough">up</del> &amp;</line>
+    <line>enquired for his brother he said that</line>
+    <line>he had been playing with <del rend="strikethrough">them</del> him</line>
+    <line>and that William had run away to</line>
+    <line>hide himself and that he had <mod>
+        <del rend="strikethrough">wai</del>
+        <add place="superlinear">vainly</add>
+      </mod></line>
+    <line>sought <del rend="strikethrough">fo</del> for him &amp; afterwards wai</line>
+    <line>ted a long time but that he did</line>
+    <line>not return.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">This rather alarmed us and we <del rend="strikethrough">sought</del></line>
+    <line>continued to search <add place="superlinear">for him</add>untill night fell<del rend="strikethrough">l</del>;</line>
+    <line><anchor xml:id="c56-0074.01"></anchor>Elizabeth conjectured that he might have</line>
+    <line>returned to the house: <del rend="strikethrough">but</del> he was</line>
+    <line>not there – We returned again with torches</line>
+    <line>for I could not rest when I thought my</line>
+    <line>sweet child had lost himself, and</line>
+    <line>was exposed to all the damps &amp; dews</line>
+    <line>of night; Elizabeth also suffered extreme</line>
+    <line>anguish. <del rend="strikethrough">We found him</del>
+      <mod>
+        <del rend="overwritten">a</del>
+        <add place="intralinear">A</add>
+      </mod>bout <mod>
+        <del rend="strikethrough">four</del>
+        <anchor xml:id="c56-0074.02"></anchor>
+      </mod></line>
+    <line>in the morning I discovered my lovely</line>
+    <line>boy whom the night before I had seen</line>
+  </zone>
+  <zone corresp="#c56-0074.01" type="left_margin">
+    <line><add>when </add></line>
+  </zone>
+  <zone corresp="#c56-0074.02" type="left_margin">
+    <line><add>seven</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="35r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0075.xml" xml:id="ox-ms_abinger_c56-0075">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0075.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>105</line></zone>
+  <zone type="library"><line>35</line></zone>
+  <zone type="main">
+    <line>blooming &amp; active in health stretch</line>
+    <line>ed on the grass livid and motionless–</line>
+    <line>the print of the murderers finger was</line>
+    <line>on his neck.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">He was conveyed home and the</line>
+    <line><del rend="strikethrough">extreme</del>
+      <del rend="strikethrough">wh</del>
+      <mod>
+        <del rend="strikethrough">misery</del>
+        <add place="superlinear">anguish</add>
+      </mod>
+      <del rend="strikethrough">agony</del> that was</line>
+    <line>visible in my countenance revealed</line>
+    <line>the secret to Elizabeth. She was <mod spanTo="#c56-0075.01"></mod><delSpan rend="strikethrough" spanTo="#c56-0075.02"></delSpan>extreme</line>
+    <line>ly<anchor xml:id="c56-0075.02"></anchor><anchor xml:id="c56-0075.03"></anchor><anchor xml:id="c56-0075.01"></anchor> earnest to see the corpse. <mod spanTo="#c56-0075.04"></mod><del rend="strikethrough">which</del><mod>
+        <add place="sublinear">^</add>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">I</add></del>
+      </mod><delSpan rend="strikethrough" spanTo="#c56-0075.05"></delSpan>for a</line>
+    <line>long time<anchor xml:id="c56-0075.05"></anchor>
+      <del rend="strikethrough">refused</del><anchor xml:id="c56-0075.07"></anchor><add hand="#pbs" place="superlinear" xml:id="c56-0075.06">attempted to prevent her</add><anchor xml:id="c56-0075.04"></anchor>
+      but <del rend="strikethrough"><unclear extent="1" unit="chars"></unclear></del> she persisted,</line>
+    <line>and entering the room where it lay</line>
+    <line><del rend="strikethrough">quickly</del> hastily examined the neck of</line>
+    <line>the victim and clasping her <del rend="strikethrough">hads</del></line>
+    <line>hands exclaimed— <del rend="strikethrough">Go</del> Oh God! I have</line>
+    <line>murdered <del rend="strikethrough">this sweet</del>
+      <del rend="strikethrough">babe</del><del rend="unmarked">.</del> my darling</line>
+    <line>infant.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">She fainted and was retored with</line>
+    <line>extreme difficulty; <del rend="strikethrough">and</del> when she again</line>
+    <line>lived it was only to weep and sigh–</line>
+    <line>She told me that that same evening</line>
+    <line>William had teazed her to let him</line>
+    <line><del rend="strikethrough">we</del>
+      <del rend="strikethrough">we</del> wear a very valuable miniature</line>
+    <line>she possessed of your Mother. This</line>
+    <line>picture is gone and was doubtless</line>
+    <line>the temptation which urged the mur</line>
+    <line>derer to the deed. We have no trace</line>
+    <line><del rend="strikethrough">of</del>
+      <del rend="strikethrough">Come my dear Victor</del>
+      <del rend="strikethrough">him</del> at</line>
+    <line>present of him, <mod>
+        <del rend="strikethrough">but</del>
+        <add hand="#pbs" place="superlinear">altho</add>
+      </mod> our exertions <mod>
+        <del rend="strikethrough">are</del>
+        <add hand="#pbs" place="superlinear">to discover him</add>
+      </mod></line>
+    <line>are unremitted; but they will not restore</line>
+    <line>my beloved William.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Come, dearest Victor, you alone can</line>
+  </zone>
+  <zone corresp="#c56-0075.03" type="left_margin">
+    <line><add>very</add></line>
+  </zone>
+  <zone corresp="#c56-0075.07" type="left_margin">
+    <line><add hand="#pbs" next="#c56-0075.06">At first I </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="35v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0076.xml" xml:id="ox-ms_abinger_c56-0076">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0076.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>106</line></zone>
+  <zone type="main">
+    <line>console Elizabeth, <mod>
+        <del rend="strikethrough">who</del>
+        <add hand="#pbs" place="superlinear">She</add>
+      </mod> weeps <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">continually</add>
+      </mod>&amp; accuses herself</line>
+    <line><del rend="strikethrough">of all how u</del>
+      <del rend="strikethrough">so</del> unjustly <mod>
+        <add place="sublinear"><metamark function="displacement" xml:id="c56-0076.01">^</metamark></add> <del rend="strikethrough">and</del></mod> yet her words</line>
+    <line><add corresp="#c56-0076.01" hand="#pbs" place="interlinear"><del rend="strikethrough">of th</del> as the cause of his death—</add></line>
+    <line>pierce my heart. We are all unhpappy</line>
+    <line>but <del rend="strikethrough">that</del> will not that be an additio</line>
+    <line>nal motive <mod>
+        <del rend="overwritten">to</del>
+        <add place="intralinear">for</add>
+      </mod> you, my <del rend="strikethrough">co</del> son, to <mod>
+        <del rend="strikethrough">come</del>
+        <add hand="#pbs" place="superlinear">return</add>
+      </mod></line>
+    <line>and be our comforter. Your dear Mother!</line>
+    <line>Alas, Victor! I now say Thank God she did</line>
+    <line>not live to witness <del rend="strikethrough">this grief</del><del rend="unmarked">–</del>
+      <mod>
+        <del rend="overwritten">T</del>
+        <add place="intralinear">t</add>
+      </mod>he cruel</line>
+    <line>miserable death of her youngest darling.</line>
+    <milestone unit="tei:p"></milestone>
+    <line><space extent="4" unit="chars"></space>Come, Victor; not brooding <del rend="strikethrough">w</del> thoughts</line>
+    <line>of vengeance against the assassin but</line>
+    <line>with feelings of peace and gentleness</line>
+    <line>that will heal instead of festering the</line>
+    <line><del rend="strikethrough">woul</del> wound<del rend="strikethrough">s</del> of our <del rend="strikethrough">soul</del> minds. Enter</line>
+    <line>the house of mourning, my son &amp; friend</line>
+    <line>but with kindness and affection</line>
+    <line>for those who love you &amp; not with</line>
+    <line>hat<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">red</add>
+      </mod> for your enemies.</line>
+    <line rend="indent2">Your affectionate &amp; afflicted father</line>
+    <line rend="right">Alphonse Frankenstein</line>
+    <line rend="indent5"><del rend="smear">Al</del></line>
+    <line><metamark function="separate">_______________</metamark></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Clerval who had watched my countenance</line>
+    <line>as I read this letter was surprised in observ-</line>
+    <line>ing the despair that succeeded to the joy</line>
+    <line>I expressed on receiving new<add hand="#pbs" place="intralinear">s</add> from my
+      friends.</line>
+    <line>I threw the letter on the table and covered</line>
+    <line>my face with my hands.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"My dear Frankenstien," exclaimed</line>
+    <line><del rend="strikethrough">hen</del> Henry when he saw me weep with</line>
+  </zone>
+  
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="36r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0077.xml" xml:id="ox-ms_abinger_c56-0077">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0077.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>107</line></zone>
+  <zone type="library"><line>36</line></zone>
+  <zone type="main">
+    <line>bitterness "are you always to be unhappy?</line>
+    <line>"my dear friend, what has happened?"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I motioned to him to <mod>
+        <del rend="strikethrough">read</del>
+        <add place="superlinear">take up</add>
+      </mod> the letter</line>
+    <line>while I walked up &amp; down the room</line>
+    <line>in the most extreme agitation. <delSpan rend="strikethrough" spanTo="#c56-0077.01"></delSpan>Clerval</line>
+    <line>read the letter<anchor xml:id="c56-0077.01"></anchor> – <del rend="strikethrough">and</del>
+      tears also <del rend="strikethrough">gush</del></line>
+    <line>gushed <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">also</add>
+      </mod> from <mod>
+        <del rend="strikethrough">his</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">the</add>
+      </mod> eyes <add place="superlinear"><metamark function="displacement" xml:id="c56-0077.02">X</metamark></add> –"I can offer you</line>
+    <line>"no consolation, my friend," said he <del rend="strikethrough">my</del></line>
+    <line>"your <mod>
+        <del rend="strikethrough">misfortune</del>
+        <add place="superlinear">disaster</add>
+      </mod> is irreperable.<del rend="strikethrough">"</del> What</line>
+    <line>"do you intend to do"?</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"To go instantly to Geneva<del rend="strikethrough">"</del> come</line>
+    <line>with me, Clerval, to order the horses"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">During our walk <del rend="strikethrough">C</del> Henry
+      endeav-</line>
+    <line>oured to raise my spirits– He did not</line>
+    <line>do this by the common topics of <del rend="strikethrough">conversatio</del></line>
+    <line>consolation but<del rend="strikethrough">t</del> by shew<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">i</add>
+      </mod>ng the truest</line>
+    <line>sympathy. "Poor William" said "that dear</line>
+    <line>"child he now sleeps with his angel</line>
+    <line>"mother. His friends mourn and weep but</line>
+    <line>"he is at rest he does not now feel the</line>
+    <line>"murderers grasp – a <del rend="strikethrough">green</del> sod covers his</line>
+    <line>"gentle form and he knows no pain–He</line>
+    <line>"can no longer be a subject for pity his</line>
+    <line>"survivors are the greatest sufferers and</line>
+    <line>"for them time is the<del rend="vertical_line">ir</del> only consolation.</line>
+    <line>"Those maxims of the stoics that death</line>
+    <line>"was no evil and that the mind of man</line>
+    <line>"ought to be sup<retrace cause="unclear">er</retrace>ior to <del rend="strikethrough">that</del> despair</line>
+    <line>"on the eternal absence of a beloved</line>
+    <line>"object ought not to be urged – even</line>
+    <line>"Cato wept over the dead body of his</line>
+    <line>"brother."</line>
+  </zone>
+  <zone corresp="#c56-0077.02" type="left_margin">
+    <addSpan spanTo="#c56-0077.03"></addSpan>
+    <line><metamark function="displacement">X</metamark>of Clerval</line>
+    <line>as he read the</line>
+    <line>account of my</line>
+    <line>misfortune</line>
+    <anchor xml:id="c56-0077.03"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="36v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0078.xml" xml:id="ox-ms_abinger_c56-0078">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0078.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>108</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Clerval spoke this as we huried</line>
+    <line><del rend="strikethrough">thou</del> through the streets the words</line>
+    <line>impressed themselves on my <del rend="strikethrough">memor</del></line>
+    <line>mind and I remembered them afterwads</line>
+    <line>in solitude. <del rend="strikethrough">As soon</del> But now, as soon</line>
+    <line>as the horses arrived I hurried into</line>
+    <line>a Cabriolet and <del rend="strikethrough">left Ingo</del> bad fare</line>
+    <line>well to my friend.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">My journey was very melancholy.</line>
+    <line>At first I wished to hurry on for I longed</line>
+    <line>to console &amp; sympathize <add place="superlinear">with</add>my loved and</line>
+    <line>sorrowing friends but when I drew</line>
+    <line>near my <del rend="strikethrough">t</del> native town I sla<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">c</add>
+      </mod>kened</line>
+    <line>my <mod>
+        <del rend="strikethrough">pace</del>
+        <add hand="#pbs" place="superlinear">progress</add>
+      </mod>. <del rend="strikethrough">I</del>
+      <del rend="strikethrough">C</del> I could hardly sustain</line>
+    <line>the multitude of feelings that</line>
+    <line><del rend="strikethrough">crowed</del> crowded into my mind. I passed</line>
+    <line>though <del rend="strikethrough">scee</del> scenes familiar to my youth</line>
+    <line>but which I had not seen for nearly</line>
+    <line>five years, how altered every thing might</line>
+    <line>be <mod>
+        <del rend="strikethrough">during</del>
+        <add hand="#pbs" place="superlinear">since</add>
+      </mod>that time<add hand="#pbs" place="intralinear">?</add> one great sudden</line>
+    <line>and desolating change had taken place</line>
+    <line>but a thousand little circumstance</line>
+    <line>might have <mod>
+        <del rend="strikethrough">sapped</del>
+        <del rend="strikethrough"><add place="superlinear">worked</add></del>
+      </mod> by <del rend="strikethrough">degreed</del> degrees</line>
+    <line><mod>
+        <del rend="strikethrough">worked</del><add place="superlinear">worked other<del rend="strikethrough">s</del></add>
+      </mod>
+      <del rend="strikethrough"><unclear>t</unclear></del>
+      <del rend="strikethrough">as great</del> alterations <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">which</add>
+      </mod> although</line>
+    <line>it might be done more tranquilly would</line>
+    <line>not be less de<mod>
+        <del rend="overwritten">s</del>
+        <add place="intralinear">c</add>
+    </mod>isive. Fear overc<retrace cause="unclear">a</retrace>me me</line>
+    <line>I dared <del rend="strikethrough">had</del>
+      <del rend="strikethrough">N</del> not advance <del rend="strikethrough">fea</del>
+      dreading</line>
+    <line>a <del rend="strikethrough">thoug</del> thousand nameless evils that</line>
+    <line>made me tremble <mod>
+        <del rend="strikethrough">while</del>
+        <add place="superlinear">although</add>
+      </mod> I <mod>
+        <del rend="strikethrough">could not</del>
+        <add place="superlinear">was unable</add>
+      </mod></line>
+  </zone>
+  
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="37r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0079.xml" xml:id="ox-ms_abinger_c56-0079">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0079.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>109</line></zone>
+  <zone type="library"><line>37</line></zone>
+  <zone type="main">
+    <line>to define them.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I remained <del rend="strikethrough">thus</del> at
+      Lausanne for</line>
+    <line>two days not daring to proceed. I contem</line>
+    <line>plated the lake – the waters were</line>
+    <line>placid – all around was calm and the</line>
+    <line>Snowy mountains the "Palaces of Nature"<add place="superlinear"><metamark function="displacement" xml:id="c56-0079.01">X</metamark></add></line>
+    <line>were not changed. By degrees, this calm</line>
+    <line>and heavenly scene restored me, and I</line>
+    <line><mod>
+        <del rend="strikethrough">proceeded</del>
+        <anchor xml:id="c56-0079.03"></anchor>
+        <add hand="#pbs" place="superlinear" xml:id="c56-0079.02">journey</add>
+      </mod> towards Geneva. The road</line>
+    <line>ran by the side of the lake which</line>
+    <line>became narrower as I approached</line>
+    <line>my native town – I discovered more</line>
+    <line>distinctly the black sides of Jura;</line>
+    <line>and the <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">bright</add>
+      </mod>summit of Mount Blanc–</line>
+    <line>I wept like a child– Dear mountains</line>
+    <line>my own beautiful lake how do you</line>
+    <line>welcome your wanderer Your sum</line>
+    <line>mits are clear the sky and lake</line>
+    <line>are blue is this <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">to</add>
+      </mod>prognosticate peace</line>
+    <line>or to mock<retrace cause="fix" hand="#pbs"><add hand="#pbs" place="superlinear">at</add></retrace> my unhappiness?</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I fear, my friend <mod>
+        <del rend="strikethrough">to</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">that I shall</add>
+      </mod> render myself</line>
+    <line>tedious by dwelling on these preliminary</line>
+    <line>circumstances but they were days of</line>
+    <line>comparative happiness and I <mod>
+        <del rend="strikethrough">dwell</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">think</add>
+      </mod></line>
+    <line>o<mod>
+        <del rend="overwritten">n</del>
+        <add place="intralinear">f</add>
+      </mod> them with pleasure – My Country</line>
+    <line>my beloved country Who <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">but a native</add>
+      </mod>can tell the</line>
+    <line>delight I took in again beholding thy</line>
+    <line>st<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">r</add>
+      </mod>eams thy mountains and more than</line>
+    <line>all thy lovely lake <del rend="strikethrough">and</del></line>
+  </zone>
+  <zone corresp="#c56-0079.01" type="left_margin">
+    <line><add><metamark function="displacement">X</metamark><del rend="strikethrough">Lo<hi rend="underline">rd Byron</hi></del></add></line>
+  </zone>
+  <zone corresp="#c56-0079.03" type="left_margin">
+    <line><add hand="#pbs" next="#c56-0079.02">continued my </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="37v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0080.xml" xml:id="ox-ms_abinger_c56-0080">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0080.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>1<mod><del rend="overwritten">0</del><add place="intralinear">1</add></mod>0</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Yet as I drew nearer home grief and</line>
+    <line>fear overcame me – night also closed</line>
+    <line>round <del rend="strikethrough">me</del> and when I could hardly</line>
+    <line>see the dark mountains I felt still</line>
+    <line>more gloomily I pictured <del rend="strikethrough">to mysel</del><del rend="unmarked">f</del> every</line>
+    <line>evil and persuaded myself that</line>
+    <line><del rend="strikethrough">the</del>
+      <del rend="strikethrough">most</del> I was destined to become</line>
+    <line>the most w<del rend="strikethrough">h</del>retched of human beings–</line>
+    <line>Alas! I <del rend="strikethrough">prho</del> prophesied truly and</line>
+    <line>failed only<add hand="#pbs" place="superlinear">in one single circumstance:</add> that in
+      all the misery</line>
+    <line>I imagined and dreaded, I did not conceive</line>
+    <line><del rend="strikethrough">of</del> the hundredth part of the anguish</line>
+    <line><mod>
+        <del rend="strikethrough">I</del>
+        <anchor xml:id="c56-0080.01"></anchor>
+      </mod> destined to <del rend="strikethrough">feel</del><del rend="unmarked">.</del>
+      endure.</line>
+  </zone>
+  <zone corresp="#c56-0080.01" type="left_margin">
+    <line><add>I was</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="38r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0081.xml" xml:id="ox-ms_abinger_c56-0081">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0081.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>111</line></zone>
+  <zone type="library"><line>38</line></zone>
+  
+  <zone type="main">
+    <line><milestone spanTo="#c56-0081.04" unit="tei:head"></milestone>Chapter 10<hi rend="sup"><hi rend="underline">th</hi></hi><anchor xml:id="c56-0081.04"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Night had closed <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">in</add>
+      </mod> when I arrived <del rend="strikethrough">and</del></line>
+    <line>the gates of Geneva were already <mod>
+        <del rend="strikethrough">closed</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">shut</add>
+      </mod> and</line>
+    <line>I determined to remain that night at</line>
+    <line>Secheron <anchor xml:id="c56-0081.01"></anchor>. The <mod>
+        <del rend="strikethrough">night</del>
+        <add hand="#pbs" place="superlinear">sky</add>
+      </mod> was <mod>
+        <del rend="strikethrough">very fine</del>
+        <add hand="#pbs" place="superlinear">serene</add>
+      </mod> and</line>
+    <line><del rend="strikethrough">unable</del> as I was unable to rest I resolved</line>
+    <line>to <mod>
+        <del rend="strikethrough">walk toward</del>
+        <del rend="unmarked">s</del>
+        <add hand="#pbs" place="superlinear">visit</add>
+      </mod> the spot where m<mod>
+        <del rend="overwritten"><unclear extent="1" unit="chars"></unclear></del>
+        <add hand="#pbs" place="intralinear">y</add>
+      </mod></line>
+    <line>poor William had been murdered;</line>
+    <line>as I walked I perceived a storm collecting</line>
+    <line>on the other side of the lake. I saw the</line>
+    <line>lightnings play in the most beautiful</line>
+    <line>figures and gained a summit</line>
+    <line>that I might observe <mod>
+        <del rend="strikethrough">the</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">its</add>
+      </mod> progress.</line>
+    <line>It advanced <del rend="strikethrough">slowly and</del> and I soon felt</line>
+    <line>the rain coming slowly in large</line>
+    <line>drops but its violence quickly encreased.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I quitted my seat and walk on,</line>
+    <line>although the darkness and storm aug</line>
+    <line>mented every minute and the thunder</line>
+    <line>burst <del rend="strikethrough">violently over</del> with a terrific</line>
+    <line>crash over my head — <delSpan rend="strikethrough" spanTo="#c56-0081.03"></delSpan>William I
+      ex</line>
+    <line>cried aloud – dear angel this is thy</line>
+    <line>funeral this thy dirge.<anchor xml:id="c56-0081.03"></anchor> It was echoed</line>
+    <line>from Salêve <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">the Jura</add>
+      </mod> and the Alps of Savoy—</line>
+    <line>vivid flashes of lightning dazzled my</line>
+    <line>eyes, <del rend="strikethrough">and</del> illumin<mod>
+        <del rend="overwritten">ed</del>
+        <add hand="#pbs" place="intralinear">ating</add>
+      </mod> the lake; <del rend="strikethrough">and</del></line>
+    <line>then for an instant every thing</line>
+    <line>seemed of a pitchy <mod>
+        <del rend="strikethrough">black</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">darkness</add>
+      </mod>
+      <del rend="strikethrough">til</del> untill</line>
+    <line>the eye recovered itself from the <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">preceeding</add>
+      </mod> flash.</line>
+    <line><del rend="strikethrough">A</del> The storm as is often the case in</line>
+  </zone>
+  <zone corresp="#c56-0081.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0081.02"></addSpan>
+    <line>a village</line>
+    <line>half a league</line>
+    <line>to the east</line>
+    <line>-ward of the city</line>
+    <anchor xml:id="c56-0081.02"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="38v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0082.xml" xml:id="ox-ms_abinger_c56-0082">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0082.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>112</line></zone>
+  <zone type="main">
+    <line><mod>
+        <del rend="strikethrough">that country</del>
+        <add place="superlinear">Switzerland</add>
+      </mod> appeared at once in various</line>
+    <line>parts of the heavens. The most violent</line>
+    <line>storm <mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">hung</add>
+      </mod> exactly <del rend="strikethrough">noth</del> north of the town</line>
+    <line><mod>
+        <del rend="strikethrough">and at</del>
+        <add hand="#pbs" place="superlinear">over</add>
+      </mod> that part <mod>
+        <del rend="strikethrough">where</del>
+        <add hand="#pbs" place="superlinear">of the</add>
+      </mod> lake <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough">turns</del>
+        <add hand="#pbs" next="#c56-0082.01" place="superlinear">which <del rend="strikethrough">at</del></add>
+        <add hand="#pbs" place="sublinear" xml:id="c56-0082.01">lies between</add>
+      </mod></line>
+    <line>the promontory of Belrive and <del next="#c56-0082.03" rend="strikethrough">changing</del><add hand="#pbs" next="#c56-0082.04" place="superlinear">the</add></line>
+    <line><add hand="#pbs" place="superlinear" xml:id="c56-0082.04">village of Copet</add>
+      <delSpan rend="strikethrough" spanTo="#c56-0082.05"></delSpan>its course from South to north
+      which</line>
+    <line>it before p<mod>
+        <del rend="overwritten"><unclear>e</unclear></del>
+        <add place="intralinear">u</add>
+      </mod>rsue<mod>
+        <add place="sublinear">s</add>
+        <del rend="strikethrough">d</del>
+      </mod> proceeds from west</line>
+    <line>to east<anchor xml:id="c56-0082.05"></anchor> — another storm enlightened</line>
+    <line>Jura with faint flashes and another</line>
+    <line><del rend="strikethrough">appeared</del> darkened and sometimes</line>
+    <line>disclosed the Mole – <del rend="strikethrough">the name of</del></line>
+    <line>a peaked mountain to the east of</line>
+    <line>the lake.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">While I watched the storm – so beauti</line>
+    <line>ful yet terrific I wandered <del rend="strikethrough">listlessly</del></line>
+    <line>on with a hasty step – <del rend="strikethrough">I felt that</del></line>
+    <line>th<mod>
+        <del rend="overwritten">is</del>
+        <add hand="#pbs" place="intralinear">e</add>
+      </mod> noble war in the sky elevated</line>
+    <line>my spirits; I clasped my hands &amp; ex</line>
+    <line>claimed aloud "William, dear angel,</line>
+    <line>this is thy funeral, this thy dirge!"–</line>
+    <line>As I said the<add place="sublinear">se</add> words <mod spanTo="#c56-0082.06"></mod><del next="#c56-0082.07" rend="strikethrough">a flash of lightning</del><add place="superlinear">I perceived in the gloom</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0082.07">discovered to me</del><anchor xml:id="c56-0082.06"></anchor> a figure which stole from</line>
+    <line>behind a clump of trees near me – <mod spanTo="#c56-0082.08"></mod><add place="superlinear"><metamark function="displacement" xml:id="c56-0082.09">X</metamark></add>
+      <delSpan rend="strikethrough" spanTo="#c56-0082.11"></delSpan>I stood</line>
+    <line>aghast<anchor xml:id="c56-0082.11"></anchor><anchor xml:id="c56-0082.08"></anchor> its gigantc sta<del rend="strikethrough">n</del>ture<mod>
+        <del rend="strikethrough">, its</del>
+        <add hand="#pbs" place="superlinear">&amp; the</add>
+      </mod> deformity</line>
+    <line><add hand="#pbs" place="superlinear">of its aspect</add>more hideous tha<mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">n</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">a</del>
+        <del rend="strikethrough">man could be</del>
+        <add place="superlinear">belongs to humanity</add>
+      </mod></line>
+    <line><del rend="strikethrough">explain</del> instantly informed me who it</line>
+    <line>was. I<add place="intralinear">t</add> was the wretch, the filthy dæmon to</line>
+    <line>whom I had given life. What did he there?</line>
+    <line>Could he be (I shuddered at the conception</line>
+  </zone>
+  <zone corresp="#c56-0082.09" type="left_margin">
+    <addSpan spanTo="#c56-0082.10"></addSpan>
+    <line>I stood</line>
+    <line>fixed gazing</line>
+    <line>intently, I</line>
+    <line>could not</line>
+    <line>be mista</line>
+    <line>ken a</line>
+    <line>flash of</line>
+    <line>lightning</line>
+    <line>illumined</line>
+    <line>the object<unclear>,</unclear></line>
+    <line>and discov</line>
+    <line>ered to me</line>
+    <anchor xml:id="c56-0082.10"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="39r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0083.xml" xml:id="ox-ms_abinger_c56-0083">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0083.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>113</line></zone>
+  <zone type="library"><line>39</line></zone>
+  <zone type="main">
+    <line>the murderer of my brother. No sooner</line>
+    <line>did that idea cross my imagination than</line>
+    <line>I became convinced <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">of its truth</add>
+      </mod> — my teeth chattered</line>
+    <line>and I was forced to lean against <del rend="strikethrough">th</del> a </line>
+    <line>tree for support — The figure quickly passed</line>
+    <line>me and I lost it in the gloom. <del rend="strikethrough">And</del>
+      <mod>
+        <del rend="overwritten">h</del>
+        <add place="intralinear">H</add>
+      </mod>e</line>
+    <line><anchor xml:id="c56-0083.01"></anchor>was the murderer! 
+      <del rend="strikethrough">I<mod>
+          <add place="sublinear"><metamark function="insert">^</metamark></add>
+          <add place="superlinear">could not</add>
+        </mod> doubt<del rend="strikethrough">ed</del> it</del>
+      <del rend="strikethrough">not</del>
+      <del rend="strikethrough">my</del></line>
+    <line><del rend="strikethrough">the</del>
+      <del rend="strikethrough">thought</del>
+      <del rend="strikethrough">was agony<mod>
+          <add place="sublinear"><metamark function="insert">^</metamark></add>
+          <add place="superlinear">I was agonized by the bare probability</add>
+        </mod></del><anchor xml:id="c56-0083.03"></anchor><anchor xml:id="c56-0083.02"></anchor> — I thought
+      of pur</line>
+    <line>sueing the devil, but <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear"> it would have been</add>
+      </mod> in vain for another</line>
+    <line>flash discovered him to me <mod spanTo="#c56-0083.05"></mod><delSpan rend="strikethrough" spanTo="#c56-0083.06"></delSpan>climbing</line>
+    <line>up the steep and<anchor xml:id="c56-0083.06"></anchor><add hand="#pbs" place="superlinear">hanging
+        among the rocks of the</add><anchor xml:id="c56-0083.05"></anchor> nearly perpendicular</line>
+    <line>ascent of the Mont-Salêve; he soon reached</line>
+    <line>the summit and dissap<mod>
+        <del rend="overwritten">p</del>
+        <add place="intralinear">e</add>
+      </mod>ared.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I remained motionless the thunder</line>
+    <line>ceased but the rain still continued &amp;</line>
+    <line>the scene was inveloped in a<mod>
+        <add place="intralinear">n</add>
+        <del rend="strikethrough">pitchy</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">impenetrable</add>
+      </mod> dark-</line>
+    <line>ness. I revolved in my mind <delSpan rend="strikethrough" spanTo="#c56-0083.07"></delSpan>I revolved in</line>
+    <line>my mind<anchor xml:id="c56-0083.07"></anchor><anchor xml:id="c56-0083.10"></anchor><anchor xml:id="c56-0083.11"></anchor> the events which I <del rend="strikethrough">u</del> had,</line>
+    <line>untill now, sought to forget. <add><metamark function="displacement" xml:id="c56-0083.08">^</metamark></add> The appearance</line>
+    <line>of <mod>
+        <del rend="strikethrough">the creature</del>
+        <add><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">the work of my own hands, alive</add>
+      </mod> at my bed side – <add hand="#pbs" place="superlinear"> &amp;</add> its
+      departure.</line>
+    <line><del rend="strikethrough">Its</del>
+      <del rend="strikethrough">It was now nearly</del> two years <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">had now nearly elapsed</add>
+      </mod> since the</line>
+    <line>night <del rend="strikethrough">of</del> on which he first received</line>
+    <line>life, and was this his first crime – <del rend="strikethrough"><unclear>?</unclear></del>Alas!</line>
+    <line>I <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add>had</add>
+      </mod> turned loose in the world a depraved</line>
+    <line>wretch whose delight was in <del rend="strikethrough">deat</del></line>
+    <line>murder &amp; wretchedness; <mod>
+        <del rend="strikethrough">For</del>
+        <add hand="#pbs" place="superlinear">for</add>
+      </mod> had he</line>
+    <line>not murdered my brother?</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">No one can conceive of the anguish I</line>
+    <line>suff<mod>
+        <del rend="overwritten">er</del>
+        <add hand="#pbs" place="intralinear">e</add>
+      </mod>red during the remainder of the</line>
+  </zone>
+
+  <zone corresp="#c56-0083.01" type="left_margin">
+    <line><add>therefore </add></line>
+  </zone>
+
+  <zone corresp="#c56-0083.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0083.04"></addSpan>
+    <line>Nothing<add hand="#pbs" place="superlinear">in</add> human</line>
+    <line>shape could</line>
+    <line>have destroyed</line>
+    <line>that fair</line>
+    <line>child. <damage agent="ink">He</damage></line>
+    <line>was the</line>
+    <line>murderer!</line>
+    <line>I could not</line>
+    <line>doubt it.</line>
+    <line>The mere presence</line>
+    <line>of the idea</line>
+    <line>was an ir</line>
+    <line>-resistible</line>
+    <line>proof of the</line>
+    <line>fact</line><anchor xml:id="c56-0083.04"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0083.10" type="left_margin">
+    <line><add hand="#pbs">I resolved in my mind</add></line>
+  </zone>
+  
+
+  <zone corresp="#c56-0083.08" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0083.09"></addSpan>
+    <line>The whole</line>
+    <line>train of my</line>
+    <line>progress to-</line>
+    <line>wards my</line>
+    <line><del rend="strikethrough"><unclear extent="1" unit="chars"></unclear></del> creation</line>
+    <anchor xml:id="c56-0083.09"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="39v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0084.xml" xml:id="ox-ms_abinger_c56-0084">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0084.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>114</line></zone>
+  <zone type="main">
+    <line>night which I spent<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">cold &amp; wet</add>
+      </mod> in the open</line>
+    <line>air. <del rend="strikethrough">cold and wet</del>. But I did not</line>
+    <line>feel th<mod>
+        <del rend="overwritten">i</del>
+        <add place="intralinear">e</add>
+        <del rend="strikethrough">s</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">incovenience of the weather.</add>
+      </mod> my imagination was busy in</line>
+    <line>in <del rend="strikethrough">scene</del> scenes of ev<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">i</add>
+      </mod>l and despair</line>
+    <line>I considered the <mod>
+        <del rend="strikethrough">wh</del>
+        <del rend="strikethrough">wretch</del>
+        <add hand="#pbs" place="superlinear">being</add>
+      </mod> whom I</line>
+    <line>had cast in among mankind <mod>
+        <del rend="strikethrough">for pu</del>
+        <anchor xml:id="c56-0084.01"></anchor>
+      </mod></line>
+    <line>purposes of <mod>
+        <del rend="strikethrough">mischief</del>
+        <add hand="#pbs" next="#c56-0084.03" place="superlinear">horror such as <del rend="strikethrough">this</del> the deed which he had</add>
+        <add hand="#pbs" place="sublinear" xml:id="c56-0084.03">now done,</add>
+      </mod> nearly in the light</line>
+    <line>of my <del rend="strikethrough">ow</del> vampire; my own spirit let</line>
+    <line>loose from the grave and forced to</line>
+    <line>destroy all who were dear to me.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Day dawned and I directed my</line>
+    <line>steps towards the town – the gates were</line>
+    <line>open and I hastened to my father's</line>
+    <line>house<del rend="strikethrough">s</del>.–My <del rend="strikethrough">n</del> first
+      thought was to disco-</line>
+    <line>ver what I knew of the murderer &amp;</line>
+    <line>cause instant <del rend="strikethrough">search</del> pursuit to</line>
+    <line>be made. But I paused when I reflect-</line>
+    <line>ed what the story was that I had</line>
+    <line>to tell. A <mod>
+        <del rend="strikethrough">creature</del>
+        <add hand="#pbs" place="superlinear">being</add>
+      </mod> whom I myself</line>
+    <line>had created and endued with life, <anchor xml:id="c56-0084.04"></anchor> The</line>
+    <line><mod>
+        <del rend="strikethrough">story</del>
+        <anchor xml:id="c56-0084.06"></anchor>
+      </mod> was utterly improbable and I knew</line>
+    <line>well that if any other had <mod>
+        <del rend="strikethrough">related</del>
+        <add place="superlinear">communicated</add>
+      </mod> such</line>
+    <line>a <mod>
+        <del rend="strikethrough">tale</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">relation</add>
+      </mod> to me I should have looked</line>
+    <line>upon it as the ravings of delirium</line>
+    <line>Besides the strange nature of the</line>
+    <line>animal would <del rend="strikethrough">elude all the <unclear>us</unclear></del></line>
+    <line>elude pursuit, even if I were <mod spanTo="#c56-0084.07"></mod><add hand="#pbs" place="superlinear">so far</add><mod>
+        <del rend="strikethrough">believed</del>
+        <anchor xml:id="c56-0084.08"></anchor>
+      </mod></line>
+    <line><del next="#c56-0084.09" rend="strikethrough">which was</del><add place="sublinear"><metamark function="insert">^</metamark></add>
+      <del rend="strikethrough" xml:id="c56-0084.09">utterly impossible</del><add hand="#pbs" place="superlinear">as to persuade <mod>
+          <del rend="strikethrough">its</del>
+          <del rend="overwritten">self</del>
+          <add place="intralinear">my</add>
+        </mod> relatives to commence it</add><anchor xml:id="c56-0084.07"></anchor> – <del rend="strikethrough">the com</del></line>
+  </zone>
+  <zone corresp="#c56-0084.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0084.02"></addSpan>
+    <line>and</line>
+    <line>endowed with</line>
+    <line>the will &amp;</line>
+    <line>the power</line>
+    <line>to effect</line>
+    <anchor xml:id="c56-0084.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0084.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0084.05"></addSpan>
+    <line>had met</line>
+    <line>me at mid</line>
+    <line>night among</line>
+    <line>the</line>
+    <line>precipices of</line>
+    <line>an inaccessi</line>
+    <line>ble mountain</line>
+    <anchor xml:id="c56-0084.05"></anchor>
+  </zone>
+  <zone corresp="#c56-0084.06" type="left_margin">
+    <line><add>tale</add></line>
+  </zone>
+  <zone corresp="#c56-0084.08" type="left_margin">
+    <line><add>credited</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="40r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0085.xml" xml:id="ox-ms_abinger_c56-0085">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0085.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>115</line></zone>
+  <zone type="library"><line>40</line></zone>
+  <zone type="main">
+    <line><mod spanTo="#c56-0085.01"></mod><delSpan spanTo="#c56-0085.02"></delSpan>mon people would believe it
+      to</line>
+    <line>be a real devil and who could attempt<anchor xml:id="c56-0085.02"></anchor><anchor xml:id="c56-0085.03"></anchor><anchor xml:id="c56-0085.01"></anchor></line>
+    <line>a creature <mod>
+        <del rend="strikethrough">that could</del>
+        <add hand="#pbs" place="superlinear">capable of</add>
+      </mod> scal<mod>
+        <del rend="overwritten">e</del>
+        <add hand="#pbs" place="intralinear">ing</add>
+      </mod> the</line>
+    <line><mod>
+        <del rend="strikethrough">steep</del>
+        <anchor xml:id="c56-0085.05"></anchor>
+      </mod> sides of Mont-Salêve? These</line>
+    <line>reflections determined me, and I resolved</line>
+    <line>to <mod>
+        <del rend="strikethrough">be</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">remain</add>
+      </mod> silent.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">It was about five in the morning when</line>
+    <line>I entered my fathers house. I told the servant<add hand="#pbs" place="intralinear">s</add></line>
+    <line>not to disturb the family<add hand="#pbs" place="intralinear">,</add> and went into</line>
+    <line>the library to attend their usual time of</line>
+    <line>rising. Five years had elapsed–passed as</line>
+    <line>a dream but for one indelible trace, and</line>
+    <line>I stood in the same place where I had last</line>
+    <line>embraced my father before my departure</line>
+    <line>for Ingolstadt. Beloved and respectable</line>
+    <line>parent! <delSpan rend="strikethrough" spanTo="#c56-0085.06"></delSpan>His chair was before the
+      reading</line>
+    <line>desk and a book open<anchor xml:id="c56-0085.06"></anchor> He still remained</line>
+    <line>to me. I gazed on a picture of my mother</line>
+    <line>which stood over the mantlepiece. It was</line>
+    <line>an historical piece painted to please my</line>
+    <line>father and represented Caroline Beaumont</line>
+    <line>in an agony of despair kneeling by the coffin</line>
+    <line>of her dead father. Her garb was rustic<add hand="#pbs" place="intralinear">,</add> &amp;
+      her</line>
+    <line>cheek pale but there was an air of dignity</line>
+    <line>and beauty that hardly <mod>
+        <del rend="strikethrough">allowed of</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">permitted</add>
+      </mod> the</line>
+    <line><mod>
+        <del rend="strikethrough">feeling</del>
+        <add hand="#pbs" place="superlinear">sentiment</add>
+      </mod> of pity. Below this picture was a</line>
+    <line>miniature of William, and my tears</line>
+    <line>flowed when I look<add place="intralinear">ed</add> upon it—While I was</line>
+    <line>thus engaged Ernest entered– he had heard</line>
+    <line>me arrive and hastened to welcome me.</line>
+    <line>He expressed the greatest delight on seeing</line>
+    <line>me – "Welcome my dearest Victor," said he,</line>
+    <line>ah I wish you had come three <del rend="strikethrough">weeks</del></line>
+  </zone>
+  <zone corresp="#c56-0085.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0085.04"></addSpan>
+    <line>Besides of what use</line>
+    <line>would be pursuit?</line>
+    <line>Who could</line>
+    <line>arrest</line><anchor xml:id="c56-0085.04"></anchor>
+  </zone>
+  <zone corresp="#c56-0085.05" type="left_margin">
+    <line><add hand="#pbs">overhanging</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="40v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0086.xml" xml:id="ox-ms_abinger_c56-0086">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0086.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>116</line></zone>
+  <zone type="main">
+    <line>months ago and then you would have <mod spanTo="#c56-0086.01"></mod><delSpan rend="strikethrough" spanTo="#c56-0086.02"></delSpan>been</line>
+    <line>welcomed as you ought<anchor xml:id="c56-0086.02"></anchor><anchor xml:id="c56-0086.03"></anchor><anchor xml:id="c56-0086.01"></anchor> – But we are now</line>
+    <line><del rend="strikethrough">all of us</del> so unhappy that I am afraid</line>
+    <line>tears instead of smiles <mod>
+        <del rend="strikethrough">for</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">will be</add>
+      </mod> your welcome</line>
+    <line><mod>
+        <del rend="strikethrough">my</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">our</add>
+      </mod> father looks so sorrowful and it seems</line>
+    <line>to have revived in his mind his sorrow</line>
+    <line>for the death of Mamma and poor Eliza</line>
+    <line>beth is quite inconsolable." Ernest began</line>
+    <line>to weep as he said these words.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Do not <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">you"</add>
+      </mod> said I," welcome me thus; try</line>
+    <line>to be more calm <mod spanTo="#c56-0086.05"></mod><del rend="strikethrough">and</del>
+      <mod>
+        <del rend="strikethrough">not let<add place="superlinear">preveng</add></del>
+      </mod>
+      <del rend="strikethrough">m<mod>
+          <del rend="overwritten">e</del>
+          <add place="intralinear">y</add>
+        </mod> be<add place="intralinear">ing</add></del></line>
+    <line><add hand="#pbs" place="superlinear">that I may not be</add><anchor xml:id="c56-0086.05"></anchor>absolutely miserable the moment I enter</line>
+    <line>my fathers house after so long an absence.</line>
+    <line>But tell me, How<add hand="#pbs" place="superlinear">does</add> my father support<delSpan rend="strikethrough" spanTo="#c56-0086.06"></delSpan>s it</line>
+    <line>and if Elizabeth<anchor xml:id="c56-0086.06"></anchor> his <del rend="strikethrough">f</del>
+      misfortunes; and how</line>
+    <line>is my poor Elizabeth?"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">She indeed requires consolation," replied</line>
+    <line>Ernest–" She accused herself of having caused</line>
+    <line>the death of my brother and that made</line>
+    <line>her very, very wretched; but since the</line>
+    <line>murderer has been discovered"——"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"The murderer discovered!" Exclaimed I–</line>
+    <line>"Good God how can that be? Who could</line>
+    <line>attempt to pursue him? It is im</line>
+    <line>possible, one might as well try to</line>
+    <line>overtake the winds or confine a</line>
+    <line>mountain stream with a straw<unclear>!</unclear></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"I do not know what you mean" replied</line>
+    <line>Ernest, But we were all very unhappy</line>
+    <line>when she was discovered–No one would</line>
+    <line><del rend="strikethrough">one</del> believe it at first and even now</line>
+  </zone>
+  <zone corresp="#c56-0086.03" type="left_margin">
+    <addSpan spanTo="#c56-0086.04"></addSpan>
+    <line>found</line>
+    <line>us all joy</line>
+    <line>ous &amp; de</line>
+    <line>lighted</line>
+    <anchor xml:id="c56-0086.04"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="41r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0087.xml" xml:id="ox-ms_abinger_c56-0087">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0087.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>117</line></zone>
+  <zone type="library"><line>41</line></zone>
+  <zone type="main">
+    <line><mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add hand="#pbs" place="superlinear">can</add></del>
+        <anchor xml:id="c56-0087.01"></anchor>
+        <del rend="strikethrough">Myrtella will</del>
+      </mod> not be convinced notwith</line>
+    <line>standing all the evidence. Indeed who</line>
+    <line>could have believed that Justine Moritz,</line>
+    <line>who was so amiable and fond of all the</line>
+    <line>family could all at once become so</line>
+    <line>extremely wicked."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Justine Moritz!" cried I,<del rend="strikethrough">"im</del> "poor, poor</line>
+    <line>girl is she then accused – but it is</line>
+    <line>wrongfully every one knows that. No one</line>
+    <line><del rend="strikethrough">bell</del> believes it surely, Ernest?"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"No one did at first," said my brother,</line>
+    <line>"but several <mod>
+        <del rend="strikethrough">things</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">circumstances</add>
+      </mod> came out, <anchor xml:id="c56-0087.03"></anchor> and her</line>
+    <line>"own behaviour <mod>
+        <del rend="strikethrough">was so</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">has been <del rend="strikethrough">such</del> so</add>
+      </mod> confused <add place="sublinear"><metamark function="displacement" xml:id="c56-0087.05">^</metamark></add> but she</line>
+    <line>"will tried today and you will then hear</line>
+    <line>"all?"</line>
+    <milestone unit="tei:p"></milestone>
+    <delSpan rend="vertical_line" spanTo="#c56-0087.07"></delSpan>
+    <line rend="indent1">He then related that after some</line>
+    <line>days of useless <del rend="strikethrough">e</del> search <del rend="strikethrough">t</del>
+      one of the magis</line>
+    <line>trates <del rend="strikethrough">opened</del> waited on my father and</line>
+    <line>informed of his desire to <del rend="strikethrough">search &amp;</del> examine</line>
+    <line>the servants of the house –To this my fa-</line>
+    <line>ther readily agreed being persuaded that</line>
+    <line><del rend="strikethrough">nothing</del>
+      <del rend="strikethrough">cou</del> all his domestics were per</line>
+    <line>fectly innocent. Justine had been</line>
+    <line>taken very ill the <del rend="strikethrough">day after</del> morning that</line>
+    <line>the murder of William had been discovered</line>
+    <line>and been obliged to confine herself to</line>
+    <line><del rend="strikethrough">her bed— Her apparel was exami</del></line>
+    <anchor xml:id="c56-0087.07"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">He <del rend="strikethrough">then</del> related that the
+      morning</line>
+    <line><mod>
+        <del rend="strikethrough">after</del>
+        <add place="superlinear">on which</add>
+      </mod> the murder of poor William</line>
+    <line><del rend="strikethrough">h</del>ad been discovered <del rend="strikethrough">Justine
+        o</del>
+      <delSpan rend="strikethrough" spanTo="#c56-0087.08"></delSpan>on the</line>
+    <line>bod<anchor xml:id="c56-0087.08"></anchor> Justine had been taken ill and</line>
+    <line>confined to her bed, and after several</line>
+  </zone>
+
+  <zone corresp="#c56-0087.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0087.02"></addSpan>
+    <line>Elizabeth</line>
+    <line>will</line>
+    <anchor xml:id="c56-0087.02"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0087.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0087.04"></addSpan>
+    <line>will</line>
+    <line>forced</line>
+    <line>conviction</line>
+    <line>upon us</line>
+    <anchor xml:id="c56-0087.04"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0087.05" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0087.06"></addSpan>
+    <line><metamark function="displacement">^</metamark>
+      <del rend="strikethrough">and</del> as</line>
+    <line>to add</line>
+    <line>to the evidence</line>
+    <line>of facts</line>
+    <line>a weight</line>
+    <line>that I</line>
+    <line>fear leaves</line>
+    <line>no hope</line>
+    <line>for doubt:</line>
+    <anchor xml:id="c56-0087.06"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="41v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0088.xml" xml:id="ox-ms_abinger_c56-0088">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0088.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>118</line></zone>
+  <zone type="main">
+    <line>days one of the servants happen<mod>
+        <del rend="overwritten"><mod>
+            <del rend="overwritten">s</del>
+            <add place="intralinear">ed</add>
+            <del rend="strikethrough"><add place="intralinear">to</add></del>
+          </mod></del>
+        <add hand="#pbs" place="intralinear">ing</add>
+      </mod> to</line>
+    <line>examine the apparel she had worn on</line>
+    <line>the night of the murder <del rend="strikethrough">&amp;</del> h<mod>
+        <del rend="overwritten"><unclear>ard</unclear></del>
+        <add hand="#pbs" place="intralinear">ad</add>
+      </mod> discovered</line>
+    <line>in her pocket the picture of my mother</line>
+    <line>which had been judged to be the tempta</line>
+    <line>tion of the murderer. The servant instantly</line>
+    <line>shewed it to one of the others, <mod>
+        <del rend="strikethrough">and</del>
+        <add hand="#pbs" place="superlinear">who</add>
+      </mod> without</line>
+    <line>saying a word to any of the family <del rend="strikethrough">they</del></line>
+    <line>went to a magistrate who sent to appre</line>
+    <line>hend Justine. <del rend="strikethrough">who</del> on being charged with</line>
+    <line>the fact<add place="superlinear">she</add> confirmed the suspicion <del rend="strikethrough">to</del></line>
+    <line><del rend="strikethrough">a</del> in a great measure by her extreme</line>
+    <line>confusion.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">This was a strange tale but it did</line>
+    <line>not shake my faith and I replied earnest</line>
+    <line>ly. "You are all mistaken. I know the</line>
+    <line>murderer Justine, poor, good Justine is</line>
+    <line>innocent."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">At that instant my father en-</line>
+    <line>tered <mod>
+        
+        <del rend="strikethrough"><add place="superlinear"><metamark function="displacement" xml:id="c56-0088.01">X</metamark></add></del>
+        <anchor xml:id="c56-0089.01"></anchor>
+      </mod>
+      <del rend="strikethrough">and</del> Ernest exclaimed Good God, Pa</line>
+    <line>pa! Victor says that he <del rend="strikethrough">ha<mod>
+          <del rend="overwritten">d</del>
+          <add place="intralinear">s</add>
+        </mod></del>
+      <del rend="strikethrough">k</del> knows</line>
+    <line>the murderer of poor William.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"<del rend="strikethrough">And</del> We do also, unfortunately," replied my</line>
+    <line>father for indeed I had rather have</line>
+    <line>been<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">for ever</add>
+      </mod> ignorant than, have discovered so</line>
+    <line>much depravity &amp; ingratitude in one whom</line>
+    <line>I valued so highly.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"My dear father" exclaimed I–"You are</line>
+    <line>mistaken. Justine is innocent."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">"If she is" replied my father "God forbid</line>
+  </zone>
+  <zone corresp="#c56-0088.01" type="left_margin">
+    <delSpan rend="vertical_line" spanTo="#c56-0088.03"></delSpan>
+    <addSpan hand="#pbs" spanTo="#c56-0088.02"></addSpan>
+    <line>After our</line>
+    <line>first</line>
+    <line>mournful</line>
+    <line>greetings</line>
+    <line>had past</line>
+    <line>I</line>
+    <anchor xml:id="c56-0088.02"></anchor>
+    <anchor xml:id="c56-0088.03"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="42r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0089.xml" xml:id="ox-ms_abinger_c56-0089">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0089.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>119</line></zone>
+  <zone type="library"><line>42</line></zone>
+  <zone type="main">
+    <line>that she should suffer as <del rend="strikethrough">innocent</del></line>
+    <line>guilty – She is to be tried today and I hope I</line>
+    <line>sincerely hope that she will be acquitted</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">This speech calmed me. I was firmly con</line>
+    <line>vinced in my own mind that Justine and</line>
+    <line>indeed every human being was guiltless of</line>
+    <line>this murder. I had no fear therefore</line>
+    <line>that any circumstantial evidence could</line>
+    <line>be brought forward strong enough to</line>
+    <line>convict her and in this assurance I calmed</line>
+    <line>myself expecting the trial with eagerness</line>
+    <line>but without prognosticating an evil</line>
+    <line>result.</line>
+    <line><metamark function="separate">_____________________</metamark></line>
+  
+    <addSpan corresp="#c56-0089.01" spanTo="#c56-0089.02"></addSpan>
+    <line><metamark function="displacement"><hi rend="sup">X</hi></metamark>I saw unhappiness deeply
+      impressed</line>
+    <line><del rend="strikethrough">co</del> on his countenance but he endea</line>
+    <line>voured to welcome me cheerfully</line>
+    <line>and <anchor xml:id="c56-0089.03"></anchor><mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">after <mod>
+            <del rend="strikethrough">our</del>
+            <add hand="#pbs" place="superlinear">we</add>
+          </mod> <del rend="strikethrough">mournful</del> had exchanged our mournful greetings</add>
+      </mod> would have spoken on some</line>
+    <line>other topic than that of our disaster</line>
+    <line>had not</line>
+    <anchor xml:id="c56-0089.02"></anchor>
+  </zone>
+  
+  <zone corresp="#c56-0089.03" type="left_margin">
+    <line><add hand="#pbs">he</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="42v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0090.xml" xml:id="ox-ms_abinger_c56-0090">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0090.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>120</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0090.03" unit="tei:head"></milestone>Chap. 11<anchor xml:id="c56-0090.03"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We were soon joined <mod>
+        <del rend="strikethrough">By</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">by</add>
+      </mod> Elizabeth. Time</line>
+    <line>had made great alterations in her form since</line>
+    <line>I had last beheld her. Five years <del rend="strikethrough">ago</del> before</line>
+    <line>she was a pretty, good humoured girl <delSpan rend="strikethrough" spanTo="#c56-0090.01"></delSpan>with an</line>
+    <line>understanding above her years<anchor xml:id="c56-0090.01"></anchor> Whom every</line>
+    <line>one loved, and <mod>
+        <del rend="strikethrough">humoured</del>
+        <add place="superlinear">caressed</add>
+      </mod>. She was now a woman</line>
+    <line>in stature and expression of countenance</line>
+    <line>which was uncommonly lovely — An open &amp;</line>
+    <line>capacious for<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">e</add>
+      </mod>head gave indications of a good</line>
+    <line>understanding joined to great frankness. Her</line>
+    <line>eyes were hazel and <delSpan rend="strikethrough" spanTo="#c56-0090.02"></delSpan>very soft now
+      through</line>
+    <line>recent affliction they expressed sorrow. Her</line>
+    <line>smile had som<anchor xml:id="c56-0090.02"></anchor> express<mod>
+        <del rend="overwritten">ed</del>
+        <add place="intralinear">ive</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">great</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">of uncommon</add>
+      </mod> mildness now</line>
+    <line>through recent affliction allied to sadness–</line>
+    <line>Her hair was of a rich<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">dark</add>
+      </mod> auburn<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">her complexion fair</add>
+      </mod> and her</line>
+    <line>figure sli<mod>
+        <del rend="overwritten">m</del>
+        <add hand="#pbs" place="intralinear">ght</add>
+      </mod> and graceful. She <del rend="strikethrough">embraced</del></line>
+    <line><del rend="strikethrough">w</del>
+      <del rend="strikethrough">me with</del> welcomed me with the greatest</line>
+    <line>affection "Your arrival, my <mod>
+        <del rend="strikethrough">best</del>
+        <add place="superlinear">dearest</add>
+      </mod> cousin,"</line>
+    <line>said she, <del rend="strikethrough">give</del> "fills me with hope. You</line>
+    <line>perhaps will find out some means to</line>
+    <line>justify my poor <mod>
+        <del rend="strikethrough">innocent</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">guiltless</add>
+      </mod> Justine. Alas</line>
+    <line>Who is safe is she were convicted <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">of crime?</add>
+        <del rend="strikethrough">for</del>
+      </mod></line>
+    <line>I <del rend="strikethrough">belie</del> rely on <del rend="strikethrough">her</del> her
+      innocence as cer</line>
+    <line>tainly as I do <mod>
+        <del rend="overwritten">on</del>
+        <add hand="#pbs" place="intralinear">upon</add>
+      </mod> my own. <add place="superlinear">Our</add>Misfortune is</line>
+    <line>doubly hard to us. <mod>
+        <del rend="strikethrough">I</del>
+        <add place="superlinear">We</add>
+      </mod> have not only lost</line>
+    <line>that lovely darling boy but this poor girl</line>
+    <line>whom I sincerely love, is to be torn</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="43r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0091.xml" xml:id="ox-ms_abinger_c56-0091">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0091.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>121</line></zone>
+  <zone type="library"><line>43</line></zone>
+  <zone type="main">
+    <line>away by even a worse fate – Alas if she</line>
+    <line>is condemned I shall never know joy more</line>
+    <line>But she will not I am sure she will</line>
+    <line>not and then I shall be happy again even</line>
+    <line>after the <del rend="strikethrough">d</del> sad death of my little William."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"She is innocent, my Elizabeth," said I and</line>
+    <line>that shall be proved – fear nothing but let</line>
+    <line>your spirits be cheered by the assurance</line>
+    <line>of her aquittal.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"How kind your are," replied Elizabeth,</line>
+    <line>"every one else believes in her guilt, and</line>
+    <line>that made me wretched <delSpan rend="strikethrough" spanTo="#c56-0091.01"></delSpan>for I would
+      as</line>
+    <line>surely believe in my<anchor xml:id="c56-0091.01"></anchor> for I knew <mod spanTo="#c56-0091.02"></mod><delSpan rend="strikethrough" spanTo="#c56-0091.03"></delSpan>it to</line>
+    <line>be<anchor xml:id="c56-0091.03"></anchor><add hand="#pbs" place="superlinear">that it
+        was</add><anchor xml:id="c56-0091.02"></anchor> impossible, and to see every one else</line>
+    <line>prejudiced in so deadly a manner rendered</line>
+    <line>me hopeless and despairing." She wept—</line>
+    <line>"Sweet niece" said my father dry your</line>
+    <line><del instant="true" rend="strikethrough">eyes</del> tears <mod spanTo="#c56-0091.04"></mod><delSpan rend="strikethrough" spanTo="#c56-0091.05"></delSpan>and do not give so sad<add place="superlinear">sorrowful</add> a welc-</line>
+    <line>come to Victor who has been so long</line>
+    <line>absent<anchor xml:id="c56-0091.05"></anchor>
+      <addSpan hand="#pbs" spanTo="#c56-0091.07"></addSpan> if she is as you believe innocent rely <del rend="strikethrough">that</del></line>
+      <line>on the justice of our judges &amp; the activity with</line>
+      <line>which I shall prevent the slightest shadow of partiality.</line><anchor xml:id="c56-0091.04"></anchor>
+      <anchor xml:id="c56-0091.07"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We passed a few sad hours untill eleven</line>
+    <line>o'clock when the trial was to <mod>
+        <del rend="strikethrough">begin</del>
+        <add place="superlinear">commence</add>
+      </mod>
+      <del rend="strikethrough">and</del>
+      <mod>
+        <del rend="overwritten">m</del>
+        <add place="intralinear">M</add>
+      </mod>y <delSpan rend="strikethrough" spanTo="#c56-0091.08"></delSpan>father</line>
+    <line>and E<anchor xml:id="c56-0091.08"></anchor>
+      <del rend="strikethrough">father</del>
+      <del rend="strikethrough">El</del> the rest of the family being obliged</line>
+    <line>to attend as witnesses <del rend="strikethrough">Iac</del> I accompanied them to</line>
+    <line>the court. During the whole of this wretched</line>
+    <line>mockery of justice I sufferred living torture.<add place="sublinear"><unclear reason="illegible"><metamark>^</metamark></unclear></add></line>
+    <line>It was to be decided whether the result of</line>
+    <line>my curiosity and lawless<mod>
+        <del rend="strikethrough">desires</del>
+        <add hand="#pbs" place="superlinear">devices</add>
+      </mod> would cause</line>
+  </zone>
+
+
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="43v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0092.xml" xml:id="ox-ms_abinger_c56-0092">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0092.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>122</line></zone>
+  <zone type="main">
+    <line>the death of two of my fellow beings. One a</line>
+    <line>smiling babe full of innocence and joy, the</line>
+    <line>other far more dreadfully murdered with</line>
+    <line>every agravation <del rend="strikethrough">ignominy</del> infamy that could</line>
+    <line>make that murder <mod>
+        <del rend="strikethrough">more terrible</del>
+        <del rend="unmarked">.</del>
+        <add hand="#pbs" place="superlinear">memorable in horror.</add>
+      </mod> Justine</line>
+    <line>also was a girl of merit and possessed</line>
+    <line>qualities which promised to render her</line>
+    <line><mod>
+        <del rend="strikethrough">little world</del>
+        <add place="superlinear">life</add>
+      </mod> happy; now all was to be oblite</line>
+    <line>rated in an<del rend="strikethrough">d</del> ignominious grave <mod>
+        <del rend="overwritten">–</del>
+        <add place="intralinear">;</add>
+      </mod> And I the</line>
+    <line>cause! A thousand times rather would</line>
+    <line>I have confessed myself guilty of the crime</line>
+    <line>ascribed to Justine, but I was absent when</line>
+    <line>it was committed and such a declaration</line>
+    <line>would have<add place="superlinear">been</add> considered as the ravings of</line>
+    <line>a madman and could not have excul</line>
+    <line>pated her who suffered through me.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The <del rend="strikethrough">aff</del> appearance of
+      Justine was</line>
+    <line>calm. She was dressed in <del rend="strikethrough">morn</del> mourning and</line>
+    <line>her countenance, always engaging, was rendered</line>
+    <line>by the solemnity of her feelings exquisite</line>
+    <line>-ly beautiful. <del rend="strikethrough">Yet she</del>
+      <del rend="strikethrough">Her mann</del> Yet she</line>
+    <line>appeared confident in innocence and</line>
+    <line>did not tremble although gazed at and</line>
+    <line>execrated by thousands. <del rend="strikethrough">fo</del> For all the kind</line>
+    <line>ness which her beauty might have</line>
+    <line>gained from others was obliterated by</line>
+    <line>the rememberance of the enormity she was</line>
+    <line>supposed to have committed. She was</line>
+    <line>tranquil yet her tranquillity was evident</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="44r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0093.xml" xml:id="ox-ms_abinger_c56-0093">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0093.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>123</line></zone>
+  <zone type="library"><line>44</line></zone>
+  <zone type="main">
+    <line>constrained – and as her confusion had</line>
+    <line>before been adduced as a proof of her guilt</line>
+    <line>she worked <del rend="strikethrough">herself</del> up her mind to an appear</line>
+    <line>ance of courage. When she entered the court</line>
+    <line>she threw her eyes round it and quickly dis</line>
+    <line>covered where we were seated – a tear seemed</line>
+    <line>to dim her eye when she saw us but she</line>
+    <line>recovered herself and <del rend="strikethrough">g</del>
+      <del rend="strikethrough">with</del> a look<del rend="strikethrough">e</del> of sorrow</line>
+    <line>ful affection seemed to attest her utter</line>
+    <line>guiltlessness.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The trial began <del rend="strikethrough">and</del>
+      <delSpan rend="strikethrough" spanTo="#c56-0093.01"></delSpan>listened attentive</line>
+    <line>ly wish<anchor xml:id="c56-0093.01"></anchor> and after the advocate against her</line>
+    <line>had stated the charge several witnesses</line>
+    <line>were called. Several strange facts combined</line>
+    <line>against her which would have staggered</line>
+    <line>any one who had not such prof of her</line>
+    <line>innocence as I had. She had been out the</line>
+    <line>whole of the night on which the mur</line>
+    <line>der had been committed and towards</line>
+    <line>morning had been perceived by a <mod spanTo="#c56-0093.02"></mod><del rend="strikethrough">farme</del></line>
+    <line><anchor xml:id="c56-0093.03"></anchor><anchor xml:id="c56-0093.02"></anchor>woman not far from the spot
+      where</line>
+    <line>the body of the murdered child had been</line>
+    <line>afterwards found. <del rend="strikethrough">He asked her wh</del>
+      <mod>
+        <del rend="strikethrough">She</del>
+        <add hand="#pbs" place="superlinear">The woman</add>
+      </mod></line>
+    <line>asked <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">her</add>
+      </mod> what she did there<add hand="#pbs" place="intralinear">?</add>–<mod>
+        <del rend="strikethrough">for</del>
+        <add hand="#pbs" place="superlinear">but</add>
+      </mod> she looked</line>
+    <line>very <del rend="strikethrough">stang</del> strangely and only returned a</line>
+    <line>confused <add place="sublinear"><metamark function="displacement" xml:id="c56-0093.04">^</metamark></add> answer<del rend="strikethrough">e</del>. <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough">S</del>
+        <add place="superlinear">She</add>
+      </mod>
+      <del rend="strikethrough">came</del> returned to</line>
+    <line>the house about eight o'clock and when</line>
+    <line>some one enquired where she had</line>
+    <line>passed the night she replied that she</line>
+    <line>had been looking <mod>
+        <del rend="strikethrough">of</del>
+        <add hand="#pbs" place="superlinear">for</add>
+      </mod> the child and <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough">enquired</del>
+        <add place="superlinear">demanded</add>
+      </mod></line>
+    <line>earnestly if any thing had been heard con</line>
+    <line>cerning him. When the body was brought</line>
+  </zone>
+  <zone corresp="#c56-0093.03" type="left_margin">
+    <line><add>market-</add></line>
+  </zone>
+  <zone corresp="#c56-0093.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0093.05"></addSpan>
+    <line>&amp; unin-</line>
+    <line>telligible</line>
+    <line><metamark function="displacement">^</metamark></line>
+    <anchor xml:id="c56-0093.05"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="44v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0094.xml" xml:id="ox-ms_abinger_c56-0094">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0094.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>124</line></zone>
+  <zone type="main">
+    <line>into the house she fell into violent hys-</line>
+    <line>terics and kept her bed for several</line>
+    <line>days. The picture was then produced</line>
+    <line>which the servant had found in her</line>
+    <line>pocket and when Elizabeth in a falte</line>
+    <line>ring voice proved that it was the same</line>
+    <line><mod>
+        <del rend="strikethrough">she had</del>
+        <add hand="#pbs" place="superlinear">which</add>
+      </mod>
+      <del rend="strikethrough">the</del> an hour before <del rend="strikethrough">the
+      murder</del></line>
+    <line>the child had been missed,<add hand="#pbs" place="superlinear">she had</add> placed
+      round</line>
+    <line>his neck a murmur of indignation</line>
+    <line>and horror filled the court.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">Justine was then called on for</line>
+    <line>her defence. <delSpan spanTo="#c56-0094.01"></delSpan>God kno who reads all</line>
+    <line>hearts knows how<anchor xml:id="c56-0094.01"></anchor> As the trial had</line>
+    <line>proceeded her countenance had altered.</line>
+    <line>Surprise horror and misery were strong</line>
+    <line>ly expressed. Sometimes she struggled</line>
+    <line>with her tears <del rend="strikethrough">wh</del> but when she</line>
+    <line>was desired to speak she collected her</line>
+    <line>powers and spoke in an audible although</line>
+    <line>variable voice.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"God knows," she said, "<del rend="strikethrough">w</del>ho<add place="intralinear">w</add> entirely I</line>
+    <line>am inocent. but I do not pretend to be</line>
+    <line>acquitted on account of my protestations</line>
+    <line>I rest my innocence <del rend="strikethrough">a</del> on a simple</line>
+    <line>explanation of the <mod>
+        <del rend="strikethrough">facts</del>
+        <add place="superlinear">facts</add>
+      </mod> which have</line>
+    <line>been adduced against me, and I hope</line>
+    <line>the character I have always borne will</line>
+    <line>encline my judges to a favourable</line>
+    <line>interpretation where any <mod>
+        <del rend="strikethrough">fact</del>
+        <add place="superlinear">circumstance</add>
+      </mod> appears</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="45r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0095.xml" xml:id="ox-ms_abinger_c56-0095">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0095.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>125</line></zone>
+  <zone type="library"><line>45</line></zone>
+  <zone type="main">
+    <line>doubtful or suspicious.</line>
+    <delSpan rend="vertical_line" spanTo="#c56-0095.01"></delSpan>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">By the permission of Mad<hi rend="sup"><hi rend="underline">ll</hi>e</hi>
+      Lavenza</line>
+    <line>I passed the evening with an aunt at</line>
+    <line>Chêne. One of my cousins returning from</line>
+    <line>Geneva said that he had been at the</line>
+    <line>house of M. Frankenstein and</line><anchor xml:id="c56-0095.01"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">She then related that by the</line>
+    <line>permission of Elizabeth she had passed</line>
+    <line>the evening of the night on which the</line>
+    <line>murder was perpetrated at <mod>
+        <del rend="strikethrough">M</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">the house of</add>
+      </mod> an aunt</line>
+    <line>who resided in Chêne a village about</line>
+    <line>a league from Geneva. On her return</line>
+    <line><anchor xml:id="c56-0095.02"></anchor>about nine o'clock she met a <del rend="strikethrough">servant</del></line>
+    <line>man who asked her if she had seen</line>
+    <line>any thing of the child who was lost. She</line>
+    <line>was frightened at this account<add hand="#pbs" place="intralinear">,</add> and
+      passed</line>
+    <line>several hours in looking for him when</line>
+    <line>the gates of Geneva were shut and she</line>
+    <line><mod>
+        <del rend="strikethrough">passed</del>
+        <anchor xml:id="c56-0095.03"></anchor>
+      </mod> s<hi rend="underline">e</hi>veral hours of the night<add place="superlinear">in</add>
+      a</line>
+    <line>cottage, but unable to rest or sleep, she</line>
+    <line>rose early that she might again</line>
+    <line>endeavour to find my brother. If she</line>
+    <line>had gone near the <del rend="strikethrough"><unclear extent="1" unit="chars"></unclear></del>
+        spot<del rend="strikethrough">e</del> where his</line>
+    <line>body lay it was without her knowledge</line>
+    <line><mod>
+        <del rend="strikethrough">and she had been confused</del>
+        <add hand="#pbs" place="superlinear">That if she had been bewildered</add>
+      </mod> when ques</line>
+    <line>tioned by the market woman, was</line>
+    <line><mod>
+        <del rend="strikethrough">that</del>
+        <add hand="#pbs" place="superlinear">not</add>
+      </mod> surprising when she <del rend="strikethrough">was so</del></line>
+    <line><del rend="strikethrough">c</del> was so wretched <mod>
+        <del rend="strikethrough">on</del>
+        <add hand="#pbs" place="superlinear">for</add>
+      </mod> the loss of poor</line>
+    <line>William. Concerning the picture she</line>
+    <line>could give no account. "I know," continued</line>
+  </zone>
+  <zone corresp="#c56-0095.02" type="left_margin">
+    <add>at </add>
+  </zone>
+  <zone corresp="#c56-0095.03" type="left_margin">
+    <mod>
+      <add hand="#pbs" place="sublinear"><metamark function="insert">^</metamark></add>
+      <add hand="#pbs" place="superlinear">was forced to </add>
+      <add>remain<del rend="strikethrough">ed</del></add>
+    </mod></zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="45v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0096.xml" xml:id="ox-ms_abinger_c56-0096">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0096.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>126</line></zone>
+  <zone type="main">
+    <line>the unhappy victim<del rend="strikethrough">e</del> "how heavily and fatally this</line>
+    <line><del rend="strikethrough">o</del> one circumstance <del rend="strikethrough">we</del>
+      weighs against me</line>
+    <line>but I have no power of explaining it and</line>
+    <line>when I have expressed my utter ignorance</line>
+    <line>I am only left <del rend="strikethrough">w</del>
+      <del rend="strikethrough">as any other is to conject</del><del rend="unmarked">ure</del></line>
+    <line>to conjecture concerning the probabilities</line>
+    <line>by which it might have been placed in</line>
+    <line>my pocket. But <del rend="strikethrough">I</del> here also I am <mod>
+        <del rend="strikethrough">at a</del>
+        <add place="superlinear">checked</add>
+      </mod></line>
+    <line><mod>
+        <del rend="strikethrough">stand</del>
+        <add place="superlinear">I believe that</add>
+      </mod> I have have no enemy on earth <delSpan rend="strikethrough" spanTo="#c56-0096.01"></delSpan>who</line>
+    <line>that I know<anchor xml:id="c56-0096.01"></anchor> and none surely who could have</line>
+    <line>been so wicked as <del rend="strikethrough">d</del> to destroy me <mod>
+        <del rend="strikethrough">so cruelly</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">wantonly.</add>
+      </mod></line>
+    <line>Did the murderer place it there? I know</line>
+    <line>of no opportunity afforded him for so doing</line>
+    <line>or if I had why should he have stolen</line>
+    <line>the jewel to part with it <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">again</add>
+      </mod> so soon <mod>
+        <del rend="strikethrough">again</del>
+        <add place="superlinear">?</add>
+      </mod></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">"I commit my cause to the justice of</line>
+    <line>my judges yet I see no room for hope. I</line>
+    <line>beg permission to have a few witnesses exam-</line>
+    <line>ined concerning my character and if the<mod>
+        <del rend="overwritten">n</del>
+        <add hand="#pbs" place="intralinear">ir</add>
+      </mod></line>
+    <line><add hand="#pbs" place="superlinear">testimony shall not overweigh</add>my supposed guilt
+        <del rend="strikethrough">is an apparent</del> I <mod>
+        <del rend="strikethrough">shall</del>
+        <add hand="#pbs" place="superlinear">must</add>
+      </mod></line>
+    <line>be condemned although I <del rend="strikethrough">p</del> would pledge</line>
+    <line>my salvation on my innocence."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Several witnesses were called who had</line>
+    <line>known her for many years and they spoke</line>
+    <line>well of her but fear and hatred of the</line>
+    <line>crime of which they supposed her guilty</line>
+    <line>rendered them timorous and unwilling</line>
+    <line><mod>
+        <del rend="strikethrough">to speak</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">come forward</add></del>
+      </mod>. Elizabeth saw even this last</line>
+    <line>resource, her excellent and irreproacha</line>
+    <line>ble dispositions &amp; conduct, about to fail</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="46r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0097.xml" xml:id="ox-ms_abinger_c56-0097">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0097.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>127</line></zone>
+  <zone type="library"><line>46</line></zone>
+  <zone type="main">
+    <line>the accused, when although <mod>
+        <del rend="strikethrough">uncalled</del>
+        <anchor xml:id="c56-0097.01"></anchor>
+      </mod></line>
+    <line>she desired permission to speak. "I am"</line>
+    <line>said she "the cousin of the unhappy</line>
+    <line>child who was murdered or rather his</line>
+    <line>sister for I was educated <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">by</add>
+      </mod> and lived</line>
+    <line>with his parents <del rend="strikethrough">s</del> ever <del rend="strikethrough">sin</del> since and</line>
+    <line>long before his birth; it may therefore</line>
+    <line>be judged indecent in me to come</line>
+    <line>forward on this occasion but when</line>
+    <line>I see a fellow creature about to perish</line>
+    <line>through the cowardice of her pretended</line>
+    <line>friends I wish to <add place="superlinear">be</add> allowed to speak that</line>
+    <line>I may say what I know of her character.</line>
+    <line><del rend="strikethrough">and</del> I <mod>
+        <del rend="strikethrough">know a great deal</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">am well acquainted with it.</add>
+      </mod>
+      <del rend="strikethrough">for</del> I have</line>
+    <line>lived in the same house with her at</line>
+    <line>one time for five and afterwards for</line>
+    <line>nearly two years. During all that <mod>
+        <del rend="strikethrough">time</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">period</add>
+      </mod></line>
+    <line>she <del rend="strikethrough"><unclear extent="1" unit="chars"></unclear></del> appeared to me a
+      most amiable</line>
+    <line>and benevolent creature. She nurst</line>
+    <line>my aunt in her last illness with the</line>
+    <line>greatest affection and care and after</line>
+    <line>terwards attended her <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">own</add>
+      </mod> mother during a</line>
+    <line>long &amp; tedious illness <del rend="strikethrough">w</del> in a manner</line>
+    <line>that excited the admiration of all</line>
+    <line>who knew her. After which she again</line>
+    <line>lived in my uncle's house where she</line>
+    <line>was <mod>
+        <del rend="strikethrough">always a favourite</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">beloved by all the family</add>
+      </mod>. <del rend="strikethrough">Of the deceased</del></line>
+    <line>she was <mod>
+        <del rend="strikethrough">very</del>
+        <del rend="strikethrough">fond</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">warmly attached to <del rend="strikethrough">of</del> the child who
+          has been murdered</add>
+      </mod> and acted towards him</line>
+    <line><del rend="strikethrough">in</del> like a most affectionate
+      Mother<unclear>.</unclear></line>
+    <line>for my own part I do not hesitate to</line>
+    <line><del rend="strikethrough">s</del>ay that not withstanding <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">all</add>
+      </mod> the evidence</line>
+  </zone>
+  <zone corresp="#c56-0097.01" type="left_margin">
+    <addSpan spanTo="#c56-0097.02"></addSpan>
+    <line>violently</line>
+    <line>agitated</line>
+    <anchor xml:id="c56-0097.02"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="46v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0098.xml" xml:id="ox-ms_abinger_c56-0098">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0098.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>12<mod><del rend="overwritten"><unclear>6</unclear></del><add place="intralinear">8</add></mod></line></zone>
+  <zone type="main">
+    <line><anchor xml:id="c56-0098.01"></anchor>against her I believe and rely <mod>
+        <del rend="overwritten">i</del>
+        <add place="intralinear">o</add>
+      </mod>n</line>
+    <line>her perfect innocence. <del rend="strikethrough">An</del> She had</line>
+    <line>no<del rend="strikethrough"><add place="intralinear">t</add></del> temptation <mod spanTo="#c56-0098.02"></mod><del next="#c56-0098.03" rend="strikethrough">and her dispo
+        character</del><add place="superlinear"><del rend="strikethrough">whi</del> for such an
+        action</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0098.03">is amiable</del>
+      <del rend="strikethrough">for</del><anchor xml:id="c56-0098.02"></anchor> as to the bauble on
+      which</line>
+    <line>the chief proof rests <del rend="strikethrough">If</del>
+      <del rend="strikethrough">s</del>
+      <mod>
+        <del rend="strikethrough">I</del>
+        <del rend="strikethrough"><add place="superlinear"><unclear>I</unclear></add></del>
+      </mod> if <hi rend="underline">s</hi>he had</line>
+    <line>earnestly wished for it I should have</line>
+    <line>willingly given it her so much <del rend="strikethrough">did</del> do</line>
+    <line><del rend="strikethrough">I rely</del> I esteem and value her."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Excellent Elizabeth! A murmur</line>
+    <line>of approbation <del rend="strikethrough">o</del> was heard, but it</line>
+    <line>was <mod>
+        <del rend="strikethrough">on her account</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">excited by her generous interference</add>
+      </mod>&amp; not in favour</line>
+    <line>of poor Justine on whom the public</line>
+    <line><del rend="strikethrough">ig</del> indignation<add hand="#pbs" place="superlinear">was</add> turned with renewed</line>
+    <line>violence, charging her<add place="superlinear">with</add> the blackest in-</line>
+    <line>gratitude. <del rend="strikethrough">For</del> She herself wept as</line>
+    <line>Elizabeth spoke but she did not</line>
+    <line>answer. My own agitation<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">&amp; anguish</add>
+      </mod> was extreme</line>
+    <line><del rend="strikethrough">wh</del> during the whole of the trial. <delSpan rend="strikethrough" spanTo="#c56-0098.04"></delSpan>The</line>
+    <line>picture was<anchor xml:id="c56-0098.04"></anchor> I believed in her inno</line>
+    <line>cence I knew it. Could the monster</line>
+    <line>who had (I did not for a minute</line>
+    <line>doubt) murdered my brother, alo in</line>
+    <line>his hellish sport<add place="superlinear">have</add> betrayed the inno</line>
+    <line>cent to death and ignominy. I could</line>
+    <line>not sustain the horror of my situa</line>
+    <line>tion and when I saw that the popu</line>
+    <line>lar voice and the countenance of the</line>
+  </zone>
+  <zone corresp="#c56-0098.01" type="left_margin">
+    <line><add>produced </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="47r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0099.xml" xml:id="ox-ms_abinger_c56-0099">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0099.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>12<mod><del rend="overwritten">7</del><add place="intralinear">9</add></mod></line></zone>
+  <zone type="library"><line>47</line></zone>
+  <zone type="main">
+    <line>Judges had already condemned <mod>
+        <add place="superlinear"><metamark function="displacement" xml:id="c56-0099.01">X</metamark></add>
+        <del rend="strikethrough">her</del>
+      </mod></line>
+    <line>I rushed out of the court in agony. The</line>
+    <line>tortures of the accused did not equal</line>
+    <line>mine she was sustained by innocence</line>
+    <line>but the fangs of remorse tore my bosom–</line>
+    <line>I passed a night of unmingled wretched</line>
+    <line>ness. In the morning I went to the</line>
+    <line>court; my lips and throat were</line>
+    <line>parched<unclear>.</unclear> I dared not ask the fatal</line>
+    <line>question – but I was know<add place="intralinear">n</add> and the</line>
+    <line>officer guessed <mod spanTo="#c56-0099.04"></mod><del next="#c56-0099.05" rend="strikethrough">what I came to en-</del><add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">the cause of my visit</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0099.05">quire;</del><anchor xml:id="c56-0099.04"></anchor>
+      — the ballots had been thrown</line>
+    <line>they were all <mod>
+        <del rend="strikethrough">blak</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">black</add>
+      </mod> &amp; Justine was</line>
+    <line>condemned.</line>
+  </zone>
+  <zone corresp="#c56-0099.01" type="left_margin">
+    <addSpan spanTo="#c56-0099.02"></addSpan>
+    <line><mod spanTo="#c56-0099.06"></mod><delSpan spanTo="#c56-0099.03"></delSpan>the accu</line>
+    <line>sed<anchor xml:id="c56-0099.03"></anchor></line>
+    <line><metamark function="displacement">X</metamark>my un</line>
+    <line>happy</line>
+    <line>victim<anchor xml:id="c56-0099.06"></anchor></line>
+    <anchor xml:id="c56-0099.02"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="47v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0100.xml" xml:id="ox-ms_abinger_c56-0100">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0100.jp2"></graphic>
+  
+  <zone rend="bordered" type="pagination"><line>130</line></zone>
+  
+  <zone type="main">
+    <line rend="indent3"><milestone spanTo="#c56-0100.01" unit="tei:head"></milestone>Chapter 1<mod><del rend="overwritten">1</del><add place="intralinear">2</add></mod><anchor xml:id="c56-0100.01"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I cannot attempt to describe what I</line>
+    <line>then felt – I had <mod>
+        <del rend="strikethrough">had</del>
+        <add hand="#pbs" place="superlinear">experienced</add>
+      </mod> sensations of horror</line>
+    <line>before and I have endeavoured to bestow</line>
+    <line>on them adequate expressions but now</line>
+    <line>words cannot convey any idea of the</line>
+    <line>heart sickening despair that I <mod>
+        <del rend="strikethrough">then felt</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">endured</add>
+      </mod>.</line>
+    <line><del rend="strikethrough">Nor</del> The person to whom I had addressed</line>
+    <line>myself also added that Justine had al-</line>
+    <line>ready confessed her guilt. "That evidence" he</line>
+    <line>observed –"was hardly required in so glaring</line>
+    <line>a case but I <del rend="strikethrough">I</del> am glad of it; and indeed</line>
+    <line>none of our judges like to condemn a</line>
+    <line><del rend="strikethrough">ch</del> criminal upon circumstantial evi-</line>
+    <line>dence <del rend="strikethrough">let it</del> be<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">it</add>
+      </mod> ever so decisive."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2">When I returned home Elizabeth</line>
+    <line>eagerly <mod>
+        <del rend="strikethrough">enquired</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">demanded</add>
+      </mod> the result. "My cousin"</line>
+    <line>replied I, "it is decided as you may have</line>
+    <line>suspected – <add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">all</add>Judges had rather that ten</line>
+    <line>innocent should suffer tha<mod>
+        <del rend="overwritten">t</del>
+        <add place="intralinear">n</add>
+      </mod> that</line>
+    <line>one guilty should escape: but she</line>
+    <line>has confessed."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">This was a <del rend="strikethrough">b</del> dire blow to
+      poor Eliza</line>
+    <line>beth who had relied with firmness on</line>
+    <line>her innocence. "Alas!" said she "How</line>
+    <line>shall I ever again believe in human</line>
+    <line>benovolence – Justine, whom I loved and</line>
+    <line>esteemed as my sister. How could she</line>
+    <line>put on <del rend="strikethrough">thos</del> those smiles of innocence</line>
+    <line>only to betray– her mild eyes seemed inca</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="48r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0101.xml" xml:id="ox-ms_abinger_c56-0101">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0101.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>131</line></zone>
+  <zone type="library"><line>48</line></zone>
+  <zone type="main">
+    <line>pable of any severity or ill humour and</line>
+    <line>yet she has <del rend="strikethrough">com</del> committed a murder."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Soon after we heard that the</line>
+    <line>poor victim had expressed a wish to</line>
+    <line>see my cousin. My father wished her not</line>
+    <line>to go but said that he left it to her</line>
+    <line>own judgement and feelings to decide.</line>
+    <line>"Yes," said Elizabeth "I will go although</line>
+    <line>she is guilty – and you Victor shall acco</line>
+    <line>pany me –I cannot go alone". <del rend="strikethrough">This</del> The</line>
+    <line>idea of this visit was torture to me</line>
+    <line>yet I could not refuse.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We entered the gloomy prison cham</line>
+    <line>ber and beheld Justine sitting on some</line>
+    <line>straw at the further end; her hands</line>
+    <line>were mannacled and her head rested</line>
+    <line>on her <del rend="strikethrough">knews</del> knees,– she rose on seeing</line>
+    <line>us and when <del rend="strikethrough">th</del> we were left alone</line>
+    <line>with her she threw herself at the</line>
+    <line>feet of Elizabeth weeping bitterly.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">My cousin wept also – Oh Justine</line>
+    <line>said she, why did you rob me of my</line>
+    <line>last consolation – I <mod>
+        <del rend="strikethrough">believed</del>
+        <add place="superlinear">relied</add>
+      </mod>
+      <mod>
+        <del rend="overwritten">i</del>
+        <add place="intralinear">o</add>
+      </mod>n your</line>
+    <line>innocence and although I was very</line>
+    <line><del rend="strikethrough">wh</del> wretched I was not so miserable</line>
+    <line>as I am now."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"And do you also believe that I am</line>
+    <line>so very very wicked–?<add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">Cried Justine</add> Do you also join</line>
+    <line>with my enemies to crush me? Her</line>
+    <line>voice was suffocated <mod>
+        <del rend="strikethrough">in</del>
+        <add place="superlinear">with</add>
+      </mod> sobs.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Rise my poor girl," said Elizabeth</line>
+    <line>"why do you kneel if you are innocen<damage type="tear">t</damage></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="48v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0102.xml" xml:id="ox-ms_abinger_c56-0102">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0102.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>132</line></zone>
+  <zone type="main">
+    <line>I am not one of your enemies, I believed in</line>
+    <line>your innocence notwith<retrace cause="unclear">sta</retrace>nding every</line>
+    <line>evidence untill I heard that you had</line>
+    <line>yourself declared your guilt. That report</line>
+    <line>you say is false, and be assured my</line>
+    <line>dear Justine nothing can for a minute</line>
+    <line>shake my confidence in you but</line>
+    <line>your own confession–"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"I did confess" said Justine "but</line>
+    <line>I confessed a lie. I confessed that I</line>
+    <line>might obtain absolution but now</line>
+    <line>that falsehood lies heavier at my</line>
+    <line>heart than all my other sins. The God</line>
+    <line>of heaven forgive me! Ever since I</line>
+    <line>was condemned my confessor has besieged</line>
+    <line>me<unclear>,–</unclear> he threatened and menaced untill</line>
+    <line>I almost began to think that I was</line>
+    <line>the wicked wretch he said I was. He</line>
+    <line>threatened excomunication and Hell</line>
+    <line>fire in my last moments if I con</line>
+    <line>tinued obdurate. Dear Lady, I had none</line>
+    <line>to support me – all looked on me</line>
+    <line>as a wretch doom to ignominy and</line>
+    <line>perdition; what could I do? In an evil</line>
+    <line>hour I <del rend="strikethrough">confessed</del> subscribed to a lie</line>
+    <line>and now only I am truly miserable." She</line>
+    <line>paused, weeping, and then continued.</line>
+    <line>"I thought with horror, my sweet lady,</line>
+    <line>that you should <del rend="strikethrough">sho</del> believe that</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="49r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0103.xml" xml:id="ox-ms_abinger_c56-0103">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0103.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>133</line></zone>
+  <zone type="library"><line>49</line></zone>
+  <zone type="main">
+    <line>your Justine whom your bessed</line>
+    <line>aunt had so highly honoured and</line>
+    <line>whom you loved, was a wretch capa</line>
+    <line>ble of<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">a</add>
+      </mod> crime which <mod>
+        <del rend="strikethrough">not</del>
+        <add place="superlinear">none</add>
+      </mod> but the</line>
+    <line>devil himself <mod>
+        <del rend="strikethrough">was capable of</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">could have perpetrated</add>
+      </mod>. Dear</line>
+    <line>William, dearest blessed child, I soon</line>
+    <line>shall see you again in heaven &amp;</line>
+    <line>glory and that consoles me going as</line>
+    <line>I am to suffer ignominy and de<add place="superlinear">"</add>ath.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Oh Justine" cried the weeping</line>
+    <line>Elizabeth, "forgive me for having for</line>
+    <line>one moment distrusted you – <del rend="strikethrough">But</del></line>
+    <line>why did<add place="superlinear">you</add> confess? But do not mourn</line>
+    <line>my dear girl, I will every where</line>
+    <line>proclaim your innocence and will</line>
+    <line>force belief. Yet you must die –</line>
+    <line>you my companion, my playfellow,</line>
+    <line>my more than sister— die –I never</line>
+    <line>never can survive so horrible</line>
+    <line>a misfortune".</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Dear Sweet lady," do not weep"–</line>
+    <line><del rend="strikethrough">sai</del> replied Justine"– you ought to</line>
+    <line>raise me <del rend="strikethrough">w</del> with thoughts of a better</line>
+    <line><mod>
+        <del rend="strikethrough">world</del>
+        <add place="superlinear">life<space extent="2" unit="chars"></space>,</add>
+      </mod> and elevate me from the</line>
+    <line>petty cares of this world of injustice</line>
+    <line>and strife –Do not you, excellent</line>
+    <line>Elizabeth drive me to despair."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Elizabeth <del rend="strikethrough">Em</del> embraced the
+      suffer</line>
+    <line>er "I will try to comfort you," said she<unclear>,</unclear></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="49v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0104.xml" xml:id="ox-ms_abinger_c56-0104">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0104.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>134</line></zone>
+  <zone type="main">
+    <line>but this I fear is an evil to<add place="intralinear">o</add> deep and poignant</line>
+    <line>to admit of consolation <del rend="strikethrough">or</del> for there is no hope</line>
+    <line>Yet heaven bless thee, my dearest Justine,</line>
+    <line>with resignation and <mod>
+        <del rend="strikethrough">a hope</del>
+        <add place="superlinear">a confidence</add>
+      </mod> elevated</line>
+    <line>beyond this world. Oh how I hate all its shews</line>
+    <line>and mockeries.– When one creature is</line>
+    <line><mod>
+        <del rend="strikethrough">deprived of life</del>
+        <add place="superlinear">murdered</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">they</del>
+        <del rend="strikethrough">bel</del>
+        <add place="superlinear">another is</add>
+      </mod> immediately <mod spanTo="#c56-0104.01"></mod><delSpan rend="strikethrough" spanTo="#c56-0104.02"></delSpan>mur</line>
+    <line>der<anchor xml:id="c56-0104.02"></anchor>
+      <del rend="strikethrough">another</del><anchor xml:id="c56-0104.03"></anchor><anchor xml:id="c56-0104.01"></anchor> of life in a slow torturing</line>
+    <line>manner &amp; <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add next="#c56-0104.04" place="superlinear">then the executioners their hands yet reeking
+          with the blood of in</add>
+        <add place="sublinear" xml:id="c56-0104.04">nocence</add>
+      </mod> believe that they have done</line>
+    <line><anchor xml:id="c56-0104.05"></anchor>great <mod>
+        <del rend="strikethrough">things</del>
+        <add place="superlinear">deed</add>
+      </mod>. The<add hand="#pbs" place="intralinear">y</add> call this retribution; hate</line>
+    <line>ful name! When that <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">word</add>
+      </mod> is pronounced</line>
+    <line>I know that greater and more horrid</line>
+    <line>punishments are going to be inflicted</line>
+    <line>than the gloomiest tyrant has <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">ever</add>
+      </mod> in</line>
+    <line>venten<add place="intralinear">t</add>e<add place="intralinear">d</add> to satiate<add place="superlinear">his utmost</add> revenge. Yet this</line>
+    <line>is not consolation <mod>
+        <del rend="strikethrough">to</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">for</add>
+      </mod> you, my Justine,</line>
+    <line>unless indeed that you may glory</line>
+    <line>in escaping so miserable a den. Alas!</line>
+    <line>I would I were <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">in peace</add>
+      </mod> with my aunt &amp; my</line>
+    <line>sweet William – <del rend="strikethrough">in peace</del> escaped</line>
+    <line>from light which <mod>
+        <del rend="strikethrough">I abhor</del>
+        <add place="superlinear">is hateful to me</add>
+      </mod> and the</line>
+    <line>visages of men which <delSpan rend="strikethrough" spanTo="#c56-0104.06"></delSpan>are hateful
+      to</line>
+    <line>me.<anchor xml:id="c56-0104.06"></anchor>" I abhor.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Justine smiled languidly. "This, dear Lady</line>
+    <line>said she is despair and not resignation.</line>
+    <line>I must not learn the lesson that you</line>
+    <line>would teach me – talk of somthing else</line>
+    <line><del rend="strikethrough">of fields</del>
+      <del rend="strikethrough">s</del> of something that will <del rend="strikethrough">brig
+        jo</del></line>
+    <line>bring joy and not encrease of misery."</line>
+  </zone>
+  <zone corresp="#c56-0104.03" type="left_margin">
+    <add>deprive</add>
+  </zone>
+  <zone corresp="#c56-0104.05" type="left_margin">
+    <add>a </add>
+  </zone>
+  
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="50r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0105.xml" xml:id="ox-ms_abinger_c56-0105">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0105.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>135</line></zone>
+  <zone type="library"><line>50</line></zone>
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">During this conversation I had retired</line>
+    <line>to a corner of the prison-room where</line>
+    <line>I could conceal the horrid anguish</line>
+    <line>that possessed me– Despair<unclear reason="illegible">!</unclear> Who dared</line>
+    <line>talk of that? The poor victim who</line>
+    <line>on the morrow was to pass the</line>
+    <line>dreary boundary of life &amp; death felt</line>
+    <line>not as I did — Such deep &amp; bitter agony</line>
+    <line>I gnashed my teeth and ground them</line>
+    <line><del rend="strikethrough"><unclear extent="1" unit="chars"></unclear></del> together uttering a
+      groan that came</line>
+    <line>from my inmost soul. Justine started</line>
+    <line><del rend="strikethrough">and</del> when she saw wh<mod>
+        <del rend="overwritten">a</del>
+        <add place="intralinear">o</add>
+        <del rend="strikethrough">t</del>
+      </mod> it was</line>
+    <line>she approached me. "Dear Sir," said</line>
+    <line>she, "you are very kind to visit me;</line>
+    <line>you I hope do not believe that I am</line>
+    <line>guilty."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><del rend="strikethrough">"</del>I could not answer – "No Justine"</line>
+    <line>said Elizabeth; "he is <del rend="strikethrough">even</del> more</line>
+    <line>convinced of your innocence than</line>
+    <line>I was for even when he heard</line>
+    <line>that you had confessed he did not </line>
+    <line><mod>
+        <del rend="strikethrough">believe</del>
+        <anchor xml:id="c56-0105.01"></anchor>
+      </mod> it."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"I truly than<add place="intralinear">k</add> him"–
+      said Justine</line>
+    <line>"In these last minutes I feel the</line>
+    <line>sincerest gratitude for those who</line>
+    <line>still think of me with kindness. How</line>
+    <line>sweet is the affection of others to</line>
+    <line>such a wretch as I am – It removes</line>
+    <line>more than half my misfortune</line>
+    <line>and I feel as if I could die in <del rend="strikethrough">pea</del></line>
+  </zone>
+  <zone corresp="#c56-0105.01" type="left_margin">
+    <add>credit</add>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="50v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0106.xml" xml:id="ox-ms_abinger_c56-0106">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0106.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>136</line></zone>
+  <zone type="main">
+    <line>peace. <del rend="strikethrough"><unclear>thn</unclear></del> now that my innocence is
+      acknow</line>
+    <line>ledged by you, sweet lady, and your cousin."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Thus the poor sufferer <del rend="strikethrough">cr</del>
+      tried</line>
+    <line>to comfort others and herself. She indeed</line>
+    <line>gained the resignation she wished for</line>
+    <line>but I the true murderer <del rend="strikethrough">w</del> felt</line>
+    <line>the never dying worm alive <mod>
+        <del rend="strikethrough">and I was</del>
+        <add hand="#pbs" place="superlinear">which</add>
+      </mod></line>
+    <line>allowed no hope or consolation. Eliza</line>
+    <line>beth also wept and was unhappy but</line>
+    <line>hers<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">also</add>
+      </mod> was <del rend="strikethrough">also</del> the misery of innocence</line>
+    <line><anchor xml:id="c56-0106.01"></anchor>like a cloud <mod>
+        <del rend="strikethrough">that</del>
+        <add place="superlinear">that</add>
+      </mod> passes over the</line>
+    <line>fair moon <mod>
+        <del rend="strikethrough">which</del>
+        <add place="superlinear">&amp;</add>
+      </mod> for a while</line>
+    <line><mod><restore type="smear_strikethrough"><del rend="strikethrough">hi</del></restore></mod>des but
+      cannot <mod>
+        <del rend="strikethrough">disturb</del>
+        <add hand="#pbs" place="superlinear">destroy</add>
+      </mod> its brightness</line>
+    <line><del rend="strikethrough">but</del>
+      <del rend="strikethrough">misery</del>
+      <del rend="strikethrough">&amp;</del>
+      <del rend="strikethrough">desp</del> anguish and</line>
+    <line>despair had <del rend="strikethrough">penetr</del> penetrated into</line>
+    <line>the core of my heart – I bore a hell</line>
+    <line>within me that nothing could <mod>
+        <del rend="strikethrough">diminish</del>
+        <del rend="unmarked">.</del>
+        <add hand="#pbs" place="superlinear">extinguish.</add>
+      </mod></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We staid several hours with Justine</line>
+    <line>and <del rend="strikethrough">with</del> it was with great difficulty</line>
+    <line>that Elizabeth tore herself away</line>
+    <line>"I wish" cried she that I were to die</line>
+    <line>with you – I cannot live in th<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">is</add>
+      </mod> world</line>
+    <line>of misery." Justine assumed an air</line>
+    <line>of Cheerfullness whi<mod>
+        <del rend="overwritten">ch</del>
+        <add place="intralinear">le</add>
+      </mod> she with diffi</line>
+    <line>culty repressed the bitter tears – "Farewell</line>
+    <line>sweet lady, dearest Elizabeth may heaven</line>
+    <line>in its bounty bless and preserve you</line>
+  </zone>
+  <zone corresp="#c56-0106.01" type="left_margin">
+    <add><mod>
+        <del rend="strikethrough">that</del>
+        <add place="superlinear">which </add>
+      </mod></add>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="51r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0107.xml" xml:id="ox-ms_abinger_c56-0107">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0107.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>137</line></zone>
+  <zone type="library"><line>51</line></zone>
+  <zone type="main">
+    <line>May this be the last misfortune that</line>
+    <line>you will ever suffer. – live &amp; be happy</line>
+    <line>to make <del rend="strikethrough">of</del> others so.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1"><space extent="4" unit="chars"></space>As We returned Elizabeth said, You</line>
+    <line>do not know, my dear Victor, <del rend="strikethrough">w</del> how</line>
+    <line>much I am relieved now that I trust</line>
+    <line>in the innocence of this unfortunate</line>
+    <line>girl. I never could again have</line>
+    <line>known peace if I had been deceived</line>
+    <line>in my reliance on her. For the mo</line>
+    <line>ment that I did believe it I felt</line>
+    <line><del rend="strikethrough">such</del> anguish that I could not have</line>
+    <line>long sustained. Now my heart is light</line>
+    <line>ened. The innocent suffers – but she</line>
+    <line>whom I thought amiable and good</line>
+    <line>is not wicked and I am consoled."</line>
+    <milestone unit="tei:p"></milestone>
+    <line><mod>
+        <add place="intralinear">Amiable</add>
+        <del rend="strikethrough">Sweet</del>
+      </mod> Cousin! Such were your</line>
+    <line>thoughts mild and gentle as your</line>
+    <line>dear eyes <del rend="strikethrough">&amp;</del>
+      <del rend="strikethrough">gentle tone</del> and voice<unclear>.</unclear></line>
+    <line>but I.—— I was a wretch <del rend="strikethrough">none</del> &amp;</line>
+    <line>none ever conceived <del rend="strikethrough">of</del> the misery</line>
+    <line>that I then suffered.</line>
+    
+ 
+  </zone>
+  
+    
+  
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="51v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0108.xml" xml:id="ox-ms_abinger_c56-0108">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0108.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>138</line></zone>
+ 
+
+  <zone type="main">
+    <line rend="indent3"><milestone spanTo="#c56-0108.08" unit="tei:head"></milestone>Chap. 13<hi rend="underline"><hi rend="sup">th</hi></hi><anchor xml:id="c56-0108.08"></anchor></line>
+    <line rend="indent1">Nothing is more painful <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">than</add>
+      </mod> when the</line>
+    <line>mind has been worked up by a <add place="intralinear">quick</add></line>
+    <line><del rend="strikethrough">S</del> succession of events, <mod spanTo="#c56-0108.05"></mod><delSpan rend="strikethrough" spanTo="#c56-0108.01"></delSpan>for a dead calm</line>
+    <line>of inaction and certainty to<anchor xml:id="c56-0108.01"></anchor><anchor xml:id="c56-0108.02"></anchor><anchor xml:id="c56-0108.05"></anchor> follow<add hand="#pbs" place="intralinear">s</add>
+      <mod>
+        <del rend="strikethrough">which</del>
+        <add hand="#pbs" place="superlinear">and</add>
+      </mod></line>
+    <line>deprives the <mod>
+        <del rend="strikethrough">mind</del>
+        <add place="superlinear">soul</add>
+      </mod> both of hope or fear.</line>
+    <line>Justine died— She rested. <mod>
+        <del rend="strikethrough">But</del>
+        <add place="superlinear">&amp;</add>
+      </mod> I was alive</line>
+    <line>the blood flowed freely in my veins but</line>
+    <line>a weight of despair &amp; remorse pressed</line>
+    <line>on my heart which nothing could remove–</line>
+    <delSpan rend="vertical_line" spanTo="#c56-0108.04"></delSpan>
+    <line>our house was a house of mourning–</line>
+    <line>My fathers health was deeply shaken by</line>
+    <line>the horror of the recent events; Eliza</line>
+    <line>beth was sad and desponding– She no longer</line>
+    <line>took delight in her ordinary occupa</line>
+    <line>tions all pleasure seemed to her sacri</line>
+    <line>ledge towards the dead— eternal woe</line>
+    <line>and tears she then thought was the</line>
+    <line>just tribute she ought to pay to inno</line>
+    <line>cence thus blasted &amp; <del rend="strikethrough">destroyed</del><anchor xml:id="c56-0108.04"></anchor>
+      <retrace cause="unclear">S</retrace>leep fled</line>
+    <line>from my eyes. I wandered like an</line>
+    <line>evil spirit for I <mod>
+        <del rend="strikethrough">done</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">had committed deeds of</add>
+      </mod> mischief beyond</line>
+    <line>description <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">horrible,</add>
+      </mod> and <del rend="smear"><add place="superlinear">hor</add></del> more much more (I</line>
+    <line>persuaded my self) was yet in store.</line>
+    <line>Yet my heart overflowed with kind</line>
+    <line>ness and <mod>
+        <del rend="strikethrough">benevolence</del>
+        <add place="superlinear">goodness</add>
+      </mod> – I had begun life</line>
+    <line>with benevolent intentions and thirsted for</line>
+    <line>the moment when I <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">could</add>
+      </mod> put them in practise</line>
+  </zone>
+
+  <zone corresp="#c56-0108.02" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0108.03"></addSpan>
+    <line xml:id="c56-0108.06">of inaction &amp; certainty</line>
+    <line><milestone spanTo="#c56-0108.09" unit="tei:seg" xml:id="c56-0108.07"></milestone>the dead calmness<anchor xml:id="c56-0108.09"></anchor>
+      <add><metamark function="insert">^</metamark>which</add><listTranspose>
+        <transpose>
+          <ptr target="#c56-0108.07"></ptr>
+          <ptr target="#c56-0108.06"></ptr>
+        </transpose>
+      </listTranspose></line><anchor xml:id="c56-0108.03"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="52r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0109.xml" xml:id="ox-ms_abinger_c56-0109">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0109.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>139</line></zone>
+  <zone type="library"><line>52</line></zone>
+  <zone type="main">
+    <line>and make myself useful to my fellow</line>
+    <line>beings. <del rend="strikethrough">But</del>
+      <mod>
+        <del rend="overwritten">n</del>
+        <add hand="#pbs" place="intralinear">N</add>
+      </mod>ow all was blasted<add hand="#pbs" place="intralinear">;</add> Instead</line>
+    <line>of seren<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">i</add>
+      </mod>ty of conscience which allowed me</line>
+    <line>to look back on my actions with self satis</line>
+    <line>faction, and from thence <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">to gather promise of</add>
+      </mod> new hopes <delSpan rend="strikethrough" spanTo="#c56-0109.01"></delSpan>like</line>
+    <line>gay<unclear>-</unclear>sweet-smelling flowers to spring up</line>
+    <line>with <hi rend="underline">regard</hi> to futurity<anchor xml:id="c56-0109.01"></anchor>. I was
+      seized by</line>
+    <line>remorse and guilt<unclear>,</unclear> and hurried away</line>
+    <line>to a hell <mod>
+        <del rend="strikethrough">no tongue</del>
+        <add hand="#pbs" place="superlinear">of intense tortures such as</add>
+      </mod> no language can</line>
+    <line>describe.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">This state of mind <mod>
+        <del rend="strikethrough">allt</del>
+        <del rend="strikethrough">altered</del>
+        <add hand="#pbs" place="superlinear">preyed upon</add>
+      </mod> my health</line>
+    <line>which had <mod>
+        <del rend="strikethrough">nearly</del>
+        <add place="superlinear">entirely</add>
+      </mod> recovered from the</line>
+    <line>first shock it had sustained. I shunned</line>
+    <line>the face of man; all sound of joy or</line>
+    <line>complacency was torture to me<add hand="#pbs" place="intralinear">;</add> Solitude</line>
+    <line>was my only consolation deep, dark, <del rend="strikethrough">night</del></line>
+    <line>death-like solitude. My father observed</line>
+    <line>with pain <mod>
+        <del rend="strikethrough">how</del>
+        <add hand="#pbs" place="superlinear">the alteration perceptible in</add>
+      </mod> my dispositions &amp; habits,</line>
+    <line><del rend="strikethrough">were altered</del> and endeavoured to reason</line>
+    <line>with me on the folly of giving way to immo</line>
+    <line>derate grief. "Do you think, Victor" said he</line>
+    <line>"That I do not suffer also– no one <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">could</add>
+      </mod> love<del rend="strikethrough">d</del></line>
+    <line>a child more than I <mod>
+        <del rend="strikethrough">did</del>
+        <add hand="#pbs" place="superlinear">loved</add>
+      </mod> your brother–</line>
+    <line>(<del rend="strikethrough">and</del> tears came <del rend="strikethrough">into</del> into
+      his eyes as he</line>
+    <line>said this) but is <add hand="#pbs" place="superlinear">it</add> not <mod>
+        <del rend="strikethrough">th</del>
+        <del rend="strikethrough">our</del>
+        <add hand="#pbs" place="superlinear">a</add>
+      </mod> duty <delSpan rend="strikethrough" spanTo="#c56-0109.02"></delSpan>not to</line>
+    <line>add to the grief of<anchor xml:id="c56-0109.02"></anchor>
+      <del rend="strikethrough">owed</del> to the<del rend="strikethrough">ir</del> survivors</line>
+    <line><mod>
+        <del rend="strikethrough">not</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">to</add></del>
+        <del rend="strikethrough">add to</del>
+        <anchor xml:id="c56-0109.03"></anchor>
+      </mod> their unhappiness by an appear</line>
+    <line>ance of immoderate grief. It is also a duty</line>
+    <line>owed to yourself; for excessive sorrow</line>
+    <line>prevents improvement or enjoyment, or</line>
+    <line>even the discharge of day<add hand="#pbs" place="intralinear">ly</add> usefullness</line>
+    <line>without which no man is fit for</line>
+  </zone>
+  <zone corresp="#c56-0109.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0109.04"></addSpan>
+    <line>that we</line>
+    <line>should re</line>
+    <line>-frain from</line>
+    <line><del rend="strikethrough">adding to</del></line>
+    <line>augmenting</line>
+    <anchor xml:id="c56-0109.04"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="52v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0110.xml" xml:id="ox-ms_abinger_c56-0110">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0110.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>140</line></zone>
+  <zone type="main">
+    <line>society."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">This advice, although good, was utterly inna-</line>
+    <line>-plicable to my case; I should have been</line>
+    <line>the first to hide my grief and console</line>
+    <line>my friends if remorse had not mingled its</line>
+    <line>bitterness with my other sensations. Now</line>
+    <line>I could only answer my father with a</line>
+    <line>look of despair and endeavour to</line>
+    <line>hide myself from his view. About this</line>
+    <line>time <del rend="strikethrough">also</del> we retired to our house at</line>
+    <line>Belrive. This <del rend="strikethrough">chal</del> change was very</line>
+    <line>agreable to me in particular. The</line>
+    <line>shutting of the gates of the town regularly</line>
+    <line>at ten o'clock and the impossibility of</line>
+    <line><mod>
+        <del rend="strikethrough">stay</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">ing</add></del>
+        <anchor xml:id="c56-0110.01"></anchor>
+      </mod> on the lake after that hour</line>
+    <line>rendered our residence within the</line>
+    <line>walls of Geneva very irksome to me.</line>
+    <line>I was now free: often, after the rest of</line>
+    <line>the family had retired for the night</line>
+    <line>I took the boat and passed the</line>
+    <line>night upon the water: sometimes</line>
+    <line>with my sails set I was carried by the</line>
+    <line>wind and sometimes after <del rend="strikethrough">wo</del> rowing</line>
+    <line>into the middle of the lake I left the</line>
+    <line>boat to <mod>
+        <del rend="strikethrough">take</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">pursue</add>
+      </mod> its own course and</line>
+    <line><mod>
+        <del rend="strikethrough">followed</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <anchor xml:id="c56-0110.02"></anchor>
+        <add place="superlinear" xml:id="c56-0110.03">to</add>
+      </mod> my own miserable reflections.</line>
+    <line>I was often tempted <del rend="strikethrough">w</del> when all was <mod>
+        <del rend="strikethrough">quiet</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">at peace</add>
+      </mod></line>
+    <line>around me and I the only unquiet</line>
+    <line>thing that wandered restless in a scene</line>
+  </zone>
+  <zone corresp="#c56-0110.01" type="left_margin">
+    <line><add hand="#pbs">remaining</add></line>
+  </zone>
+  <zone corresp="#c56-0110.02" type="left_margin">
+    <line><add next="#c56-0110.03">gave way </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="53r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0111.xml" xml:id="ox-ms_abinger_c56-0111">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0111.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>141</line></zone>
+  <zone type="library"><line>53</line></zone>
+  <zone type="main">
+    <line>so beautiful <add place="intralinear">&amp;</add> heavenly; if I except</line>
+    <line>alone some bat, or the<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">frogs, whose</add>
+      </mod> harsh and</line>
+    <line>interrupted croaking <del rend="strikethrough">of the frogs</del><mod>
+        <del rend="strikethrough">which</del>
+        <add hand="#pbs" place="superlinear">was</add>
+      </mod></line>
+    <line><del rend="strikethrough">I</del> heard only when I app<retrace cause="unclear">r</retrace>oached the</line>
+    <line>shore; often I say, I was tempted to</line>
+    <line>plunge into the <del rend="strikethrough">still and</del> silent lake</line>
+    <line><mod>
+        <del rend="strikethrough">and let</del>
+        <add hand="#pbs" place="superlinear">that</add>
+      </mod> the waters<mod>
+        <add place="sublinear"><metamark function="insert">&gt;^</metamark></add>
+        <add hand="#pbs" place="superlinear">might</add>
+      </mod> close over me &amp;</line>
+    <line>my calamities for ever. But I was</line>
+    <line>restrained when I thought of the heroic</line>
+    <line><add place="intralinear">&amp; </add>suffering Elizabeth whom I tenderly</line>
+    <line>loved, and whose existence was bound</line>
+    <line>up in mine. And then I thought also</line>
+    <line>of my father and surviving brother; <del rend="strikethrough">And</del></line>
+    <line>should I not by my base desertion leave</line>
+    <line>them exposed &amp; unprotected to the</line>
+    <line>mali<mod>
+        <del rend="overwritten"><unclear>s</unclear></del>
+        <add place="intralinear">c</add>
+      </mod>e of the fiend <del rend="strikethrough">I</del> whom I had</line>
+    <line>let lose among them? At these</line>
+    <line>moments I wept bitterly and wished</line>
+    <line>that peace would revisit my mind <add place="sublinear"><metamark function="displacement" xml:id="c56-0111.02">^</metamark></add></line>
+    <line>that I might afford them consolation</line>
+    <line>and happiness — but that could not</line>
+    <line>be: remorse <mod>
+        <del rend="strikethrough">took away</del>
+        <add hand="#pbs" place="superlinear">extinguished</add>
+      </mod> every hope—</line>
+    <line>I had been the <mod>
+        <del rend="strikethrough">cause</del>
+        <add hand="#pbs" place="superlinear">author</add>
+      </mod> of unalterable</line>
+    <line>evil, and I lived in daily fear <mod spanTo="#c56-0111.03"></mod><delSpan rend="strikethrough" spanTo="#c56-0111.04"></delSpan>that</line>
+    <line>the dæmon<anchor xml:id="c56-0111.04"></anchor>
+      <delSpan rend="strikethrough" spanTo="#c56-0111.05"></delSpan>of some new wickedness</line>
+    <line>which<anchor xml:id="c56-0111.05"></anchor><add place="superlinear">let</add><anchor xml:id="c56-0111.03"></anchor> the monster whom I had</line>
+    <line>created might <mod>
+        <del rend="strikethrough">commit</del>
+        <add place="superlinear">perpetrate</add>
+        <add hand="#pbs" place="superlinear">some new wickedness.</add>
+      </mod> –I had a<mod>
+        <add hand="#pbs" place="intralinear">n</add>
+        <add hand="#pbs" place="superlinear">obscure</add>
+      </mod> feeling</line>
+    <line>that all was not over, and that</line>
+    <line>he would still commit some signal</line>
+  </zone>
+  
+  <zone corresp="#c56-0111.02" type="left_margin">
+    <line><add hand="#pbs"><del rend="strikethrough">if</del> only —</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="53v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0112.xml" xml:id="ox-ms_abinger_c56-0112">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0112.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>142</line></zone>
+  <zone type="main">
+    <line><del rend="strikethrough">cr</del> crime which by its enormity would</line>
+    <line><anchor xml:id="c56-0112.01"></anchor>efface the recollection of the past. <add place="superlinear"><metamark function="displacement" xml:id="c56-0112.02">X</metamark></add>
+      My</line>
+    <line>abhorrence of this fiend cannot be</line>
+    <line>conceived – When I thought of him I</line>
+    <line>gnashed my teeth my eyes became inflam</line>
+    <line>ed and I ardently wished to extinguish</line>
+    <line>that life which I had so thoughtlessly</line>
+    <line>bestowed. When I <del rend="strikethrough">though</del> reflected on his</line>
+    <line>crimes and malice, my hatred and</line>
+    <line>revenge burst all bounds of moderation</line>
+    <line><delSpan rend="strikethrough" spanTo="#c56-0112.04"></delSpan>I wished but to see him again that
+      I</line>
+    <line>might<anchor xml:id="c56-0112.04"></anchor> I would have made a pilgrimage</line>
+    <line>to the highest<add hand="#pbs" place="superlinear">peak of the</add> Andes could I when
+      there</line>
+    <line>have precipitated him to their <mod>
+        <del rend="strikethrough">foot</del>
+        <add hand="#pbs" place="superlinear">base</add>
+      </mod>; I</line>
+    <line>wished but to see him again that</line>
+    <line>I might wreak the utmost extent of</line>
+    <line>anger on his head and avenge the</line>
+    <line>deaths of William and Justine.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Our house was <del rend="strikethrough">now</del> the
+      house</line>
+    <line>of mourning, my father's health was deeply</line>
+    <line>shaken by the horror of the recent</line>
+    <line>events. Elizabeth was sad and desponding</line>
+    <line>she no longer took delight in her</line>
+    <line>ordinary occupations; all pleasure seemed</line>
+    <line>to her sacriledge towards the dead; eter<anchor xml:id="c56-0112.05"></anchor></line>
+    <line>woe and tea<mod>
+        <del rend="overwritten">s</del>
+        <add place="intralinear">rs</add>
+      </mod> she then thought was the</line>
+    <line>just tribute she should pay to innocence</line>
+    <line>so blasted and destroyed. She was no longer</line>
+    <line>that happy creature <del next="#c56-0113.02" rend="strikethrough" xml:id="c56-0112.99">she had been when</del></line>
+  </zone>
+  <zone corresp="#c56-0112.01" type="left_margin">
+    <line><add>almost </add></line>
+  </zone>
+  <zone corresp="#c56-0112.02" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0112.03"></addSpan>
+    <line><metamark function="displacement"><hi rend="sup">X</hi></metamark>There was</line>
+    <line>always scope</line>
+    <line>for fear so</line>
+    <line>long as any</line>
+    <line>thing that</line>
+    <line>I loved remained</line>
+    <line>alive.</line>
+    <anchor xml:id="c56-0112.03"></anchor>
+  </zone>
+  <zone corresp="#c56-0112.05" type="left_margin">
+    <line><add><metamark>=</metamark>nal</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5428" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="54r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0113.xml" xml:id="ox-ms_abinger_c56-0113">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0113.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>143</line></zone>
+  <zone type="library"><line>54</line></zone>
+  <zone type="main">
+    <line><del prev="#c56-0112.99" rend="strikethrough">last saw her</del><anchor xml:id="c56-0113.03"></anchor><anchor xml:id="c56-0113.01"></anchor>
+      <del rend="unmarked">– <mod>
+          <del rend="overwritten">who</del>
+          <add hand="#pbs" place="intralinear">had</add>
+        </mod></del> wandered with</line>
+    <line><del rend="strikethrough">on</del> me on the banks of the lake</line>
+    <line>and talked with extacy of our future</line>
+    <line>prospects– She <mod>
+        <del rend="strikethrough">was</del>
+        <add hand="#pbs" place="superlinear">had become</add>
+      </mod> grave, and often</line>
+    <line><mod>
+        <del rend="strikethrough">talked</del>
+        <anchor xml:id="c56-0113.05"></anchor>
+      </mod> of the inconstancy of fortune</line>
+    <line>and the instability of human life—</line>
+    <line>"When I reflect, my dear Cousin," she said "on</line>
+    <line>the miserable death of Justine Moritz, I</line>
+    <line>no longer see <del rend="strikethrough">things</del> the world and its</line>
+    <line>works in the same light as they before</line>
+    <line>appeared to <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">me.</add>
+      </mod> Before – <mod>
+        <del rend="strikethrough">Stories</del>
+        <add place="superlinear">I looked upon the</add>
+      </mod> accounts of vice</line>
+    <line>and injustice that I read in books or heard</line>
+    <line>from others as tales of ancient days or</line>
+    <line>imaginary evils<mod>
+        <add hand="#pbs" place="intralinear">;</add>
+        <add place="superlinear"><metamark function="displacement" xml:id="c56-0113.06">X</metamark></add>
+      </mod> but now misery has</line>
+    <line>come home and men appear to me as</line>
+    <line>monsters thirsting for each others blood.</line>
+    <line>Yet I am certainly unjust.–Every one</line>
+    <line>believed that poor girl to be guilty, and</line>
+    <line>if she <mod>
+        <del rend="strikethrough">had</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">could have committed the crime for which she suffered,
+          assuredly she</add>
+      </mod> would <del rend="strikethrough">she not</del> have been</line>
+    <line>the most depraved of <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">human</add>
+      </mod> creatures. For the</line>
+    <line>sake of a few jewels to have murdered</line>
+    <line>the son of her benefactor &amp; friend, a child</line>
+    <line>whom she had nursed from its birth</line>
+    <line>and appeared to love as if it had been</line>
+    <line><del rend="strikethrough">its</del> her own. I could not consent to the</line>
+    <line>death of any human being <mod>
+        <del rend="strikethrough">yet</del>
+        <add place="superlinear">but</add>
+      </mod> certainly</line>
+    <line>I should have thought such a <mod spanTo="#c56-0113.09"></mod><del next="#c56-0113.10" rend="strikethrough">woman</del><add hand="#pbs" next="#c56-0113.11" place="superlinear">being</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0113.10">unworthy of life</del>
+      <add hand="#pbs" place="superlinear" xml:id="c56-0113.11"><del rend="strikethrough">as</del>
+        unfit to remain in the society of men.</add><anchor xml:id="c56-0113.09"></anchor> – Yet she
+        <del rend="strikethrough">she</del> was inno</line>
+    <line>cent–I know<del rend="vertical_line">–</del>I feel she was innocent
+      You</line>
+    <line>are of the same opinion and that</line>
+    <line>confirms me. Alas, Victor! when <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough">lies</del>
+        <del rend="strikethrough">appear</del>
+        <add place="superlinear">falsehood <del rend="strikethrough">look</del></add>
+      </mod></line>
+  </zone>
+  <zone corresp="#c56-0113.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0113.04"></addSpan>
+    <line>who in earlier</line>
+    <line>youth had </line>
+    <anchor xml:id="c56-0113.04"></anchor>
+  </zone>
+  <zone corresp="#c56-0113.05" type="left_margin">
+    <line><add>conversed</add></line>
+  </zone>
+  <zone corresp="#c56-0113.06" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0113.07"></addSpan>
+    <line><metamark function="displacement"><hi rend="sup">X</hi></metamark>At least they</line>
+    <line>were remote,</line>
+    <line>and more</line>
+    <line>familiar to <delSpan spanTo="#c56-0113.08"></delSpan>the</line>
+    <line>beli<anchor xml:id="c56-0113.08"></anchor> reason than</line>
+    <line>to imagination</line>
+    <anchor xml:id="c56-0113.07"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="54v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0114.xml" xml:id="ox-ms_abinger_c56-0114">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0114.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>144</line></zone>
+  <zone type="main">
+    <line><anchor xml:id="c56-0114.01"></anchor>so like the truth, who can assure them</line>
+    <line>selves of certain happiness? I feel as if I</line>
+    <line>were walking on the edge of precipiece</line>
+    <line>towards which thousands are crowding &amp;</line>
+    <line>endeavouring to plunge me into the</line>
+    <line>abyss.<unclear>–</unclear> William &amp; Justine were assassi</line>
+    <line>nated and the murderer escap<mod>
+        <del rend="overwritten">s</del>
+        <add place="intralinear">es</add>
+      </mod>, wearing</line>
+    <line>human lineaments; he walks abou<mod>
+        <del rend="overwritten">l</del>
+        <add place="intralinear">t</add>
+        <del rend="strikethrough">d</del>
+      </mod></line>
+    <line>the world free &amp; perhaps respected.</line>
+    <line>But <del rend="strikethrough">if</del> even if <del rend="strikethrough">tomo</del> I were
+      condemmed</line>
+    <line>to suffer on the scaffold for the same</line>
+    <line>crimes I would not change places with</line>
+    <line>such a wretch."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I listened to this discourse with the</line>
+    <line>extremest agony – I – not <mod>
+        <del rend="strikethrough"><unclear extent="2" unit="chars"></unclear></del>
+        <del rend="strikethrough">ind</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">in</add>
+      </mod> deed</line>
+    <line>but in effect was the true murderer.—</line>
+    <line>Elizabeth read my anguish in my counte</line>
+    <line>nance, and kindly taking my hand</line>
+    <line>said–"My dearest cousin, you must</line>
+    <line>calm yourself; these events have affect</line>
+    <line>ed me <mod>
+        <del rend="overwritten">g</del>
+        <add place="intralinear">G</add>
+      </mod>od knows how deeply! but I am</line>
+    <line>not so wretched as you are. There is an</line>
+    <line>expression of misery and sometimes of</line>
+    <line>revenge in your countenance that</line>
+    <line>makes me tremble; be calm, my <mod>
+        <restore type="stetdots">
+          <del rend="strikethrough">beloved</del>
+        </restore>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear"><unclear>best</unclear></add></del>
+      </mod></line>
+    <line>Victor, I <mod>
+        <del rend="overwritten">c</del>
+        <add place="intralinear">w</add>
+      </mod>ould sacrifice my life to your</line>
+    <line>peace. We surely shall be happy; <del rend="strikethrough">quite</del></line>
+    <line>quiet in our native country and not</line>
+  </zone>
+  <zone corresp="#c56-0114.01" type="left_margin">
+    <line><add>can look </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5428" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="55r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0115.xml" xml:id="ox-ms_abinger_c56-0115">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0115.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>1<mod><del rend="overwritten">3</del><add place="intralinear">4</add></mod>5</line></zone>
+  <zone type="library"><line>55</line></zone>
+  <zone type="main">
+    <line>mingling in the world what can dis</line>
+    <line>-turb our tranquillity?"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">She shed tears as she said this <add place="sublinear"><metamark function="displacement" xml:id="c56-0115.01">^</metamark></add></line>
+    <line><del rend="strikethrough">but</del><add hand="#pbs" place="intralinear">but</add> at the
+      same time <retrace cause="unclear" hand="#pbs">s</retrace>miled, that</line>
+    <line>she might chase away the fiend that</line>
+    <line>lurked in my heart. My father who saw</line>
+    <line>in the unhappiness that was painted in</line>
+    <line>my face, only an exag<add place="intralinear">g</add>eration of that</line>
+    <line><del rend="strikethrough">w</del> sorrow which I might naturally</line>
+    <line>feel thought that an amusement</line>
+    <line>suited to my taste would be the best</line>
+    <line>means of restoring to me my wonted</line>
+    <line>serenity – It was <del rend="strikethrough">th</del> fro<mod>
+        <del rend="overwritten">n</del>
+        <add place="intralinear">m</add>
+      </mod> this cause that</line>
+    <line>he<del rend="strikethrough">a</del> had removed to the country &amp; <mod>
+        <del rend="strikethrough">from</del>
+        <anchor xml:id="c56-0115.03"></anchor>
+      </mod></line>
+    <line>the same reasons he now proposed</line>
+    <line>that <del rend="strikethrough">I</del> we should all <del rend="strikethrough">tak</del>
+      take a</line>
+    <line>journey to the Valley of C<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">h</add>
+      </mod>amounix. I had</line>
+    <line>been there before but Elizabeth &amp; Ernest</line>
+    <line>never had, and both had often ex</line>
+    <line>pressed a wish to see this place which</line>
+    <line>had been described to them as so wonderful</line>
+    <line>&amp; sublime. Accordingly we departed from</line>
+    <line>Geneva on this tour about the middle</line>
+    <line>of the month of august <del rend="strikethrough">more</del>
+      <del rend="strikethrough">than</del> nearly</line>
+    <line>two months after the death of Justine.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The weather was beautiful and if</line>
+    <line>mine<del rend="strikethrough">d</del> had been a sorrow to be chased</line>
+    <line>away by any fleeting circumstance this</line>
+    <line>voyage would certainly have had the</line>
+    <line>effect <mod>
+        <del rend="strikethrough">which</del>
+        <add hand="#pbs" place="superlinear">intended by</add>
+      </mod> my father <del rend="strikethrough">intended</del>. As it</line>
+  </zone>
+  <zone corresp="#c56-0115.01" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0115.02"></addSpan>
+    <line>distrusting the</line>
+    <line>very solace</line>
+    <line>which she</line>
+    <line>gave,</line>
+    <anchor xml:id="c56-0115.02"></anchor>
+  </zone>
+  <zone corresp="#c56-0115.03" type="left_margin">
+    <line><add hand="#pbs">induced by</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="55v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0116.xml" xml:id="ox-ms_abinger_c56-0116">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0116.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>146</line></zone>
+  <zone type="main">
+    <line>was I wa<retrace cause="unclear" hand="#pbs">s</retrace>
+      <add hand="#pbs" place="superlinear">somewhat</add> interrested <mod spanTo="#c56-0116.01"></mod>
+      <del next="#c56-0116.02" rend="strikethrough">and sometimes</del><add hand="#pbs" next="#c56-0116.03" place="superlinear">in the scene..it sometimes</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0116.02">amused<del rend="unmarked">.</del>
+      </del><anchor xml:id="c56-0116.05"></anchor><add hand="#pbs" place="superlinear" xml:id="c56-0116.04"><del rend="strikethrough">somehow</del> could not extinguish my grief.</add><anchor xml:id="c56-0116.01"></anchor>
+      <add hand="#pbs" place="sublinear">during</add>The first day we travelled</line>
+    <line>in a carriage. In the morning we</line>
+    <line>had seen the mountains at a distance</line>
+    <line>to which we gradually advanced. <del rend="strikethrough">Br</del></line>
+    <line>We perceived that the valley through</line>
+    <line>which we wound, and which was</line>
+    <line>formed by the Arve whose course</line>
+    <line>we followed, closed upon us by degrees</line>
+    <line>and when the sun had set we</line>
+    <line>saw immense mountains &amp; preci</line>
+    <line>pieces overhanging <add hand="#pbs" place="superlinear">us</add> on <mod>
+        <del rend="strikethrough">each</del>
+        <add hand="#pbs" place="superlinear">every</add>
+      </mod>side</line>
+    <line><del rend="strikethrough">of us</del> &amp; heard the sound of <mod spanTo="#c56-0116.06"></mod><del next="#c56-0116.07" rend="strikethrough">moun</del><add hand="#pbs" next="#c56-0116.08" place="superlinear">the river raging</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0116.07">tain</del>
+      <del rend="strikethrough">streams</del><add hand="#pbs" place="superlinear" xml:id="c56-0116.08">among rocks</add><anchor xml:id="c56-0116.06"></anchor>, and the dashing of the</line>
+    <line>waterfalls<del rend="unmarked">.</del><add hand="#pbs" place="intralinear">around.</add></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The next day we pursued our</line>
+    <line>journey on mules and as we ascended</line>
+    <line>still higher; the valley assumed a</line>
+    <line>more beautiful &amp; verdant appear</line>
+    <line>ance – Ruined castles <mod>
+        <del rend="strikethrough">on</del>
+        <add place="sublinear">^</add>
+        <add hand="#pbs" place="superlinear"><mod>
+            <del rend="strikethrough">built</del>
+            <add place="superlinear">hanging</add>
+          </mod> on the precipices of</add>
+      </mod> piny mountains;</line>
+    <line>the impetuous Arve, and cottages every</line>
+    <line>here &amp; there peeping from among the</line>
+    <line>trees, formed a scene of singular</line>
+    <line>beauty.. But it was augment<add place="intralinear">ed</add> &amp;</line>
+    <line>rendered sublime by the mighty</line>
+    <line>alps whose white <add place="superlinear">&amp;</add> shining <del rend="strikethrough">pir</del></line>
+    <line>piramids &amp; domes towered above</line>
+    <line>all like <del rend="strikethrough">the</del> another earth —the</line>
+  </zone>
+  <zone corresp="#c56-0116.05" type="left_margin">
+    <line><add hand="#pbs" next="#c56-0116.04" xml:id="c56-0116.03">lulled, <hi rend="underline">it</hi></add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5428" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="56r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0117.xml" xml:id="ox-ms_abinger_c56-0117">
+    <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0117.jp2"></graphic>
+    <zone rend="bordered" type="pagination"><line>147</line></zone>
+    <zone type="library"><line>56</line></zone>
+    <zone type="main">
+        <line>habitations of another race of beings</line>
+        <delSpan rend="vertical_line" spanTo="#c56-0117.01"></delSpan>
+        <line>Soon<del rend="strikethrough">e</del> after we entered the valley of</line>
+        <line>Chamounix. This valley is more <mod spanTo="#c56-0117.06"></mod><delSpan rend="strikethrough" spanTo="#c56-0117.02"></delSpan>beauti</line>
+        <line>ful<anchor xml:id="c56-0117.02"></anchor><anchor xml:id="c56-0117.03"></anchor><anchor xml:id="c56-0117.06"></anchor> and sublime but not so beau</line>
+        <anchor xml:id="c56-0117.01"></anchor>
+        <line>We passed the bridge of <del rend="strikethrough">Pellisier</del></line>
+        <line>Pellissier, where the ravine which the</line>
+        <line>river forms opened before us and</line>
+        <line>we began to ascend the mountain</line>
+        <line>which over hung it–. Soon after we</line>
+        <line>entered the Valley of Chamounix. This</line>
+        <line>valley is more wonderful and sublime</line>
+        <line>but not so beautiful &amp; picturesque</line>
+        <line>as that of Servox; through which we</line>
+        <line>had just passed. The high &amp; snowy</line>
+        <line>mountains w<del rend="strikethrough">h</del>ere its boundaries</line>
+        <line>but <del rend="strikethrough">t</del> we saw no more ruined castles</line>
+        <line>or fertile fields. Immense glaciers</line>
+        <line>approached the road, <del rend="strikethrough">and</del> we heard</line>
+        <line>the rumbling thunder of the falling</line>
+        <line>Avelanche and marked the smoke</line>
+        <line>of its passage.–Mont Blanc, the <mod spanTo="#c56-0117.07"></mod><delSpan spanTo="#c56-0117.04"></delSpan>beau-</line>
+        <line>tiful<anchor xml:id="c56-0117.04"></anchor><add hand="#pbs" place="superlinear">supreme &amp; magnificent</add><anchor xml:id="c56-0117.07"></anchor> Mont Blanc raised itself from</line>
+        <line>the surrounding <hi rend="underline">aiguilles</hi> and its tremen</line>
+        <line>dous <hi rend="underline">dome</hi> overlooked the valley.</line>
+        <milestone unit="tei:p"></milestone>
+        <line rend="indent1">During this journey I sometimes joined</line>
+        <line>Elizabeth and exerted myself to point</line>
+        <line>out to her the various beauties of the</line>
+        <line>scene.— And often I <del rend="strikethrough">let my</del> suffered</line>
+        <line>my mule to lag behind &amp; indulged</line>
+    </zone>
+    <zone corresp="#c56-0117.03" type="left_margin">
+        <line><del rend="strikethrough"><add>wondeful</add></del></line>
+    </zone>
+    
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="56v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0118.xml" xml:id="ox-ms_abinger_c56-0118">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0118.jp2"></graphic>
+
+  <zone rend="bordered" type="pagination"><line>148</line></zone>
+  <zone type="main">
+    <line>in the misery of reflection. At other</line>
+    <line>times I spurred on <mod>
+        <del rend="strikethrough">my mule</del>
+        <add place="superlinear">the animal</add>
+      </mod> before</line>
+    <line>my companions that I might forget</line>
+    <line>them, the world, and more than</line>
+    <line>all myself. When at <add place="superlinear"><unclear>a</unclear></add> distance I</line>
+    <line>alighted and threw myself on</line>
+    <line>the grass <del rend="strikethrough">to shut out</del> weighed down</line>
+    <line>by horror &amp; despair. At eight in</line>
+    <line>the evening we arrived at Chamou</line>
+    <line>nix. <mod>
+        <del rend="strikethrough">Myrtella</del>
+        <del rend="strikethrough">was</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">My father &amp; Elizabeth were</add>
+      </mod> very much fatigued.</line>
+    <line><del rend="strikethrough">a</del> Ernest who accompanied us was</line>
+    <line>delighted and in high spirits– The</line>
+    <line>only circumstance that detracted</line>
+    <line>from his pleasure was the south wind</line>
+    <line>and the rain that that wind seemed</line>
+    <line>to promise <del rend="strikethrough">us</del> for the next day.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We retired early to our appartments</line>
+    <line>but not to sleep:– at least I did not. I</line>
+    <line>remained many hours at the window</line>
+    <line>watching the <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">pallid</add>
+      </mod> lightning that played</line>
+    <line>above Mont Blanc – and listening</line>
+    <line>to the rushing of the Arve which</line>
+    <line>ran before my window.</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="57r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0119.xml" xml:id="ox-ms_abinger_c56-0119">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0119.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>149</line></zone>
+  <zone type="library"><line>57</line></zone>
+  
+  <zone type="main">
+    <line rend="center"><milestone spanTo="#c56-0119.01" unit="tei:head"></milestone>Chap. 14<anchor xml:id="c56-0119.01"></anchor></line>
+    <milestone unit="tei:p"></milestone>
+    <line><retrace cause="unclear">T</retrace>he next day, contrary to the prognostics of our</line>
+    <line>guides, was fine although clouded. <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">We</add>
+      </mod> visited the</line>
+    <line>source of the Aveiron and rode about the</line>
+    <line>valley <mod>
+        <del rend="strikethrough">the whole da</del>
+        <del rend="unmarked">y</del>
+        <add hand="#pbs" place="superlinear">until evening</add>
+      </mod>. These sublime and</line>
+    <line>magnificent scenes afforded me the greatest</line>
+    <line>consolation that I was capable of receiving</line>
+    <line>They elevated me from <add place="superlinear">all</add> littleness of feeling</line>
+    <line>and although they <del rend="strikethrough">d</del> did not remove my</line>
+    <line>grief they <del rend="strikethrough">t</del> subdued and tranquilized it.</line>
+    <line>In some degree<retrace cause="unclear" hand="#pbs">,</retrace> also they diverted my
+      mind</line>
+    <line>from the thoughts <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">over which</add>
+      </mod> it had brooded <del rend="strikethrough">over</del></line>
+    <line>for the last month<del rend="strikethrough">s</del>. I returned in the</line>
+    <line>evening, fatigued but less unhappy and convered</line>
+    <line>with the family <del type="strikethrough">t</del> with more cheerfulness than</line>
+    <line><del rend="strikethrough">I</del> had been <mod>
+        <del rend="strikethrough">accustomed</del>
+        <del rend="strikethrough">to</del>
+        <add hand="#pbs" place="superlinear">my custom</add>
+      </mod> for some time. My fa</line>
+    <line>ther was pleased and Elizabeth overjoyed; "My</line>
+    <line>dear Cousin," said she, "You see what happiness</line>
+    <line>you diffuse when you are <mod>
+        <del rend="strikethrough">cheerful</del>
+        <add hand="#pbs" place="superlinear">happy</add>
+      </mod>; do</line>
+    <line>not relapse again!—</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The following morning the rain poured</line>
+    <line>down in torrents and thick mists hid</line>
+    <line>the summits of the mountains. I rose early</line>
+    <line>but felt unusually melancholy. The rain</line>
+    <line>depressed <mod>
+        <del rend="strikethrough">my</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">me</add>
+      </mod>, my old feelings recurred</line>
+    <line>and I was miserable. I knew how my father</line>
+    <line>would be dissapointed at this sudden</line>
+    <line>change and I wished to avoid him</line>
+    <line>untill I had <del rend="strikethrough">rev</del> recovered myself so far</line>
+    <line>as to conceal the feelings that overpowered</line>
+    <line>me — I knew that they would remain</line>
+    <line>that day at the inn and as I had</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="57v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0120.xml" xml:id="ox-ms_abinger_c56-0120">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0120.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>150</line></zone>
+  <zone type="main">
+    <line><del rend="strikethrough">n</del>ever inured myself to rain and cold I</line>
+    <line>resolved <del rend="strikethrough">t</del> to go to the summit of</line>
+    <line>Montanvert <mod>
+        <del rend="strikethrough">by myself</del>
+        <add place="superlinear">alone</add>
+      </mod>. I remembered</line>
+    <line>the effect the view of the tremendous</line>
+    <line>and ever moving glacier had <mod>
+        <del rend="strikethrough">had</del>
+        <anchor xml:id="c56-0120.01"></anchor>
+      </mod></line>
+    <line>upon my mind when I first saw it</line>
+    <line><mod>
+        <del rend="strikethrough">how</del>
+        <mod>
+          <del rend="overwritten">i</del>
+          <add hand="#pbs" place="intralinear">I</add>
+        </mod>
+      </mod>t had then filled me with</line>
+    <line>a sublime extacy that gave wings</line>
+    <line>to the soul and allowed <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">it</add>
+      </mod> to soar from</line>
+    <line>the <mod>
+        <del rend="strikethrough">lower</del>
+        <add hand="#pbs" place="superlinear">obscure</add>
+      </mod> world to light &amp; joy. The</line>
+    <line>sight of the awful &amp; majestic in</line>
+    <line>nature had indeed always the effect</line>
+    <line>of <mod>
+        <del rend="strikethrough">tranquillizing the</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">solemnizing</add>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">my</add>
+      </mod> mind &amp; causing</line>
+    <line>me to forget the <del rend="strikethrough">the</del> passing cares</line>
+    <line>of life. I determined to go <mod>
+        <del rend="strikethrough">f</del>
+        <del rend="strikethrough">by myself</del>
+        <add place="superlinear">alone</add>
+      </mod></line>
+    <line>for I was well acquainted with the</line>
+    <line>path and the presence of another</line>
+    <line><mod>
+        <del rend="strikethrough">had the effect of</del>
+        <add place="superlinear">would</add>
+      </mod> destroy<del rend="strikethrough">ing</del> the <del rend="strikethrough">solitary</del></line>
+    <line>solitary grandeur of the scene.<unclear extent="1" unit="chars"></unclear></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The ascent <mod>
+        <del rend="strikethrough">to the mountain</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">is</add>
+      </mod> pre</line>
+    <line>cipitous <mod>
+        <del rend="strikethrough">w</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough">with</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">but <add place="superlinear">the path is</add> cut into</add>
+      </mod> continual and short</line>
+    <line>windings which enable<del rend="strikethrough">s</del>
+      <del rend="strikethrough">to</del> you</line>
+    <line>surmount the perpedicularity of</line>
+    <line>the mountains– It is a scene terrifical</line>
+    <line>ly desolate. In a thousand places the</line>
+    <line>traces of the winter avelanche may</line>
+    <line>be perceived where trees lie broken</line>
+    <line>and str<retrace cause="unclear" hand="#pbs">ewed</retrace> on the ground; some</line>
+    <line>entirely destroyed others bent leaning</line>
+  </zone>
+  <zone corresp="#c56-0120.01" type="left_margin">
+    <line><add hand="#pbs">produced</add>
+    </line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="58r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0121.xml" xml:id="ox-ms_abinger_c56-0121">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0121.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>151</line></zone>
+  <zone type="library"><line>58</line></zone>
+  <zone type="main">
+    <line>upon <del rend="strikethrough">juts in</del> the jutting <mod>
+        <del rend="strikethrough">corners</del>
+        <add hand="#pbs" place="superlinear">rocks</add>
+      </mod> of the</line>
+    <line>mountain, or <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">transversely</add>
+      </mod> upon other trees. The</line>
+    <line>path as you <del rend="strikethrough">ascen</del> ascend higher is inters</line>
+    <line><mod>
+        <del rend="strikethrough">persed</del>
+        <add hand="#pbs" place="superlinear">ected</add>
+        <del rend="strikethrough">wi</del>
+        <del rend="unmarked">th</del>
+        <add hand="#pbs" place="superlinear">by</add>
+      </mod> ravines <add hand="#pbs" place="superlinear">of</add> snow, down which</line>
+    <line>stones continually roll from above;</line>
+    <line>one of the them is particularly dange</line>
+    <line>rous as the slightest sound such as <add hand="#pbs" place="intralinear">even</add></line>
+    <line>speaking in a loud voice <mod>
+        <del rend="strikethrough">is</del>
+        <add hand="#pbs" place="superlinear">produces</add>
+      </mod> a <delSpan spanTo="#c56-0121.01"></delSpan>suffi</line>
+    <line>cien<mod>
+        <del rend="overwritten">d</del>
+        <add place="intralinear">t</add>
+      </mod><anchor xml:id="c56-0121.01"></anchor> concussion of air sufficient</line>
+    <line>to draw destruction the head of the</line>
+    <line>speaker. The pine<add hand="#pbs" place="intralinear">s</add> here are not</line>
+    <line>tall or luxuriant but they are sombre</line>
+    <line>and add an air of <mod>
+        <del rend="strikethrough">gravit</del>
+        <del rend="unmarked">y</del>
+        <add place="superlinear">severity</add>
+      </mod> to the scene.</line>
+    <line>I looked on the valley beneath.<add hand="#pbs" place="intralinear">;</add> Vast
+      mist</line>
+    <line>were rising from the river which ran</line>
+    <line>through<del rend="strikethrough">t</del>
+      <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">it</add>
+      </mod> and curling in thick wreaths</line>
+    <line>around the opposite mountains</line>
+    <line>whose summits were hid in the</line>
+    <line><anchor xml:id="c56-0121.02"></anchor>clouds, while rain poured from the</line>
+    <line>dark sky and added to the melancholy</line>
+    <line>impression I received from the objects</line>
+    <line>around me — Alas! <del rend="strikethrough">who can boast</del> why</line>
+    <line>does man boast of sensibilities above</line>
+    <line>those apparent in the brute it only</line>
+    <line>renders them more <hi rend="underline">necessary</hi> beings. <delSpan spanTo="#c56-0121.03"></delSpan>Hunger</line>
+    <line>&amp; desire and <unclear extent="1" unit="chars"></unclear><anchor xml:id="c56-0121.03"></anchor> If our
+      impulses were</line>
+    <line>confined to hunger thirst and desire</line>
+    <line>we might be <mod>
+        <del rend="strikethrough">more</del>
+        <add place="superlinear">nearly</add>
+      </mod> free but now</line>
+    <line>we are moved by every wind that</line>
+    <line>blows &amp; by every <del rend="strikethrough">sc</del> chance <del rend="strikethrough">work</del> word or</line>
+  </zone>
+  <zone corresp="#c56-0121.02" type="left_margin">
+    <line><add>uniform </add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="58v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0122.xml" xml:id="ox-ms_abinger_c56-0122">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0122.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>152</line></zone>
+
+  <zone type="main">
+    <line>scene that that win<damage agent="ink">d</damage> may convey to</line>
+    <line>us</line>
+    <milestone spanTo="#c56-0122.01" unit="tei:lg"></milestone>
+    <line rend="indent3">We rest, A dream has power to poison</line>
+    <line rend="right"><metamark>L</metamark> sleep</line>
+    <line rend="indent4">We rise one wandering thought pollutes</line>
+    <line rend="right">the day</line>
+    <line rend="indent2">We feel conceive, or reason – laugh or weep</line>
+    <line rend="indent3">Embrace fond woe or cast our cares</line>
+    <line rend="right">away</line><anchor xml:id="c56-0122.01"></anchor>
+    <milestone spanTo="#c56-0122.02" unit="tei:lg"></milestone>
+    <line rend="indent1">It is the same –for be it joy or sorrow</line>
+    <line rend="indent2">The path of its departure still is free</line>
+    <line rend="indent3">Mans yesterday may ne'er be like</line>
+    <line rend="right"><add hand="#pbs" place="intralinear">h</add>is
+      morrow</line>
+    <line rend="indent2">Nought may endure but mutability.</line>
+    <anchor xml:id="c56-0122.02"></anchor>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">I<add place="intralinear">t</add> was noon when I arrived
+      at the</line>
+    <line>top of the <mod>
+        <del rend="strikethrough">mountain</del>
+        <add hand="#pbs" place="superlinear">ascent</add>
+      </mod>. For some time I</line>
+    <line>sat upon the <del rend="strikethrough">the</del> rock that overlooks</line>
+    <line>the sea of ice. A mist covered both</line>
+    <line>that and the surrounding <mod><restore type="smear_strikethrough"><del rend="strikethrough">mo</del></restore></mod>untains</line>
+    <line>Presently a breeze dissipated the mist</line>
+    
+    <line>and I descended on the <mod>
+        <del rend="strikethrough">ice</del>
+        <add place="superlinear">glacier</add>
+      </mod>. <delSpan spanTo="#c56-0122.03"></delSpan>It is in<del rend="strikethrough">s</del>tersper</line>
+    <line>sed with rifts<anchor xml:id="c56-0122.03"></anchor> – The surface is very uneven</line>
+    <line>rising like the waves of a troubled sea,</line>
+    <line>decending <del rend="strikethrough">tow</del> low, &amp; in<mod>
+        <del rend="overwritten">s</del>
+        <add place="intralinear">t</add>
+      </mod>erspered by rifts</line>
+    <line>that sink deep— The <mod>
+        <del rend="strikethrough">width of the</del>
+        <add hand="#pbs" place="intralinear">field of</add>
+      </mod></line>
+    <line>ice is <del rend="strikethrough">nearly</del> a <del rend="strikethrough">lege</del> league,<mod>
+        <add place="sublinear"><metamark>^</metamark></add>
+        <add hand="#pbs" place="superlinear">in width,</add>
+      </mod> but I was</line>
+    <line>nearly two hours <add hand="#pbs" place="superlinear">in</add> crossing it – The
+      oppo</line>
+    <line>site <del rend="strikethrough">t</del> mountain is a bare perpendicu</line>
+    <line>lar rock.–From that side where I now</line>
+    <line>stood Montanvert was exactly opposite</line>
+    <line>at the distance of a league and above</line>
+  </zone>
+
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="59r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0123.xml" xml:id="ox-ms_abinger_c56-0123">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0123.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>153</line></zone>
+  <zone type="library"><line>59</line></zone>
+  <zone type="main">
+    <delSpan rend="vertical_line" spanTo="#c56-0123.01"></delSpan>
+    <line>I should listen to the dæmon – my</line>
+    <line>feelings were ag<hi rend="underline">ainst</hi> it but the</line>
+    <line>misery he expressed had al<del rend="strikethrough">l</del>ready</line>
+    <line>moved m<damage agent="ink">y</damage> compassion and I thought</line>
+    <line>the least justice I could shew would</line>
+    <line>be to listen to to his tale.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">We entered the hut – the monster</line>
+    <line>lighted a fire and sitting by it he</line>
+    <line>began thus.</line>
+    <anchor xml:id="c56-0123.01"></anchor>
+    <line>it rose Mont Blanc in awful majesty. I re</line>
+    <line>mained in a recess of the rock gazing on</line>
+    <line>this wonderful &amp; stupedous scene – <anchor xml:id="c56-0123.02"></anchor> My
+      heart</line>
+    <line>before<mod>
+        <add place="sublinear"><unclear><metamark function="insert">^</metamark></unclear></add>
+        <del rend="strikethrough">sad</del>
+        <add hand="#pbs" place="superlinear">which was sorrowful<del rend="strikethrough">ly</del>,
+          now</add>
+      </mod> swelled with somthing like</line>
+    <line>joy <del rend="strikethrough">I clas</del> I exclaimed – Wandering spirits,</line>
+    <line>if indeed ye wander and do not rest in</line>
+    <line>your narrow beds, allow me this faint</line>
+    <line>happiness or take me as your compa</line>
+    <line>nion away from the joys of life." As I</line>
+    <line>said this I suddenly beheld <mod>
+        <del rend="strikethrough">a</del>
+        <del rend="strikethrough">human</del>
+        <add place="superlinear">the</add>
+      </mod></line>
+    <line>figure <add place="superlinear">of a man</add> at some distance advancing</line>
+    <line>towards me with superhuman speed—</line>
+    <line>He bounded over the crevices in the</line>
+    <line>ice <mod>
+        <del rend="strikethrough">by</del>
+        <add hand="#pbs" place="superlinear">among</add>
+      </mod> which I had walked with caution,</line>
+    <line>his stature also as he approached seem</line>
+    <line>ed to exceed that of man –I was</line>
+    <line>troubled — a mist covered my eyes and</line>
+    <line>I felt <mod>
+        <del rend="strikethrough">ready to pa faint</del>
+        <add hand="#pbs" place="superlinear">faintness seize me.</add>
+      </mod> – The cold breeze</line>
+    <line>of the mountains quickly restored me.</line>
+    <line><del rend="strikethrough">But</del> I perceived as <mod>
+        <del rend="strikethrough">he</del>
+        <add hand="#pbs" place="superlinear">the shape</add>
+      </mod> came nearer</line>
+  </zone>
+  <zone corresp="#c56-0123.02" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0123.03"></addSpan>
+    <line>the sea or</line>
+    <line>rather <add place="superlinear">the vast</add> river of</line>
+    <line>ice, wound among</line>
+    <line><del rend="strikethrough">the</del> its dependant</line>
+    <line>mountains whose</line>
+    <line>aerial summits</line>
+    <line>hung over its</line>
+    <line>recesses. Thier</line>
+    <line>icy &amp; glittering</line>
+    <line>peaks shone</line>
+    <line>in sunlight</line>
+    <line>over the clouds. </line>
+    <anchor xml:id="c56-0123.03"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="59v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0124.xml" xml:id="ox-ms_abinger_c56-0124">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0124.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>154</line></zone>
+  <zone type="main">
+    <line>(<del rend="strikethrough">oh</del> sight tremendous and abhorred) that it</line>
+    <line>was the wretch whom I had <del rend="strikethrough">cr</del> created <delSpan rend="strikethrough" spanTo="#c56-0124.01"></delSpan>and</line>
+    <line>who had caused me such deep misery<anchor xml:id="c56-0124.01"></anchor>. I</line>
+    <line>trembled with rage <del rend="strikethrough">an</del> and horror <mod spanTo="#c56-0124.02"></mod><del next="#c56-0124.03" rend="strikethrough">determin</del><add hand="#pbs" place="superlinear">I</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0124.03">ing</del><add place="superlinear">resolv<mod>
+          <del rend="overwritten">in</del>
+          <add hand="#pbs" place="intralinear">ed</add>
+        </mod><del rend="unmarked">g</del></add><anchor xml:id="c56-0124.02"></anchor> to wait his approach
+      &amp; then close</line>
+    <line>with him in mortal combat. He ap-</line>
+    <line>proached; I <del rend="strikethrough">saw again that form from which</del></line>
+    <line><del rend="strikethrough"><unclear>I</unclear></del> His countenance bespoke bitter
+      anguish</line>
+    <line>combined with d<mod>
+        <del rend="overwritten">e</del>
+        <add place="intralinear">i</add>
+      </mod>sdain and malignancy.</line>
+    <line>But I <mod>
+        <del rend="strikethrough">hardly</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">scarcely</add>
+      </mod> observed this–anger and hatred</line>
+    <line><del rend="strikethrough">at f</del> had at first deprived me of utterance</line>
+    <line>and I recovered only to overwhelm him</line>
+    <line>with <del rend="strikethrough">express</del> words expressive of utter</line>
+    <line>detestation <del rend="strikethrough">and</del>
+      <del rend="strikethrough">re</del> and contempt – "Devil"</line>
+    <line>I exclaimed – "do you dare approach me</line>
+    <line>and do not <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">you</add>
+      </mod> dread the fierce vengeance</line>
+    <line>of my arm wreaked on you<add place="intralinear">r</add> miserable</line>
+    <line>head – Begone vile insect or <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">rather</add>
+      </mod> Stay that</line>
+    <line>I may trample you to dust and oh that</line>
+    <line>I could with <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">the <del rend="strikethrough">end</del></add>
+        <add hand="#pbs" place="superlinear">extinction of</add>
+      </mod> your miserable existence</line>
+    <line>restore those creatures whom you</line>
+    <line>have diabollicaly murdered"</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"I expect<add hand="#pbs" place="intralinear">ed</add> this reception" said the
+      dæmon</line>
+    <line>all men hate <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">the</add>
+      </mod> wretched – how then</line>
+    <line>must <mod>
+        <del rend="strikethrough">O</del>
+        <add place="superlinear">I</add>
+      </mod> be hated who am miserable</line>
+    <line>beyond <mod>
+        <del rend="strikethrough">conception or</del>
+        <del rend="strikethrough">idea</del>
+        <add hand="#pbs" place="superlinear">all living things.</add>
+      </mod> – Yet you</line>
+    <line><del rend="strikethrough">my</del> my creator hate me and spurn me</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5368" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="60r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0125.xml" xml:id="ox-ms_abinger_c56-0125">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0125.jp2"></graphic>
+  <zone type="pagination"><line>155</line></zone>
+  
+  <zone type="library"><line>60</line></zone>
+  
+  <zone type="main">
+    <line><del rend="strikethrough">me</del> thy creature to whom thou art</line>
+    <line>bound with ties only dissoluble by the</line>
+    <line>death of one of us. <del rend="strikethrough">And</del>
+      <mod><del rend="overwritten">y</del><add place="intralinear">Y</add></mod>ou <mod><del rend="strikethrough">wish</del><add hand="#pbs" place="superlinear">purpose</add></mod> to
+      kill</line>
+    <line>me. <del rend="strikethrough">And</del>
+      <mod><del rend="overwritten">h</del><add place="intralinear">H</add></mod>ow dare you sport
+      thus</line>
+    <line>with life? Do your duty towards me</line>
+    <line>and I will do mine towards you &amp;</line>
+    <line>the rest of mankind. <mod><add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">If you comply with my conditions</add></mod> –I will leave
+      them</line>
+    <line>and you at peace – <mod spanTo="#c56-0125.01"></mod><delSpan rend="strikethrough" spanTo="#c56-0125.02"></delSpan>but as I am if</line>
+    <line>you do not comply with my conti condi</line>
+    <line>tions<anchor xml:id="c56-0125.02"></anchor><add place="superlinear">but if you refuse</add><anchor xml:id="c56-0125.01"></anchor> I <mod><add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">will</add></mod> glut the <del rend="strikethrough">t</del> maw of
+      death untill</line>
+    <line><mod><del rend="strikethrough">he</del><add hand="#pbs" place="superlinear">it</add></mod>
+      be <del rend="strikethrough">satiate</del> satiated even with your</line>
+    <line>dearest friends."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"<del rend="strikethrough">Miserable</del>
+      <del rend="strikethrough">wretch</del> Abhorred monster,</line>
+    <line>cried I furiously, fiend that thou art</line>
+    <line>the tortures of Hell are too <mod><del rend="strikethrough">soft for thee</del><add><anchor xml:id="c56-0125.03"></anchor></add></mod></line>
+    <line>wretched devil! you reproach me</line>
+    <line>with your creation; come, that I may</line>
+    <line>extinguish the spark that I so negli</line>
+    <line>gently bestowed." My rage was without</line>
+    <line>bounds I sprung on him <mod spanTo="#c56-0125.05"></mod><del next="#c56-0125.06" rend="strikethrough">that I</del><del rend="strikethrough"><add hand="#pbs" place="superlinear">and</add></del></line>
+    <line><del rend="strikethrough" xml:id="c56-0125.06">might destroy so hateful a
+      monster–</del><add hand="#pbs" place="superlinear"><del rend="strikethrough">and</del> impelled by all the feelings which can arm one</add>
+      <anchor xml:id="c56-0125.07"></anchor><anchor xml:id="c56-0125.05"></anchor></line>
+    <line>He eluded <add hand="#pbs" place="superlinear">me easily,</add> and said – Be calm!
+      I entreat</line>
+    <line><del rend="strikethrough">h</del> you to hear me, before you give vent</line>
+    <line>to your hatred <add hand="#pbs" place="intralinear">up</add>on my devoted head–<add hand="#pbs" place="sublinear">.</add> Have</line>
+    <line>I not suffer<del rend="strikethrough">r</del>ed enough that you</line>
+    <line><del rend="strikethrough">should</del> wish to encrease my misery–Life</line>
+    <line>although it be only an accumulation</line>
+    <line>of anguish is dear to me and I will defend</line>
+    <line>it remember thou hast made me more</line>
+  </zone>
+  
+  <zone corresp="#c56-0125.03" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0125.04"></addSpan>
+    <line>mild a</line>
+    <line>vengeance for</line>
+    <line>thy crimes.</line>
+    <anchor xml:id="c56-0125.04"></anchor>
+  </zone>
+  
+  <zone corresp="#c56-0125.07" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0125.08"></addSpan>
+    <line> being against</line>
+    <line>the existence</line>
+    <line>of another.</line>
+    <anchor xml:id="c56-0125.08"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5368" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="60v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0126.xml" xml:id="ox-ms_abinger_c56-0126">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0126.jp2"></graphic>
+  <zone type="pagination"><line>156</line></zone>
+  <zone type="main">
+    <line>powe<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">r</add>
+      </mod>ful than thyself my height is superior</line>
+    <line>to yours my joints more supple. But I</line>
+    <line><mod>
+        <del rend="strikethrough">do not wish to <unclear>trave</unclear></del>
+        <del rend="strikethrough">you</del>
+        <add hand="#pbs" place="superlinear">will not be tempted to set myself in opposition to
+          thee,</add>
+      </mod> I am thy</line>
+    <line>creature and <del rend="strikethrough">I</del> wi<mod>
+        <del rend="overwritten">th</del>
+        <add place="intralinear">ll</add>
+      </mod> be <add hand="#pbs" place="superlinear">even</add> mild and docile</line>
+    <line><mod>
+        <del rend="strikethrough">to you</del>
+        <anchor xml:id="c56-0126.01"></anchor>
+      </mod>, <mod>
+        <del rend="strikethrough">my gentle master</del>
+        <add hand="#pbs" place="superlinear">my natural master &amp; king</add>
+      </mod>, – if <mod>
+        <del rend="strikethrough">you</del>
+        <add hand="#pbs" place="superlinear">thou</add>
+      </mod> will</line>
+    <line>perform <mod>
+        <del rend="strikethrough">your</del>
+        <add hand="#pbs" place="superlinear">thy part also, the which thou owest me</add>
+      </mod> dut<mod>
+        <del rend="overwritten">y</del>
+        <add hand="#pbs" place="intralinear">ies</add>
+      </mod>
+      <mod>
+        <del rend="strikethrough">towards</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+      </mod> me. Oh Fran</line>
+    <line>kenstein, do not <add hand="#pbs" place="intralinear">be</add> equitable to every
+      other</line>
+    <line>and trample upon me <add hand="#pbs" place="superlinear">alone</add> to whom thy</line>
+    <line>justice &amp; even <mod>
+        <del rend="strikethrough">mere</del>
+        <del rend="strikethrough">charity</del>
+        <add hand="#pbs" place="superlinear">they clemency, thy affection</add>
+      </mod> is most</line>
+    <line>due. <del rend="strikethrough">Remb</del> Remember that I am</line>
+    <line>thy creature – <add hand="#pbs" place="superlinear">I ought to be</add> Thy Adam
+      – <mod>
+        <del rend="strikethrough">or</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">but I am</add>
+      </mod> rather the</line>
+    <line>fallen angel <mod>
+        <del rend="strikethrough">for</del>
+        <add hand="#pbs" place="superlinear">whom thou driven from joy for no misdeed;</add>
+      </mod> every where I see</line>
+    <line>bliss <add hand="#pbs" place="superlinear">from</add> whi<mod>
+        <del rend="overwritten">ile</del>
+        <add hand="#pbs" place="intralinear">ch</add>
+      </mod> I alome am irrecoverably</line>
+    <line><mod>
+        <del rend="strikethrough">wretched</del>
+        <anchor xml:id="c56-0126.02"></anchor>
+      </mod>. I was benevolent and good:</line>
+    <line>misery made me a fiend. Make me</line>
+    <line>happy and I shall again be virtuous</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">Begone replied I – I <del rend="strikethrough">cannot and</del></line>
+    <line>will not hear you. there can be no</line>
+    <line>community between you and I– We are</line>
+    <line>enemies — Begone or <del rend="strikethrough">allhow</del> let us try</line>
+    <line>our streng<del rend="strikethrough">h</del>th in a fight in which</line>
+    <line>one must fall."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">&gt;<del rend="strikethrough">How</del> How can I move you?
+      said the</line>
+    <line>fiend— Will no entreaties cause you</line>
+    <line>to turn a favourable eye upon thy</line>
+    <line>creature who implores thy goodness and</line>
+    <line>compassion – Believe me, Frankenstien</line>
+    <line>I was benevolent —my soul glowed with</line>
+  </zone>
+
+  <zone corresp="#c56-0126.01" type="left_margin">
+    <line><add hand="#pbs">to <add hand="#pbs" place="superlinear">thee</add></add></line>
+  </zone>
+
+  <zone corresp="#c56-0126.02" type="left_margin">
+    <line><add hand="#pbs">excluded</add></line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5368" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="61r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0127.xml" xml:id="ox-ms_abinger_c56-0127">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0127.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>157</line></zone>
+  <zone type="library"><line>61</line></zone>
+  <zone type="main">
+    <line>love and humanity but am I not alone</line>
+    <line>miserably alone – <delSpan rend="strikethrough" spanTo="#c56-0127.01"></delSpan>None to love
+      me but</line>
+    <line>all fly<anchor xml:id="c56-0127.01"></anchor>
+      <del rend="strikethrough">and</del> You, my creator abhor me</line>
+    <line>What hope <mod>
+        <del rend="strikethrough">have I then from</del>
+        <add hand="#pbs" place="superlinear">can I gather from</add>
+      </mod> your</line>
+    <line>fellow creatures <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">who owe me nothing.</add>
+      </mod>—They spurn and <mod>
+        <del rend="strikethrough">abhor</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">hate</add>
+      </mod></line>
+    <line>me. The desart mountains and mourful</line>
+    <line>glaciers are my refuge—I have wandered</line>
+    <line>here many days– The caves of ice <mod>
+        <del rend="strikethrough">are my</del>
+        <add place="superlinear">which</add>
+      </mod>
+      <unclear extent="1" unit="chars"></unclear></line>
+    <line>I only do not fear are a dwelling to me and</line>
+    <line>the only one which man does not grudge</line>
+    <line><del rend="strikethrough">to me</del> — <del rend="strikethrough">And food</del>
+      – These bleak skies I </line>
+    <line>hail for they are kinder <add place="superlinear">to me</add> than <mod>
+        <del rend="strikethrough">man</del>
+        <add place="superlinear">your fellow <del rend="strikethrough">creatures</del><add place="sublinear"><metamark function="insert">^</metamark></add><add place="superlinear">beings</add></add>
+      </mod></line>
+    <line><mod spanTo="#c56-0127.02"></mod><del rend="strikethrough">and</del>
+      <del rend="strikethrough">But I no</del><add place="sublinear"><metamark function="insert">^</metamark></add>
+      <mod>
+        <del rend="strikethrough">They</del>
+        <del rend="strikethrough"><add place="superlinear">Man</add></del>
+      </mod>
+      <del next="#c56-0127.03" rend="strikethrough">hate<add place="intralinear">s</add> me and
+        i</del><del rend="unmarked">f</del></line>
+    <line><mod>
+        <del rend="strikethrough" xml:id="c56-0127.03">they</del>
+        <del rend="strikethrough"><add place="superlinear">he</add></del>
+      </mod><anchor xml:id="c56-0127.04"></anchor><anchor xml:id="c56-0127.02"></anchor> knew of my
+      existence <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">they</add>
+      </mod> would as you<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">do</add>
+      </mod></line>
+    <line>arm themselves for my destruction – <del rend="strikethrough">And</del></line>
+    <line><mod>
+        <del rend="overwritten">s</del>
+        <add place="intralinear">S</add>
+      </mod>hall I not <add place="superlinear">then</add> hate them who abhor me</line>
+    <line>I <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">will</add>
+      </mod> keep no <del rend="strikethrough">temm</del> terms with <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">my</add>
+      </mod> enemies <del rend="strikethrough">and</del></line>
+    <line>I am miserable <add place="intralinear">&amp;</add> they shall share my</line>
+    <line>wretchedness– Yet it is in your pow<mod>
+        <del rend="overwritten">re</del>
+        <add place="intralinear">er</add>
+      </mod></line>
+    <line>to recompense me and deliver them from</line>
+    <line>an evil which<mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add hand="#pbs" place="superlinear">it</add>
+        <anchor xml:id="c56-0127.06"></anchor>
+      </mod>
+      <mod>
+        <del rend="strikethrough"><add place="superlinear">you</add></del>
+        <del rend="strikethrough">have bestowed on them</del>
+      </mod>.</line>
+    <line>Let your compassion and justice be</line>
+    <line>moved and do not disdain me. Listen</line>
+    <line>to my tale <unclear>!</unclear> when you have heard that</line>
+    <line>deny or comiserate<del rend="strikethrough">d</del> me as you shall</line>
+    <line>judge <add hand="#pbs" place="superlinear">that</add> I deserve–<add hand="#pbs" place="sublinear">.</add> But <mod>
+        <del rend="strikethrough">here</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">hear</add>
+      </mod> me –The</line>
+    <line>guilty <del rend="strikethrough">may</del> are allowed by human laws,</line>
+    <line>bloody as they <mod>
+        <del rend="strikethrough">are</del>
+        <add hand="#pbs" place="superlinear">may be</add>
+      </mod>, to speak in their <add hand="#pbs" place="superlinear">own</add> defence</line>
+    <line><add hand="#pbs" place="superlinear">before they are condemned</add> Listen to me
+      Frankenstein <del rend="strikethrough">for you are</del></line>
+  </zone>
+  <zone corresp="#c56-0127.04" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0127.05"></addSpan>
+    <line>If the</line>
+    <line>multitude</line>
+    <line>of mankind</line>
+    <anchor xml:id="c56-0127.05"></anchor>
+  </zone>
+
+  <zone corresp="#c56-0127.06" type="left_margin">
+    <addSpan spanTo="#c56-0127.07"></addSpan>
+    <line> only remains</line>
+    <line>for you to</line>
+    <line>make so</line>
+    <line>great, that</line>
+    <line>not only you</line>
+    <line>&amp; your family</line>
+    <line>but thousands</line>
+    <line>of others shall</line>
+    <line>be swallowed</line>
+    <line>up in the</line>
+    <line>whirlwinds of</line>
+    <line>its rage.</line>
+    <anchor xml:id="c56-0127.07"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5368" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="61v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0128.xml" xml:id="ox-ms_abinger_c56-0128">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0128.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>158</line></zone>
+  <zone type="main">
+    <line>you accuse me of muder and yet <del rend="strikethrough">wh</del></line>
+    <line>you would with a <del rend="strikethrough">s</del>
+      <unclear extent="1" unit="chars"></unclear> satisfi<del rend="strikethrough">c</del>ed
+      conscience</line>
+    <line>destroy <mod>
+        <del rend="strikethrough">thy</del>
+        <add hand="#pbs" place="superlinear">thine own</add>
+      </mod> creature –Oh praise the eter</line>
+    <line>nal justice of man<add hand="#pbs" place="intralinear">!</add>—Yet I ask you</line>
+    <line>not to spare me, listen and then, if</line>
+    <line>you <mod>
+        <add place="sublinear"><metamark>^</metamark></add>
+        <add hand="#pbs" place="superlinear">can and if you</add>
+      </mod> will, destroy the work of your hands."</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">"Why" cried I–"do you <del rend="strikethrough">ever</del> call to my</line>
+    <line>remembrance <del rend="strikethrough">those</del> circumstances <add hand="#pbs" place="superlinear">of</add> which</line>
+    <line>I shudder to reflect <mod>
+        <del rend="strikethrough">ever re occured</del>
+        <add hand="#pbs" place="superlinear">that I have been the</add>
+        <anchor xml:id="c56-0128.01"></anchor>
+      </mod> –</line>
+    <line>Cursed be the <del rend="strikethrough">night o during which you</del></line>
+    <line>day in which you first saw light, cursed</line>
+    <line>(although I curse myself) be the hands</line>
+    <line>that formed you!— You have made</line>
+    <line>me wretched beyond expression <mod>
+        <add place="sublinear"><metamark>^</metamark></add>
+        <add hand="#pbs" place="superlinear">You have left me no power to consider</add>
+        <add hand="#pbs" place="sublinear">whether I am just to you or no.</add>
+      </mod> begone,</line>
+    <line>relieve me from <mod>
+        <del rend="strikethrough">they</del>
+        <add hand="#pbs" place="superlinear">your</add>
+      </mod> sight</line>
+    <milestone unit="tei:p"></milestone>
+    <line><mod spanTo="#c56-0128.06"></mod><add next="#c56-0128.07" place="interlinear">Thus I relieve you, Creator</add></line>
+    <line><add place="intralinear" xml:id="c56-0128.07">he replied &amp;</add> <del rend="strikethrough">He</del><anchor xml:id="c56-0128.06"></anchor>
+       placed his abhorred hand<del rend="strikethrough">s</del> before</line>
+    <line>my eyes – <mod>
+        <del rend="strikethrough">Thus will I relieve yo</del>
+        <del rend="unmarked">u</del>
+        <add place="superlinear">which I flung from me with violence</add>
+      </mod> – <delSpan rend="strikethrough" spanTo="#c56-0128.03"></delSpan>Creator</line>
+    <line>he replied<anchor xml:id="c56-0128.03"></anchor> –fro<mod>
+        <del rend="overwritten">n</del>
+        <add place="intralinear">m</add>
+      </mod> the sight of one whom</line>
+    <line>you abhor.–still you can listen to me</line>
+    <line>and grant me your compassion –By the</line>
+    <line>the virtues I <del rend="strikethrough">c</del>once possessed I demand this</line>
+    <line>of you – <del rend="strikethrough">Lis</del> Hear my <del rend="strikethrough">tale</del> tale –It is</line>
+    <line>long and strange <del rend="strikethrough">but</del> and the temperature</line>
+    <line>of this place is not fitting <del rend="strikethrough">y</del> to your</line>
+    <line>fine sensations; come to <add place="superlinear">the</add> hut on <mod spanTo="#c56-0128.04"></mod><del next="#c56-0128.05" rend="strikethrough">Motan</del><add place="superlinear">the mountain</add></line>
+    <line><del rend="strikethrough" xml:id="c56-0128.05">vert</del><anchor xml:id="c56-0128.04"></anchor>
+      – The sun is yet high in the</line>
+  </zone>
+
+  <zone corresp="#c56-0128.01" type="left_margin">
+    <addSpan spanTo="#c56-0128.02"></addSpan>
+    <line> miserable</line>
+    <line>origin</line>
+    <line>&amp; author</line>
+    <anchor xml:id="c56-0128.02"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="62r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0129.xml" xml:id="ox-ms_abinger_c56-0129">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0129.jp2"></graphic>
+  <zone rend="bordered" type="pagination"><line>159</line></zone>
+  <zone type="library"><line>62</line></zone>
+  <zone type="main">
+    <line>heavens – before it descends to <del rend="strikethrough">its lowest</del></line>
+    <line>hide itself behind <mod>
+        <del rend="strikethrough">thes</del>
+        <del rend="unmarked">e</del>
+        <add hand="#pbs" place="superlinear">yon</add>
+      </mod> mountains and</line>
+    <line>illumin<add hand="#pbs" place="intralinear">a</add>t<add hand="#pbs" place="intralinear">es</add> another world you will have</line>
+    <line>heard my story and can decide. <del rend="strikethrough">And</del></line>
+    <line>on you it rests whether I quit for ever</line>
+    <line>the habitations of man &amp; lead a</line>
+    <line>harmless life or become the scourge</line>
+    <line>of your fellow creatures<unclear>,</unclear>
+      <del rend="strikethrough">–</del>
+      <add hand="#pbs" place="intralinear">&amp; the author </add><add hand="#pbs" place="sublinear">of your own speedy ruin.</add></line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">As he said this he led the way</line>
+    <line>across the ice –I followed – my heart was</line>
+    <line>full and <add hand="#pbs" place="intralinear">I</add> did not answer him but</line>
+    <line><mod>
+        <del rend="strikethrough">when</del>
+        <anchor xml:id="c56-0129.01"></anchor>
+      </mod> I weighed the various arguments</line>
+    <line>which he had used, <mod spanTo="#c56-0129.02"></mod><add place="sublinear"><metamark function="insert">^</metamark></add><del rend="strikethrough">I</del>
+      <del rend="strikethrough">felt enclined</del><add hand="#pbs" place="superlinear">&amp; I
+        determined at </add></line>
+    <line><anchor xml:id="c56-0129.03"></anchor><anchor xml:id="c56-0129.02"></anchor>to listen to his tale—I
+      was partly urged</line>
+    <line>by curiosity, and compassion confirmed</line>
+    <line>me.– <del rend="strikethrough">As</del>
+      <del rend="strikethrough">I was not</del> I had hitherto suppos</line>
+    <line>ed him to be the murder<add hand="#pbs" place="intralinear">er</add> of my brother</line>
+    <line>and I <mod spanTo="#c56-0129.04"></mod><delSpan rend="strikethrough" spanTo="#c56-0129.05"></delSpan>wished to find this either confirmed</line>
+    <line>or denied<anchor xml:id="c56-0129.05"></anchor><del rend="unmarked">.</del><anchor xml:id="c56-0129.06"></anchor><anchor xml:id="c56-0129.04"></anchor> For the first time also I felt</line>
+    <line>what the duties of a creator towards his</line>
+    <line>creature were and that I ought to</line>
+    <line>render him happy before I complained</line>
+    <line>of his wickedness. these motives urged me</line>
+    <line>to comply with his <mod>
+        <del rend="strikethrough">request</del>
+        <add place="superlinear">demand</add>
+      </mod> – We crossed</line>
+    <line>the ice therefore, and ascended the</line>
+    <line>opposite rock.– The air was cold and</line>
+    <line>the rain began again to descend–We</line>
+    <line>entered the hut – the fiend with an</line>
+    <line>air of exultation I with a heavy</line>
+  </zone>
+  <zone corresp="#c56-0129.01" type="left_margin">
+    <line><add hand="#pbs">as I proceeded</add></line>
+  </zone>
+  <zone corresp="#c56-0129.03" type="left_margin">
+    <line><add hand="#pbs">least </add></line>
+  </zone>
+  <zone corresp="#c56-0129.06" type="left_margin">
+    <addSpan hand="#pbs" spanTo="#c56-0129.07"></addSpan>
+    <line>I eagerly sought</line>
+    <line>a confirma</line>
+    <line>tion or denial</line>
+    <line>of this opinion.</line>
+    <anchor xml:id="c56-0129.07"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5364" lry="7104" partOf="#ox-frankenstein_volume_i" ulx="0" uly="0" mith:folio="62v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0130.xml" xml:id="ox-ms_abinger_c56-0130">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0130.jp2"></graphic>
+  <zone type="pagination">
+    <line>160</line>
+  </zone>
+  <zone type="main">
+    <line>heart and depressed spirits – But I consented</line>
+    <line>to listen and <mod>
+        <del rend="strikethrough">sitting</del>
+        <add hand="#pbs" place="superlinear">seating myself</add>
+      </mod> by the fire which he</line>
+    <line>lighted he thus <del rend="strikethrough">began</del> began his tale.</line>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5078" lry="7304" ulx="0" uly="0" mith:folio="63r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0131.xml" xml:id="ox-ms_abinger_c56-0131">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0131.jp2"></graphic>
+
+  <zone type="library"><line>63</line></zone>
+
+  <zone type="main">
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent1">The first nations whose names <del rend="strikethrough">ever</del> are on
+      record are Chaldea</line>
+    <line>and <del rend="strikethrough">Eg</del> India. Tradition has preserved wonderful accounts
+      of their</line>
+    <line>progress in astronomical science. To them we owe the Zodiac</line>
+    <line>and many observations on the motions of the heavenly bodies <del rend="strikethrough">w</del></line>
+    <line>which argue a much more accurate knowledge of that art</line>
+    <line>than any succeeding country could boast <del rend="strikethrough">of</del> u<mod>
+        <del rend="overwritten">n</del>
+        <add place="intralinear">p</add>
+      </mod>til the time of Galileo</line>
+    <line>and Newton. But their wisdom passed away <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">from the earth</add>
+      </mod> leaving <del rend="strikethrough">but</del> faint</line>
+    <line>traces <del instant="true" rend="strikethrough">in</del> among the Eyptians a race of men
+        <del rend="strikethrough">whose of</del> whose</line>
+    <line>minds <mod>
+        <del rend="strikethrough">appear to have</del>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">bear a</add>
+      </mod> considerable affinity with <mod>
+        <del rend="strikethrough">most</del>
+        <add place="superlinear">those</add>
+      </mod> of the</line>
+    <line>Chinese. Both these <mod>
+        <del rend="strikethrough">nations</del>
+        <add place="superlinear">people</add>
+      </mod> arrived at a certain point in</line>
+    <line>refinement and knowledge and remained fixed: Superstiti</line>
+    <line>on and slavery clouded their perceptions and a hatred of</line>
+    <line>innovation, the never-failing attendant on <mod>
+        <del rend="strikethrough">the</del>
+        <del rend="strikethrough">mids</del>
+        <add place="superlinear">a</add>
+      </mod> mind<del rend="strikethrough">s</del></line>
+    <line>which ha<mod>
+        <del rend="overwritten">v</del>
+        <add place="intralinear">s</add>
+        <del rend="strikethrough">e</del>
+      </mod> learnt every thing from imitation and no-</line>
+    <line>thing from itself, was the natural consequence of the <del rend="strikethrough">govern</del></line>
+    <line>arbitrary <del rend="strikethrough">t</del> government they obeyed.
+      Their history both on ac-</line>
+    <line>count of its antiquity and the genius of the nation presents</line>
+    <line>little more than a list of <del rend="strikethrough">m</del> names. Pride and a love of
+      Con</line>
+    <line>quest was the distinguishing characteristic of their kinds</line>
+    <line>kings and <del rend="strikethrough">they</del>
+      <del rend="strikethrough">displayed</del> their magnificance <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">was displayed</add>
+      </mod> either by <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">a</add>
+      </mod> bloody</line>
+    <line>and useless <del instant="true" rend="strikethrough">con</del> warfare on the liberties of
+      their neighbours</line>
+    <line>or by the <del instant="true" rend="strikethrough">de</del> oppression and <del instant="true" rend="strikethrough">destruct</del> destruction of their <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">own</add>
+      </mod></line>
+    <line>subjects employed in the building of those famous pyra</line>
+    <line>mids, which, <del instant="true" rend="strikethrough">shap</del> being scarcely more than
+      shapless masses</line>
+    <line>of brick <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">or</add>
+        <del rend="strikethrough">and</del>
+      </mod> stone, seem fitted to endure till the earth</line>
+    <line>itself shall <del instant="true" rend="strikethrough">pass away.</del> be no longer.</line>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2"><del instant="true" rend="strikethrough">Slavery</del> The oppression of
+      their own <mod>
+        <del rend="strikethrough">monarchs</del>
+        <add place="superlinear">sovereigns</add>
+      </mod> fitted</line>
+    <line>the necks of th<mod>
+        <del rend="overwritten">i</del>
+        <add place="intralinear">e</add>
+        <del rend="strikethrough">s</del>
+      </mod>
+      <mod>
+        <del rend="strikethrough">people</del>
+        <add place="superlinear">Egyptians</add>
+      </mod> for the yoke of a foreign prince</line>
+    <line>after a few generations they were subdued and remained for</line>
+    <line>ages swallowed up in the <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">great</add>
+      </mod> Persian monarchy till after the</line>
+    <line>death of Alexander when they again<del rend="strikethrough">s</del>
+      <del rend="strikethrough">???????</del>
+      became</line>
+    <line>a<mod>
+        <add>n</add>
+        <del rend="strikethrough">separate</del>
+        <add place="superlinear">independant</add>
+      </mod> nation till the<del rend="strikethrough">y</del>
+      <del rend="strikethrough">fell</del>
+      <del rend="strikethrough">with</del>
+      <del rend="strikethrough"><unclear>of</unclear></del> overpowering</line>
+    <line>force of the Roman Empire reduced <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">them</add>
+      </mod> once more to the</line>
+    <line>condition of a Province.</line>
+    <delSpan rend="vertical_line" spanTo="#c56-0131.01"></delSpan>
+    <milestone unit="tei:p"></milestone>
+    <line rend="indent2"><del rend="strikethrough">Conquest and warfare</del>
+      <del rend="strikethrough">destruct</del>
+      <del rend="strikethrough">destruction has have</del></line>
+    <line rend="right"><add place="interlinear">Princes <del rend="strikethrough">of</del>
+        <del rend="strikethrough">Princes</del> of Babylon</add></line>
+    <line rend="indent2">The names of princes and Simiramis are preserved</line>
+    <line>by that bloody hallo <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">with</add>
+      </mod> which glory and <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <add place="superlinear">victory</add>
+      </mod>
+      <del rend="strikethrough">conquest</del>
+      <mod>
+        <add place="sublinear"><metamark function="insert">^</metamark></add>
+        <del rend="strikethrough"><add place="superlinear">blood<unclear>y</unclear> conquest</add></del>
+      </mod>
+      <del rend="strikethrough">all</del> always dese</line>
+    <line>rates its worshippers but the effects of their <del rend="strikethrough">vi</del> conquests <damage></damage></line>
+    <anchor xml:id="c56-0131.01"></anchor>
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5078" lry="7304" ulx="0" uly="0" mith:folio="63v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0132.xml" xml:id="ox-ms_abinger_c56-0132">
+    <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0132.jp2"></graphic>
+    <zone type="main">
+        <delSpan rend="vertical_line" spanTo="#c56-0132.01"></delSpan>
+        <line>soon forgotten and we hasten from this semi-barbarous</line>
+        <line>period to contemplate the glories of Greece <mod>
+                <del rend="strikethrough">in</del>
+                <add place="superlinear">on</add>
+            </mod> whose his-</line>
+        <line>tory <del rend="strikethrough">we shall find the <unclear reason="illegible">tr</unclear> triumph of <unclear extent="1" unit="chars"></unclear></del> human
+            nature</line>
+        <line>may meditate with complacency <del>and</del>
+            <del rend="strikethrough">triumphe</del>
+            <del rend="strikethrough">and</del>
+            <del rend="strikethrough">in
+            selecting</del></line>
+        <line><del rend="strikethrough">names &amp; act</del>
+            <del rend="strikethrough">and by challenge its detractors with names
+                and</del></line>
+        <line><del rend="strikethrough">actions</del> and summing up the <del>n</del> names &amp;
+            actions that <del rend="strikethrough">orna</del></line>
+        <line><del rend="strikethrough">men</del> embellish the pages of history <del rend="strikethrough">through</del> through so
+            long</line>
+        <line>a series of years – they may existing<anchor xml:id="c56-0132.01"></anchor>
+            <delSpan rend="vertical_line" spanTo="#c56-0132.02"></delSpan>While <del rend="strikethrough">that</del> of Cyrus</line>
+        <line><mod>
+                <add place="interlinear"><metamark function="insert">^</metamark> who overturned
+                    their empire and founded his own on its ruins</add>
+            </mod></line>
+        <line>conducted on principles of utility and benevolence endured</line>
+        <line>through the lapse of many ages.</line>
+        <milestone unit="tei:p"></milestone>
+        <line rend="indent2">C The <del rend="strikethrough">m</del> memory of <del rend="strikethrough">Cy</del> Cyrus is contemplated with pe</line>
+        <line>culiar complacency by most historians. His <del rend="strikethrough">ge</del> humanity
+            &amp;</line>
+        <line>love of justice distinguishes <del rend="strikethrough">w</del> him from <mod>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear">those</add>
+            </mod> other conquerors to</line>
+        <line>whom ambition was the ruling motive. <del rend="strikethrough">Cy</del> Cyrus was
+            edu</line>
+        <line>cated in the strictest simplicity <del rend="strikethrough">en</del> early inured to
+            fatigue</line>
+        <line>and <mod>
+                <add place="sublinear"><metamark>^</metamark></add>
+                <add place="superlinear">taught</add>
+            </mod> after the manners of the age, to consider glory <del rend="strikethrough">as
+                the</del></line>
+        <line>as the great and desirable bourne to which every virtu</line>
+        <line>ous man ought to direct his <mod>
+                <del rend="strikethrough">steps</del>
+                <add place="superlinear">exertions</add>
+            </mod>. But the natural</line>
+        <line>mildness of his disposition led him the rather to seek for</line>
+        <line>honour in the pardon than in the punishment of his</line>
+        <line>enemies. <del rend="strikethrough">and if he conquered it was to bestow a more</del>
+            and</line>
+        <line>his conquests <mod>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear">often</add>
+            </mod> appeared to <del rend="strikethrough">f</del> the fallen nation<del rend="strikethrough">s</del>
+            <del rend="strikethrough">as</del> in light</line>
+        <line>of a blessing rather than a curse. <delSpan rend="vertical_line" spanTo="#c56-0132.03"></delSpan>The romance with which</line>
+        <line>Xenophon has embellished the history of this prince and</line>
+        <line>the numerous <del rend="strikethrough">ane</del> anecdotes which he has <del rend="strikethrough">either recor</del></line>
+        <line>invented in his honour renders as apparent by better</line>
+        <line>acquainted with the character of this monarch than of</line>
+        <line>any other of ancient times.<anchor xml:id="c56-0132.03"></anchor> Inmemorable anecdotes
+            are</line>
+        <line>recorded of his virtue and mildness by <del rend="strikethrough">his his</del>
+            Xenophon</line>
+        <line>but unfortunately this history must be <mod>
+                <del rend="strikethrough">looked upon</del>
+                <add place="superlinear">regarded</add>
+            </mod> rather</line>
+        <line>as a romance than the real biography of the man; for al</line>
+        <line>through tradition might probably preserve several of the</line>
+        <line>private actions of so distinguished a <del instant="true" rend="strikethrough">man</del> prince <del rend="strikethrough">it <unclear reason="illegible">e</unclear> is</del></line>
+        <line><del rend="strikethrough">not probable that</del>
+            <del rend="strikethrough">in ea</del> yet the minuteness &amp; egularity</line>
+        <line>of detail which embellishes the <mod>
+                <add place="sublinear"><metamark function="insert">^</metamark></add>
+                <add place="superlinear">narrations of the</add>
+            </mod>
+            Cyropedia must be <del rend="strikethrough">entirely</del></line>
+        <line><damage type="tear"></damage>ed upon entirely as the invention of the <mod>
+                <del rend="strikethrough">historian</del>
+                <add place="superlinear">writer</add>
+            </mod>. <del rend="strikethrough">How</del></line>
+        <line><damage type="tear"></damage>
+            <del rend="strikethrough">The extent of our belie</del>
+            <del rend="strikethrough">became</del>
+            <mod>
+                <del rend="strikethrough">forever</del>
+                <add place="superlinear">utterly</add>
+            </mod>
+            <del rend="strikethrough">entirely incapa</del></line><anchor xml:id="c56-0132.02"></anchor>
+    </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5078" lry="7304" ulx="0" uly="0" mith:folio="64r" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0133.xml" xml:id="ox-ms_abinger_c56-0133">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0133.jp2"></graphic>
+  <zone type="library">
+    <line>64</line>
+    <line>(ul<unclear reason="illegible">v</unclear>)</line>
+    
+  </zone>
+</surface>
+        <?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><?xml-model href="../../../schemata/shelley-godwin-page.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><surface xmlns:mith="http://mith.umd.edu/sc/ns1#" lrx="5078" lry="7304" ulx="0" uly="0" mith:folio="64v" mith:shelfmark="MS. Abinger c. 56" xml:base="ox-ms_abinger_c56/ox-ms_abinger_c56-0134.xml" xml:id="ox-ms_abinger_c56-0134">
+  <graphic url="http://shelleygodwinarchive.org/images/ox/ms_abinger_c56/ms_abinger_c56-0134.jp2"></graphic>
+  <zone type="main">
+  <line rend="center"><add hand="#library">i + 64 leaves</add></line>
+  </zone>
+</surface>
+    </sourceDoc>
+</TEI>

--- a/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0012.xml
+++ b/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0012.xml
@@ -23,7 +23,7 @@
     <line>and bore it into the cottage himself. She</line>
     <line>followed <del rend="strikethrough">wiping</del>
       <del rend="strikethrough">dry my her tears whi</del>, and they</line>
-    <line>diasppeared &#x2013; Presently I saw the young man</line>
+    <line>disappeared &#x2013; Presently I saw the young man</line>
     <line>again with some tools in his hand cross the</line>
     <line>field opposite the cottage and the girl was</line>
     <line>also busied someti<mod>

--- a/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0013.xml
+++ b/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0013.xml
@@ -41,7 +41,7 @@
     <line>she sobbed audibly &#x2013; He <del rend="strikethrough" instant="true">the</del> then
       pronounced</line>
     <line>a few sounds and the poor creature leaving</line>
-    <line>her work knelt at his feet he rasied her</line>
+    <line>her work knelt at his feet he raised her</line>
     <line>and smiled with such <del rend="strikethrough">grace</del> kindness &amp;</line>
     <line>love that I felt <mod spanTo="#c57-0013.02"/><del rend="strikethrough" next="#c57-0013.03"
         >my own hard nerves</del><retrace hand="#mws" cause="fix"><add hand="#pbs"

--- a/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0021.xml
+++ b/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0021.xml
@@ -36,7 +36,7 @@
         <add place="superlinear">bestowed pleasure</add>
       </mod></line>
     <line><anchor xml:id="c57-0021.01"/>Agatha listened with respect&#x2013; her eyes</line>
-    <line><del rend="strikethrough">f</del> somethimes filled with tears which</line>
+    <line><del rend="strikethrough">f</del> sometimes filled with tears which</line>
     <line><metamark function="displacement" xml:id="c57-0021.02"/>wipe<del rend="strikethrough"
         >d</del> away unpercieved but I general</line>
     <line>ly found that her manners and tone</line>

--- a/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0022.xml
+++ b/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0022.xml
@@ -10,7 +10,7 @@
   </zone>
   <zone type="main">
     <milestone unit="tei:p"/>
-    <line rend="indent1">I could mention innumberable instances</line>
+    <line rend="indent1">I could mention innumerable instances</line>
     <line>which although slight marked the <mod>
         <del rend="strikethrough">heart</del>
         <add place="superlinear">dispositions</add>

--- a/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0048.xml
+++ b/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0048.xml
@@ -87,7 +87,7 @@
     <line><add>to undertake </add></line>
   </zone>
 
-  <zone type="left_margin" corresp="#c57-0002.03">
+  <zone type="left_margin" corresp="#c57-0048.03">
     <line><add>for many months </add></line>
   </zone>
 </surface>

--- a/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0048.xml
+++ b/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0048.xml
@@ -56,7 +56,7 @@
         <add place="sublinear"><metamark function="insert">^</metamark></add>
         <del rend="strikethrough"><add place="superlinear">for many months</add></del>
       </mod> unknown to them been</line>
-    <line><anchor xml:id="c57-0002.03"/>in the habits of daily kindness towards them,</line>
+    <line><anchor xml:id="c57-0048.03"/>in the habits of daily kindness towards them,</line>
     <line>but they believe that I wish to injure</line>
     <line>them and it is that prejudice which</line>
     <line>I wish to over come.</line>

--- a/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0049.xml
+++ b/data/tei/ox/ox-ms_abinger_c57/ox-ms_abinger_c57-0049.xml
@@ -24,7 +24,7 @@
         <add place="sublinear"><metamark function="insert">^</metamark></add>
         <add place="superlinear">generous</add>
       </mod> offer</line>
-    <line><add place="superlinear"><metamark function="displacement" xml:id="c58-0049.02"
+    <line><add place="superlinear"><metamark function="displacement" xml:id="c57-0049.02"
           >X</metamark></add>I trust <del rend="strikethrough">now</del> that I shall not be
       driven</line>
     <line>from the society &amp; sympathy of my</line>


### PR DESCRIPTION
Hi @raffazizzi and @trevormunoz ! As we're gearing up to work with the notebook files to prep for collation, I wanted to make sure we had a fully operable schema. I spent some time with the ODD files this evening, and worked out a few sources of problems (and I think some things just resolved themselves over time as TEI ODDs improved). We now have a working RNG for use on the Pgh-Frankenstein copy of the notebook files, and I figured you might want these files, too. 

Note: I compiled a version of the ODD that combined the shelley-godwin-page.odd with the godwin-master.odd, mostly so I could see what I was doing as I was hunting for problems. Ultimately, besides updating the xml-model lines at the top, there was really just one change I needed to make that was causing an error in the RNG: it was the modification of the `@hand` attribute: it should be made in the att.written classSpec, not in att.transcriptional. (Of course, att.written is a member of att.transcriptional, but the output RNG was calling an error on `@hand` having two different definitions until I fixed it).  I made the change in the shelley-godwin-page.odd as well as in my shelley-godwin-FULL.odd . Hope this is useful! 